### PR TITLE
CLEANUP: enable optimize mget operation with instance version

### DIFF
--- a/libmemcached/connect.cc
+++ b/libmemcached/connect.cc
@@ -649,6 +649,12 @@ memcached_return_t memcached_connect(memcached_server_write_instance_st server)
 
   if (memcached_success(rc))
   {
+#if 1 // OPTIMIZE_MGET
+    if (server->major_version == UINT8_MAX)
+    {
+      memcached_version_from_instance(server);
+    }
+#endif
     memcached_mark_server_as_clean(server);
     return rc;
   }

--- a/libmemcached/server.cc
+++ b/libmemcached/server.cc
@@ -58,8 +58,15 @@ static inline void _server_init(memcached_server_st *self, memcached_st *root,
   WATCHPOINT_SET(self->io_wait_count.read= 0);
   WATCHPOINT_SET(self->io_wait_count.write= 0);
   self->major_version= UINT8_MAX;
+#if 1 // OPTIMIZE_MGET
+  self->minor_version= UINT8_MAX;
+  self->micro_version= UINT8_MAX;
+  self->is_enterprise= false;
+  self->enable_optimized_mget= false;
+#else
   self->micro_version= UINT8_MAX;
   self->minor_version= UINT8_MAX;
+#endif
   self->type= type;
   self->error_messages= NULL;
   self->read_ptr= self->read_buffer;

--- a/libmemcached/server.h
+++ b/libmemcached/server.h
@@ -78,8 +78,15 @@ struct memcached_server_st {
     uint32_t write;
   } io_wait_count;
   uint8_t major_version; // Default definition of UINT8_MAX means that it has not been set.
+#if 1 // OPTIMIZE_MGET
+  uint8_t minor_version; // ditto
+  uint8_t micro_version; // ditto
+  bool    is_enterprise;
+  bool    enable_optimized_mget;
+#else
   uint8_t micro_version; // ditto
   uint8_t minor_version; // ditto
+#endif
   memcached_connection_t type;
   char *read_ptr;
   size_t read_buffer_length;

--- a/libmemcached/version.h
+++ b/libmemcached/version.h
@@ -37,12 +37,20 @@
 
 #pragma once
 
+#if 1 // OPTIMIZE_MGET
+#include <libmemcached/server_instance.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 LIBMEMCACHED_API
 memcached_return_t memcached_version(memcached_st *ptr);
+#if 1 // OPTIMIZE_MGET
+LIBMEMCACHED_API
+memcached_return_t memcached_version_from_instance(memcached_server_write_instance_st instance);
+#endif
 
 LIBMEMCACHED_API
 const char * memcached_lib_version(void);

--- a/tests/mem_functions.cc
+++ b/tests/mem_functions.cc
@@ -863,6 +863,10 @@ static test_return_t bad_key_test(memcached_st *memc)
     }
     test_compare(before_query_id +1, memcached_query_id(memc_clone));
 
+    /* MEMCACHED_BEHAVIOR_VERIFY_KEY is a flag that does not check
+     * the validity of the key. So the request for a get operation is
+     * key "foo bad" but key count is 1.
+     */
     query_id= memcached_query_id(memc_clone);
     test_compare(MEMCACHED_SUCCESS,
                  memcached_behavior_set(memc_clone, MEMCACHED_BEHAVIOR_VERIFY_KEY, false));


### PR DESCRIPTION
Reviewer
- [ ] @jooho812
- [ ] @jhpark816 

서버 version 정보를 조회 및 저장하고
multiple get operation에 대한 optimize 가능 여부를 판단해서
n개의 get operation으로 나누어 보내도록 할 수 있도록 수정 한 PR 입니다.
확인 요청 드립니다.
code tag : OPTIMIZE_MGET