### PR TITLE
FIX: stats cachedump bug

### DIFF
--- a/libmemcached/dump.cc
+++ b/libmemcached/dump.cc
@@ -36,14 +36,14 @@ static memcached_return_t ascii_dump(memcached_st *ptr, memcached_dump_fn *callb
     memcached_server_write_instance_st instance;
     instance= memcached_server_instance_fetch(ptr, server_key);
 
-    /* 256 I BELIEVE is the upper limit of slabs */
-    for (uint32_t x= 0; x < 256; x++)
+    /* 200 : the upper limit of slabs */
+    for (uint32_t x= 0; x < 200; x++)
     {
       char buffer[MEMCACHED_DEFAULT_COMMAND_SIZE];
       char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
       int send_length;
       send_length= snprintf(buffer, MEMCACHED_DEFAULT_COMMAND_SIZE,
-                            "stats cachedump %u 0 0\r\n", x);
+                            "stats cachedump %u 0\r\n", x);
 
       if (send_length >= MEMCACHED_DEFAULT_COMMAND_SIZE || send_length < 0)
       {

--- a/tests/mem_functions.cc
+++ b/tests/mem_functions.cc
@@ -38,6 +38,7 @@
 
 #include <config.h>
 #include <libtest/test.hpp>
+#include <climits>
 
 /*
   Test cases
@@ -4301,6 +4302,7 @@ static test_return_t dump_test(memcached_st *memc)
   // confirm_key_count() call dump
   size_t counter= confirm_key_count(memc);
 
+  test_true(counter != ULONG_MAX);
   /* We may have more then 32 if our previous flush has not completed */
   test_true(counter >= 32);
 


### PR DESCRIPTION
stats cachedump command format :
stats cachedump <slab_clsid> \<limit> [ forward | backward [sticky] ]\r\n

slab_clsid의 범위는 0 ~ 200이며, 수행방향은 forward나 backward로 지정하게 됩니다.

현재 c-client의 cachedump는 slab_clsid가 200 ~ 255까지 수행되서 CLIENT_ERROR illegal slab id와 명령어의 수행방향 인자값이 0으로 들어가 있어 CLIENT_ERROR BAD COMMAND FORMAT를 받게 됩니다.

dump test에선 실패 시 반환값이 적절하지 않아 dump 기능이 제대로 검사되지 않았습니다.

commit 내역 요약:
- slab_clsid의 최대 수행범위를 255에서 200으로 수정.
- 명령어 수행방향 인자값 0을 생략(수행방향 default는 forward)
- dump_test()에서 confirm_key_count() 결과값이 ULONG_MAX이 아닌지 확인하도록 수정.

Reviewer
- [x] @MinWooJin 
- [x] @jhpark816  