### PR TITLE
FEATURE: immediate reconnect according to error response.

### DIFF
--- a/libmemcached/constants.h
+++ b/libmemcached/constants.h
@@ -59,6 +59,7 @@
 #endif
 
 #define UPDATE_HASH_RING_OF_FETCHED_MC 1
+#define IMMEDIATELY_RECONNECT 1
 
 /* Public defines */
 #define MEMCACHED_DEFAULT_PORT 11211

--- a/libmemcached/response.cc
+++ b/libmemcached/response.cc
@@ -679,10 +679,22 @@ memcached_return_t memcached_read_one_response(memcached_server_write_instance_s
   {
     rc= textual_read_one_response(ptr, buffer, buffer_length, result);
   }
+#ifdef IMMEDIATELY_RECONNECT
+  if (rc == MEMCACHED_PROTOCOL_ERROR or
+      rc == MEMCACHED_CLIENT_ERROR or
+      rc == MEMCACHED_SERVER_ERROR or
+      rc == MEMCACHED_PARTIAL_READ)
+  {
+    memcached_server_set_immediate_reconnect(ptr);
+  }
+#endif
 
   unlikely(rc == MEMCACHED_UNKNOWN_READ_FAILURE or
            rc == MEMCACHED_PROTOCOL_ERROR or
            rc == MEMCACHED_CLIENT_ERROR or
+#ifdef IMMEDIATELY_RECONNECT
+           rc == MEMCACHED_SERVER_ERROR or
+#endif
            rc == MEMCACHED_PARTIAL_READ or
            rc == MEMCACHED_MEMORY_ALLOCATION_FAILURE)
     memcached_io_reset(ptr);
@@ -1770,10 +1782,22 @@ static memcached_return_t memcached_read_one_coll_response(memcached_server_writ
   {
     rc= textual_read_one_coll_response(ptr, buffer, buffer_length, result);
   }
+#ifdef IMMEDIATELY_RECONNECT
+  if (rc == MEMCACHED_PROTOCOL_ERROR ||
+      rc == MEMCACHED_CLIENT_ERROR ||
+      rc == MEMCACHED_SERVER_ERROR ||
+      rc == MEMCACHED_PARTIAL_READ)
+  {
+    memcached_server_set_immediate_reconnect(ptr);
+  }
+#endif
 
   unlikely(rc == MEMCACHED_UNKNOWN_READ_FAILURE ||
            rc == MEMCACHED_PROTOCOL_ERROR ||
            rc == MEMCACHED_CLIENT_ERROR ||
+#ifdef IMMEDIATELY_RECONNECT
+           rc == MEMCACHED_SERVER_ERROR ||
+#endif
            rc == MEMCACHED_PARTIAL_READ ||
            rc == MEMCACHED_MEMORY_ALLOCATION_FAILURE)
     memcached_io_reset(ptr);
@@ -2464,10 +2488,22 @@ static memcached_return_t memcached_read_one_coll_smget_response(memcached_serve
   {
     rc= textual_read_one_coll_smget_response(ptr, buffer, buffer_length, result);
   }
+#ifdef IMMEDIATELY_RECONNECT
+  if (rc == MEMCACHED_PROTOCOL_ERROR or
+      rc == MEMCACHED_CLIENT_ERROR or
+      rc == MEMCACHED_SERVER_ERROR or
+      rc == MEMCACHED_PARTIAL_READ)
+  {
+    memcached_server_set_immediate_reconnect(ptr);
+  }
+#endif
 
   unlikely(rc == MEMCACHED_UNKNOWN_READ_FAILURE or
            rc == MEMCACHED_PROTOCOL_ERROR or
            rc == MEMCACHED_CLIENT_ERROR or
+#ifdef IMMEDIATELY_RECONNECT
+           rc == MEMCACHED_SERVER_ERROR or
+#endif
            rc == MEMCACHED_PARTIAL_READ or
            rc == MEMCACHED_MEMORY_ALLOCATION_FAILURE )
     memcached_io_reset(ptr);

--- a/libmemcached/server.cc
+++ b/libmemcached/server.cc
@@ -71,6 +71,9 @@ static inline void _server_init(memcached_server_st *self, memcached_st *root,
 
   self->state= MEMCACHED_SERVER_STATE_NEW;
   self->next_retry= 0;
+#ifdef IMMEDIATELY_RECONNECT
+  self->immediate_reconnect= false;
+#endif
 
   self->root= root;
   if (root)
@@ -381,6 +384,17 @@ const char *memcached_server_type(const memcached_server_instance_st ptr)
 
   return "UNKNOWN";
 }
+
+#ifdef IMMEDIATELY_RECONNECT
+void memcached_server_set_immediate_reconnect(memcached_server_st *self)
+{
+  WATCHPOINT_ASSERT(self);
+  if (not self)
+    return;
+
+  self->immediate_reconnect= true;
+}
+#endif
 
 uint8_t memcached_server_major_version(const memcached_server_instance_st ptr)
 {

--- a/libmemcached/server.h
+++ b/libmemcached/server.h
@@ -88,6 +88,9 @@ struct memcached_server_st {
   struct addrinfo *address_info;
   struct addrinfo *address_info_next;
   time_t next_retry;
+#ifdef IMMEDIATELY_RECONNECT
+  bool immediate_reconnect; /* about ERROR, CLIENT_ERROR, SERVER_ERROR, PARTIAL_READ_ERROR */
+#endif
 #ifdef ENABLE_REPLICATION
   /* In replication, a group may have one master and one slave.
    */
@@ -191,6 +194,11 @@ uint8_t memcached_server_micro_version(const memcached_server_instance_st ptr);
 
 LIBMEMCACHED_LOCAL
 void __server_free(memcached_server_st *);
+
+#ifdef IMMEDIATELY_RECONNECT
+LIBMEMCACHED_API
+void memcached_server_set_immediate_reconnect(memcached_server_st *ptr);
+#endif
 
 #ifdef __cplusplus
 } // extern "C"

--- a/libmemcached/server.hpp
+++ b/libmemcached/server.hpp
@@ -107,6 +107,13 @@ static inline void memcached_mark_server_for_timeout(memcached_server_write_inst
     {
       server->next_retry= 1; // Setting the value to 1 causes the timeout to occur immediatly
     }
+#ifdef IMMEDIATELY_RECONNECT
+    if (server->immediate_reconnect)
+    {
+      server->next_retry= 1; // Setting the value to 1 causes the timeout to occur immediately
+      server->immediate_reconnect= false;
+    }
+#endif
 
     server->state= MEMCACHED_SERVER_STATE_IN_TIMEOUT;
     if (server->server_failure_counter_query_id != server->root->query_id)

--- a/tests/mem_functions.cc
+++ b/tests/mem_functions.cc
@@ -408,6 +408,22 @@ static test_return_t connection_test(memcached_st *memc)
   return TEST_SUCCESS;
 }
 
+#ifdef IMMEDIATELY_RECONNECT
+static test_return_t immediate_reconnect_test(memcached_st *memc)
+{
+  memcached_return_t rc;
+  const char *key= "bad key";
+  for (int i= 0; i < 2; i++) {
+    rc= memcached_set(memc, key, strlen(key), NULL, 0, 0, 0);
+    /* immediate reconnect about CLIENT_ERROR.
+       so don't occur MEMCACHED_SERVER_TEMPORARILY_DISABLED.
+    */
+    test_compare(MEMCACHED_CLIENT_ERROR, rc);
+  }
+  return TEST_SUCCESS;
+}
+#endif
+
 static test_return_t libmemcached_string_behavior_test(memcached_st *)
 {
   for (int x= MEMCACHED_BEHAVIOR_NO_BLOCK; x < int(MEMCACHED_BEHAVIOR_MAX); ++x)
@@ -6363,6 +6379,13 @@ test_st memcached_server_add_tests[] ={
   {0, 0, (test_callback_fn*)0}
 };
 
+#ifdef IMMEDIATELY_RECONNECT
+test_st immediate_reconnect[] ={
+  {"immediate_reconnect", false, (test_callback_fn*)immediate_reconnect_test },
+  {0, 0, (test_callback_fn*)0}
+};
+#endif
+
 test_st namespace_tests[] ={
   {"basic tests", true, (test_callback_fn*)selection_of_namespace_tests },
   {"increment", true, (test_callback_fn*)memcached_increment_namespace },
@@ -11625,6 +11648,9 @@ collection_st collection[] ={
   {"hsieh_availability", 0, 0, hsieh_availability},
   {"murmur_availability", 0, 0, murmur_availability},
   {"memcached_server_add", 0, 0, memcached_server_add_tests},
+#ifdef IMMEDIATELY_RECONNECT
+  {"immediate_reconnect", 0, 0, immediate_reconnect},
+#endif
   {"block", 0, 0, tests},
   {"binary", (test_callback_fn*)pre_binary, 0, tests},
   {"nonblock", (test_callback_fn*)pre_nonblock, 0, tests},


### PR DESCRIPTION
**delayed reconnect cases**
- 네트워크 순단 문제
- client 단 error

**immediate reconnect cases**
- server error response (ERROR, CLIENT_ERROR, SERVER_ERROR)
  * ERROR, CLIENT_ERROR 에 경우 Connection 상에 잔여 데이터가 있을 수 있어 cleanup 필요
  * SERVER_ERROR 에 경우 응용에게 service unavalable 응답을 보내는 것보다 out of memory 오류를 넘기는 것이 나음. 네트워크 순단 문제와 달리 빠른 응답이기 때문에 응용의 작업 스레드가 증가될 요인도 없다.
- client 단 response partial failure (client - server protocol 이 다른 상태)

**no reconnect cases**
- no error (END, NOT_FOUND, TYPE_MISMATCH ..)
- E2BIG

**cilent 단 error code**
- MEMCACHED_UNKNOWN_READ_FAILURE : 알 수 없는 에러코드가 오는 경우 or network bytes read failure.
- MEMCACHED_PROTOCOL_ERROR : ERROR response 받은 경우 or 읽은 문자열이 프로토콜이 틀린 경우(ex \n이 없는 경우).
- MEMCACHED_CLIENT_ERROR : CLIENT_ERROR response
- MEMCACHED_SERVER_ERROR : SERVER_ERROR response
- MEMCACHED_E2BIG : "CLIENT_ERROR Object too large for cache" response
- MEMCACHED_MEMORY_ALLOCATION_FAILURE : client malloc failure

Reviewer
- [x] @MinWooJin 
- [ ] @jhpark816  