### PR TITLE
ENHANCE: optimized reflection of cache list changes

### DIFF
--- a/libmemcached/constants.h
+++ b/libmemcached/constants.h
@@ -58,6 +58,8 @@
 #define ENABLE_REPLICATION 1
 #endif
 
+#define USE_SHARED_HASHRING_IN_ARCUS_MC_POOL 1
+
 /* Public defines */
 #define MEMCACHED_DEFAULT_PORT 11211
 #define MEMCACHED_MAX_KEY 251 /* We add one to have it null terminated */

--- a/libmemcached/continuum.hpp
+++ b/libmemcached/continuum.hpp
@@ -44,3 +44,11 @@ struct memcached_continuum_item_st
   uint32_t index;
   uint32_t value;
 };
+
+#ifdef USE_SHARED_HASHRING_IN_ARCUS_MC_POOL
+struct memcached_ketama_info_st {
+  uint32_t continuum_refcount;
+  uint32_t continuum_points_counter;
+  memcached_continuum_item_st *continuum;
+};
+#endif

--- a/libmemcached/hash.cc
+++ b/libmemcached/hash.cc
@@ -61,12 +61,23 @@ static uint32_t dispatch_host(const memcached_st *ptr, uint32_t hash)
   case MEMCACHED_DISTRIBUTION_CONSISTENT_KETAMA:
   case MEMCACHED_DISTRIBUTION_CONSISTENT_KETAMA_SPY:
     {
+#ifdef USE_SHARED_HASHRING_IN_ARCUS_MC_POOL
+      WATCHPOINT_ASSERT(ptr->ketama.info);
+
+      uint32_t num= ptr->ketama.info->continuum_points_counter;
+      WATCHPOINT_ASSERT(ptr->ketama.info->continuum);
+
+      memcached_continuum_item_st *begin, *end, *left, *right, *middle;
+      begin= left= ptr->ketama.info->continuum;
+      end= right= ptr->ketama.info->continuum + num;
+#else
       uint32_t num= ptr->ketama.continuum_points_counter;
       WATCHPOINT_ASSERT(ptr->ketama.continuum);
 
       memcached_continuum_item_st *begin, *end, *left, *right, *middle;
       begin= left= ptr->ketama.continuum;
       end= right= ptr->ketama.continuum + num;
+#endif
 
       while (left < right)
       {

--- a/libmemcached/memcached.h
+++ b/libmemcached/memcached.h
@@ -186,6 +186,13 @@ struct memcached_st {
   size_t pipe_responses_length;
   memcached_return_t pipe_return_code;
 
+#ifdef USE_SHARED_HASHRING_IN_ARCUS_MC_POOL
+  struct {
+    bool weighted;
+    time_t next_distribution_rebuild;
+    memcached_ketama_info_st *info;
+  } ketama;
+#else
   struct {
     bool weighted;
     uint32_t continuum_count; // Ketama
@@ -193,6 +200,7 @@ struct memcached_st {
     time_t next_distribution_rebuild; // Ketama
     memcached_continuum_item_st *continuum; // Ketama
   } ketama;
+#endif
 
   struct memcached_virtual_bucket_t *virtual_bucket;
 
@@ -279,6 +287,14 @@ memcached_return_t memcached_get_last_response_code(memcached_st *ptr);
 
 LIBMEMCACHED_API
 void memcached_set_last_response_code(memcached_st *ptr, memcached_return_t rc);
+
+#ifdef USE_SHARED_HASHRING_IN_ARCUS_MC_POOL
+LIBMEMCACHED_API
+void memcached_ketama_reference(memcached_st *dest, memcached_st *src);
+
+LIBMEMCACHED_API
+void memcached_ketama_release(memcached_st *ptr);
+#endif
 
 #ifdef __cplusplus
 } // extern "C"

--- a/libmemcached/types.h
+++ b/libmemcached/types.h
@@ -75,6 +75,9 @@ typedef struct memcached_callback_st memcached_callback_st;
 typedef struct memcached_string_st memcached_string_st;
 typedef struct memcached_string_t memcached_string_t;
 typedef struct memcached_continuum_item_st memcached_continuum_item_st;
+#ifdef USE_SHARED_HASHRING_IN_ARCUS_MC_POOL
+typedef struct memcached_ketama_info_st memcached_ketama_info_st;
+#endif
 
 typedef struct memcached_coll_create_attrs_st memcached_coll_create_attrs_st;
 typedef struct memcached_coll_result_st memcached_coll_result_st;

--- a/libmemcached/util/pool.h
+++ b/libmemcached/util/pool.h
@@ -95,6 +95,14 @@ memcached_return_t memcached_pool_behavior_get(memcached_pool_st *ptr,
                                                memcached_behavior_t flag,
                                                uint64_t *value);
 
+#ifdef USE_SHARED_HASHRING_IN_ARCUS_MC_POOL
+LIBMEMCACHED_API
+void memcached_pool_lock(memcached_pool_st *ptr);
+
+LIBMEMCACHED_API
+void memcached_pool_unlock(memcached_pool_st *ptr);
+#endif
+
 #ifdef LIBMEMCACHED_WITH_ZK_INTEGRATION
 /**
  * Utility functions for the Arcus ZooKeeper client to manipulate the pool.

--- a/tests/ketama.cc
+++ b/tests/ketama.cc
@@ -75,7 +75,11 @@ test_return_t ketama_compatibility_libmemcached(memcached_st *)
   /* VDEAAAAA hashes to fffcd1b5, after the last continuum point, and lets
    * us test the boundary wraparound.
    */
+#ifdef USE_SHARED_HASHRING_IN_ARCUS_MC_POOL
+  test_true(memcached_generate_hash(memc, (char *)"VDEAAAAA", 8) == memc->ketama.info->continuum[0].index);
+#else
   test_true(memcached_generate_hash(memc, (char *)"VDEAAAAA", 8) == memc->ketama.continuum[0].index);
+#endif
 
   /* verify the standard ketama set. */
   for (uint32_t x= 0; x < 99; x++)
@@ -136,7 +140,11 @@ test_return_t user_supplied_bug18(memcached_st *trash)
   /* VDEAAAAA hashes to fffcd1b5, after the last continuum point, and lets
    * us test the boundary wraparound.
    */
+#ifdef USE_SHARED_HASHRING_IN_ARCUS_MC_POOL
+  test_true(memcached_generate_hash(memc, (char *)"VDEAAAAA", 8) == memc->ketama.info->continuum[0].index);
+#else
   test_true(memcached_generate_hash(memc, (char *)"VDEAAAAA", 8) == memc->ketama.continuum[0].index);
+#endif
 
   /* verify the standard ketama set. */
   for (x= 0; x < 99; x++)
@@ -267,7 +275,11 @@ test_return_t ketama_compatibility_spymemcached(memcached_st *)
   /* VDEAAAAA hashes to fffcd1b5, after the last continuum point, and lets
    * us test the boundary wraparound.
    */
+#ifdef USE_SHARED_HASHRING_IN_ARCUS_MC_POOL
+  test_true(memcached_generate_hash(memc, (char *)"VDEAAAAA", 8) == memc->ketama.info->continuum[0].index);
+#else
   test_true(memcached_generate_hash(memc, (char *)"VDEAAAAA", 8) == memc->ketama.continuum[0].index);
+#endif
 
   /* verify the standard ketama set. */
   for (uint32_t x= 0; x < 99; x++)


### PR DESCRIPTION
pool 을 사용하는 상태에서, cache list 변경이 발생하면
pool의 모든 memcached_st hash ring update 지연시간 동안
서비스하지 못하는 상태가 지속된다. pool size가 크고 cluster를 구성하는
cache instance 수가 많을 경우 문제가 될 수 있다.

pool을 사용 할 경우 master memcached_st의 hash ring 의 pointer를
pool의 모든 memcached_st가 공유해서 사용하도록 최적화 한다.

pool fetch, release 단계에서는 항상 pool->mutex lock을 획득 한 상태로 동작하므로,
master memcached_st의 hash ring은 pool->mutex lock hold 상태에서 교체 한다.
모든 hash ring은 reference count를 두고 0이 되면 memory를 free 한다.

- master는 cache list update가 발생하면, 새로운 cache list hash ring을 생성하고, refcount=1로 설정해
pool->mutex lock 상태에서 기존 hash ring release & new hash ring으로 교체 를 수행한다.
- pool fetch는 pool->mutex lock 상태에서 master의 hash ring pointer를 copy 하고 refcount += 1 한다.
- pool release는 pool->mutex lock 상태에서 hash ring pointer의 refcount -= 1 하고, 0 이면 memory free 한다.
- memcached_free() 는 hash ring != NULL 이면, release 작업을 수행한다.

Reviewer
- [ ] @jhpark816 

리뷰 요청 드립니다.

---
이전 리뷰 내용은, hash ring 접근 조건이 많아
c client를 사용하는 여러 case 동작에 문제없음을 확인하는데 어려운 제약이 있었음.

1. arcus & not pool
2. arcus & pool
3. not arcus & not pool
4. not arcus & pool

2번 case가 문제가 발생했던 case로 master_mc의 hash ring을 reference 하도록 수정된 형태.
hash ring을 생성하는 run_distribute() 함수에서 2번 case에서만 master_mc를 구분해
hash ring을 생성하고, 나머지는 모두 hash ring을 생성.

ketama_reference는 2번 case일 때만 수행하고,
ketama_release도 2번 case에서만 수행됨을 조건을 정리해서 드러나게 수정.