### PR TITLE
CLEANUP: print travis-ci test log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
   - ./configure --with-memcached=$HOME/arcus-memcached/memcached --with-memcached_engine=$HOME/arcus-memcached/.libs/default_engine.so
   - make
   - sudo make test
+  - cat test-suite.log
 
 notifications:
   email:


### PR DESCRIPTION
@jhpark816 

travis-ci 환경인 ubuntu 14.04 에서는
test에 대한 결과 파일인 test-suite.log를 생성 합니다.
test실패 했을 때 실패에 대한 내용을 한번에 알 수 있도록
test-suite.log 내용을 출력하는 코드를 추가 했습니다.