### PR TITLE
Fixed failed unit tests.

### DIFF
--- a/libmemcached/auto.cc
+++ b/libmemcached/auto.cc
@@ -348,7 +348,10 @@ memcached_return_t memcached_increment_with_initial_by_key(memcached_st *ptr,
   LIBMEMCACHED_MEMCACHED_INCREMENT_WITH_INITIAL_START();
 
   if (ptr->flags.binary_protocol)
-    rc= MEMCACHED_PROTOCOL_ERROR;
+    //rc= MEMCACHED_PROTOCOL_ERROR;
+    rc= binary_incr_decr(ptr, PROTOCOL_BINARY_CMD_INCREMENT,
+                         group_key, group_key_length, key, key_length,
+                         offset, initial, expiration, value); 
   else
     rc= text_incr_decr(ptr, "incr", group_key, group_key_length, key, key_length, offset, true, initial, flags, expiration, value);
 
@@ -404,7 +407,10 @@ memcached_return_t memcached_decrement_with_initial_by_key(memcached_st *ptr,
 
   LIBMEMCACHED_MEMCACHED_INCREMENT_WITH_INITIAL_START();
   if (ptr->flags.binary_protocol)
-    rc= MEMCACHED_PROTOCOL_ERROR;
+    //rc= MEMCACHED_PROTOCOL_ERROR;
+    rc= binary_incr_decr(ptr, PROTOCOL_BINARY_CMD_DECREMENT,
+                         group_key, group_key_length, key, key_length,
+                         offset, initial, expiration, value); 
   else
     rc= text_incr_decr(ptr, "decr", group_key, group_key_length, key, key_length, offset, true, initial, flags, expiration, value);
 

--- a/tests/mem_functions.cc
+++ b/tests/mem_functions.cc
@@ -1338,7 +1338,7 @@ static test_return_t increment_test(memcached_st *memc)
 
 static test_return_t increment_with_initial_test(memcached_st *memc)
 {
-  test_skip(true, memcached_behavior_get(memc, MEMCACHED_BEHAVIOR_BINARY_PROTOCOL));
+  //test_skip(true, memcached_behavior_get(memc, MEMCACHED_BEHAVIOR_BINARY_PROTOCOL));
 
   uint64_t new_number;
   uint64_t initial= 0;
@@ -6202,7 +6202,11 @@ test_st replication_tests[]= {
   {"mget", false, (test_callback_fn*)replication_mget_test },
   {"delete", true, (test_callback_fn*)replication_delete_test },
   {"rand_mget", false, (test_callback_fn*)replication_randomize_mget_test },
-  {"fail", false, (test_callback_fn*)replication_randomize_mget_fail_test },
+  /* TODO : uncomment this when we support binary protocol fully.
+   * Now ARCUS does not support binary protocol. (arcus-memcached version 1.9.4 and
+   * C Client version 1.7.4)
+   */
+  //  {"fail", false, (test_callback_fn*)replication_randomize_mget_fail_test },
   {0, 0, (test_callback_fn*)0}
 };
 

--- a/tests/parser.cc
+++ b/tests/parser.cc
@@ -645,11 +645,7 @@ test_return_t regression_bug_71231153_poll(memcached_st *)
     char *value= memcached_get(memc, test_literal_param("test"), &value_len, NULL, &rc);
     test_false(value);
     test_zero(value_len);
-#ifdef __APPLE__
-    test_compare_got(MEMCACHED_CONNECTION_FAILURE, rc, memcached_last_error_message(memc));
-#else
     test_compare_got(MEMCACHED_TIMEOUT, rc, memcached_last_error_message(memc));
-#endif
 
     memcached_free(memc);
   }


### PR DESCRIPTION
Make test 시 fail 되던 테스트 케이스들을 수정하였습니다.

- `memcached_inc/decrement_with_initial_by_key()` 가 `MEMCACHED_PROTOCOL_ERROR`를 리턴하지 않고, `binary_incr_decr()` 함수를 호출하여 결과를 돌려주도록 수정
- test collection 'regression' 의 'fail' 테스트 케이스를 테스트 목록에서 제외 (ARCUS 는 binary protocol 을 fully 지원하지 않음)
- 특정 테스트 케이스 판정 부분의 `__APPLE__` 매크로 구분을 삭제.

@jhpark816 @whchoi83 구두로 논의 후에 수정하고 PR 보낸 것이긴 하지만, 일단 리뷰...해... 주십사 하고 멘션 답니다 ㅋ