### PR TITLE
FIX: if replication is enabled, only free rgroup lists

### DIFF
--- a/libmemcached/memcached.cc
+++ b/libmemcached/memcached.cc
@@ -167,7 +167,9 @@ static void _free(memcached_st *ptr, bool release_st)
   /* If we have anything open, lets close it now */
   send_quit(ptr);
 #ifdef ENABLE_REPLICATION
-  memcached_rgroup_list_free(ptr);
+  if (ptr->flags.repl_enabled)
+    memcached_rgroup_list_free(ptr);
+  else
 #endif
   memcached_server_list_free(memcached_server_list(ptr));
   memcached_result_free(&ptr->result);


### PR DESCRIPTION
replication enabled 일 때 rgroup list만 free하도록 수정 했습니다.

@jhpark816 
확인 요청 드립니다.