### PR TITLE
FEATURE: Immediately connect to server according to the server response

### DIFF
--- a/libmemcached/constants.h
+++ b/libmemcached/constants.h
@@ -58,6 +58,8 @@
 #define ENABLE_REPLICATION 1
 #endif
 
+#define IMMEDIATELY_RECONNECT_WHEN_SOME_ERROR
+
 /* Public defines */
 #define MEMCACHED_DEFAULT_PORT 11211
 #define MEMCACHED_MAX_KEY 251 /* We add one to have it null terminated */

--- a/libmemcached/response.cc
+++ b/libmemcached/response.cc
@@ -220,6 +220,13 @@ memcached_return_t memcached_read_one_response(memcached_server_write_instance_s
   {
     rc= textual_read_one_response(ptr, buffer, buffer_length, result);
   }
+#ifdef IMMEDIATELY_RECONNECT_WHEN_SOME_ERROR
+  if(rc == MEMCACHED_CLIENT_ERROR or
+     rc == MEMCACHED_PROTOCOL_ERROR)
+  {
+    memcached_server_set_retry_timeout_immediately(ptr);
+  }
+#endif
 
   unlikely(rc == MEMCACHED_UNKNOWN_READ_FAILURE or
            rc == MEMCACHED_PROTOCOL_ERROR or
@@ -855,6 +862,13 @@ memcached_return_t memcached_read_one_coll_response(memcached_server_write_insta
   {
     rc= textual_read_one_coll_response(ptr, buffer, buffer_length, result);
   }
+#ifdef IMMEDIATELY_RECONNECT_WHEN_SOME_ERROR
+  if(rc == MEMCACHED_CLIENT_ERROR ||
+     rc == MEMCACHED_PROTOCOL_ERROR)
+  {
+    memcached_server_set_retry_timeout_immediately(ptr);
+  }
+#endif
 
   unlikely(rc == MEMCACHED_UNKNOWN_READ_FAILURE ||
            rc == MEMCACHED_PROTOCOL_ERROR ||
@@ -1670,6 +1684,13 @@ memcached_return_t memcached_read_one_coll_smget_response(memcached_server_write
   {
     rc= textual_read_one_coll_smget_response(ptr, buffer, buffer_length, result);
   }
+#ifdef IMMEDIATELY_RECONNECT_WHEN_SOME_ERROR
+  if(rc == MEMCACHED_CLIENT_ERROR or
+     rc == MEMCACHED_PROTOCOL_ERROR)
+  {
+    memcached_server_set_retry_timeout_immediately(ptr);
+  }
+#endif
 
   unlikely(rc == MEMCACHED_UNKNOWN_READ_FAILURE or
            rc == MEMCACHED_PROTOCOL_ERROR or

--- a/libmemcached/server.cc
+++ b/libmemcached/server.cc
@@ -90,6 +90,9 @@ static inline void _server_init(memcached_server_st *self, memcached_st *root,
   self->groupindex= -1; /* replica group index */
   self->next= NULL;     /* next server pointer */
 #endif
+#ifdef IMMEDIATELY_RECONNECT_WHEN_SOME_ERROR
+  self->immediately_connect = false;
+#endif
 }
 
 static memcached_server_st *_server_create(memcached_server_st *self, const memcached_st *memc)
@@ -381,3 +384,16 @@ const char *memcached_server_type(const memcached_server_instance_st ptr)
 
   return "UNKNOWN";
 }
+
+#ifdef IMMEDIATELY_RECONNECT_WHEN_SOME_ERROR
+void memcached_server_set_retry_timeout_immediately(memcached_server_st *self)
+{
+  WATCHPOINT_ASSERT(self);
+  if (not self)
+  {
+    return;
+  }
+
+  self->immediately_connect = true;
+}
+#endif

--- a/libmemcached/server.h
+++ b/libmemcached/server.h
@@ -100,6 +100,9 @@ struct memcached_server_st {
   char read_buffer[MEMCACHED_MAX_BUFFER];
   char write_buffer[MEMCACHED_MAX_BUFFER];
   char hostname[MEMCACHED_NI_MAXHOST];
+#ifdef IMMEDIATELY_RECONNECT_WHEN_SOME_ERROR
+  bool immediately_connect;
+#endif
 };
 
 
@@ -183,6 +186,11 @@ const char *memcached_server_type(const memcached_server_instance_st ptr);
 
 LIBMEMCACHED_LOCAL
 void __server_free(memcached_server_st *);
+
+#ifdef IMMEDIATELY_RECONNECT_WHEN_SOME_ERROR
+LIBMEMCACHED_API
+void memcached_server_set_retry_timeout_immediately(memcached_server_st *ptr);
+#endif
 
 #ifdef __cplusplus
 } // extern "C"

--- a/libmemcached/server.hpp
+++ b/libmemcached/server.hpp
@@ -99,16 +99,21 @@ static inline void memcached_mark_server_for_timeout(memcached_server_write_inst
   if (server->state != MEMCACHED_SERVER_STATE_IN_TIMEOUT)
   {
     struct timeval next_time;
-    if (server->root->retry_timeout != 0 and gettimeofday(&next_time, NULL) == 0)
+#ifdef IMMEDIATELY_RECONNECT_WHEN_SOME_ERROR
+    if (server->root->retry_timeout != 0 and gettimeofday(&next_time, NULL) == 0 and !server->immediately_connect)
     {
       server->next_retry= next_time.tv_sec +server->root->retry_timeout;
     }
+#endif
     else
     {
       server->next_retry= 1; // Setting the value to 1 causes the timeout to occur immediatly
     }
 
     server->state= MEMCACHED_SERVER_STATE_IN_TIMEOUT;
+#ifdef IMMEDIATELY_RECONNECT_WHEN_SOME_ERROR
+    server->immediately_connect = false;
+#endif
     if (server->server_failure_counter_query_id != server->root->query_id)
     {
       server->server_failure_counter++;


### PR DESCRIPTION
기존에는 CLIENT_ERROR, PROTOCOL_ERROR 발생 시 connection을 끊고 timeout을 설정합니다.

memcached_server_st 구조체 안에 immediately_connect라는 flag를 추가하여
위와 같은 에러 발생 시 flag 값을 설정하여 다음 connection 시에 즉시 맺을 수 있도록 구현하였습니다.

Reviewer
- [ ] @MinWooJin 
- [ ] @jhpark816  