### PR TITLE
FIX: Makefile error due to include header

### DIFF
--- a/libmemcached/include.am
+++ b/libmemcached/include.am
@@ -86,7 +86,8 @@ nobase_include_HEADERS+= \
 			 libmemcached/verbosity.h \
 			 libmemcached/version.h \
 			 libmemcached/visibility.h \
-			 libmemcached/watchpoint.h
+			 libmemcached/watchpoint.h \
+                         libmemcached/server_instance.h
 
 lib_LTLIBRARIES+= libmemcached/libmemcached.la
 libmemcached_libmemcached_la_CFLAGS= -DBUILDING_LIBMEMCACHED


### PR DESCRIPTION
Makefile에서 server_instance header file
추가 부분이 빠져있어서 추가 했습니다.