### PR TITLE
FIX: prevent master_mc from being freed while using pool

### DIFF
--- a/libmemcached/memcached.cc
+++ b/libmemcached/memcached.cc
@@ -62,6 +62,7 @@
 static inline bool _memcached_init(memcached_st *self)
 {
   self->state.is_purging= false;
+  self->state.is_referenced= false;
   self->state.is_processing_input= false;
   self->state.is_time_for_rebuild= false;
 
@@ -164,6 +165,11 @@ static inline bool _memcached_init(memcached_st *self)
 
 static void _free(memcached_st *ptr, bool release_st)
 {
+  /* If ptr is referenced as the master of the pool, do not free it. */
+  if (ptr->state.is_referenced) {
+    return;
+  }
+
   /* If we have anything open, lets close it now */
   send_quit(ptr);
 #ifdef ENABLE_REPLICATION

--- a/libmemcached/memcached.h
+++ b/libmemcached/memcached.h
@@ -122,6 +122,7 @@ struct memcached_st {
   */
   struct {
     bool is_purging:1;
+    bool is_referenced:1;
     bool is_processing_input:1;
     bool is_time_for_rebuild:1;
   } state;

--- a/libmemcached/util/pool.cc
+++ b/libmemcached/util/pool.cc
@@ -113,6 +113,7 @@ struct memcached_pool_st
     delete [] mc_pool;
     if (_owns_master)
     {
+      master->state.is_referenced= false;
       memcached_free(master);
     }
   }
@@ -200,6 +201,8 @@ memcached_pool_st *memcached_pool_create(memcached_st* master, uint32_t initial,
     return NULL;
   }
 
+  master->state.is_referenced= true;
+
   return object;
 }
 
@@ -238,6 +241,9 @@ memcached_st*  memcached_pool_destroy(memcached_pool_st* pool)
   else
   {
     ret= pool->master;
+    if (ret != NULL) {
+      ret->state.is_referenced= false;
+    }
   }
 
   delete pool;


### PR DESCRIPTION
pool 사용 시 master_mc 객체에 대해 free할 수 없도록 하기 위한 PR 입니다.

memcached_st 객체 내부 state에 is_referenced 라는 변수를 추가했고, true로 세팅되어 있을 경우 free할 수 없도록 했습니다.

is_referenced 변수는 memcached_pool_create() 호출 시 master_mc 객체에 true로 세팅,
memcached_pool_destory() 호출 시
  - master_mc ownership을 pool이 가지고 있을 경우 pool delete 내부에서 false로 세팅하고 직접 free
  - master_mc 를 create 한 application 이 가지고 있을 경우 is_referenced false 세팅하고 application이 free
하는 방식으로 동작합니다.

destory() 의 동작이 구분되는 이유는 pool 생성 시 아래 두 가지 방법으로 생성이 가능하기 때문입니다.
- `memcached_pool(option_string)` : option string 기반으로 master_mc를 직접 생성하고 pool 에 등록
- `memcached_pool_create(master)` : 전달받은 master를 기반으로 pool 생성

@jhpark816 
확인 요청 드립니다.