### PR TITLE
ENHANCE: if changed in the cache list, repopulate the pool

### DIFF
--- a/libmemcached/arcus.cc
+++ b/libmemcached/arcus.cc
@@ -804,7 +804,7 @@ static inline void do_arcus_proxy_update_cachelist(memcached_st *mc,
 static inline memcached_return_t
 __do_arcus_update_grouplist(memcached_st *mc,
                             struct memcached_server_info *serverinfo,
-                            uint32_t servercount, bool *changed_serverinfo)
+                            uint32_t servercount, bool *serverlist_changed)
 {
   struct memcached_rgroup_info *groupinfo;
   uint32_t groupcount= 0;
@@ -813,8 +813,11 @@ __do_arcus_update_grouplist(memcached_st *mc,
   bool prune_flag= false;
 
   if (servercount == 0) {
+    if (memcached_server_count(mc) == 0) {
+      return MEMCACHED_SUCCESS;
+    }
     memcached_rgroup_prune(mc, true); /* prune all rgroups */
-    *changed_serverinfo= true;
+    *serverlist_changed= true;
     return run_distribution(mc);
   }
 
@@ -866,7 +869,7 @@ __do_arcus_update_grouplist(memcached_st *mc,
   memcached_rgroup_info_destroy(mc, groupinfo);
 
   if (prune_flag or validcount > 0) {
-    *changed_serverinfo= true;
+    *serverlist_changed= true;
     return run_distribution(mc);
   } else {
     return MEMCACHED_SUCCESS;
@@ -877,7 +880,7 @@ __do_arcus_update_grouplist(memcached_st *mc,
 static inline memcached_return_t
 __do_arcus_update_cachelist(memcached_st *mc,
                             struct memcached_server_info *serverinfo,
-                            uint32_t servercount, bool *changed_serverinfo)
+                            uint32_t servercount, bool *serverlist_changed)
 {
   memcached_return_t error= MEMCACHED_SUCCESS;
   uint32_t x, y;
@@ -888,8 +891,11 @@ __do_arcus_update_cachelist(memcached_st *mc,
   if (servercount == 0)
   {
     /* If there's no available servers, delete all managed servers. */
+    if (memcached_server_count(mc) == 0) {
+      return MEMCACHED_SUCCESS;
+    }
     memcached_server_prune(mc, true); /* prune all servers */
-    *changed_serverinfo = true;
+    *serverlist_changed = true;
     return run_distribution(mc);
   }
 
@@ -933,7 +939,7 @@ __do_arcus_update_cachelist(memcached_st *mc,
       }
     }
     if (servers or prune_flag) {
-      *changed_serverinfo = true;
+      *serverlist_changed = true;
     }
   } else { /* memcached_server_list_append FAIL */
     if (prune_flag) {
@@ -963,13 +969,13 @@ static inline void do_arcus_update_cachelist(memcached_st *mc,
   gettimeofday(&tv_begin, 0);
 
   /* Update the server list. */
-  bool changed_serverinfo= false;
+  bool serverlist_changed= false;
 #ifdef ENABLE_REPLICATION
   if (mc->flags.repl_enabled)
-    error= __do_arcus_update_grouplist(mc, serverinfo, servercount, &changed_serverinfo);
+    error= __do_arcus_update_grouplist(mc, serverinfo, servercount, &serverlist_changed);
   else
 #endif
-  error= __do_arcus_update_cachelist(mc, serverinfo, servercount, &changed_serverinfo);
+  error= __do_arcus_update_cachelist(mc, serverinfo, servercount, &serverlist_changed);
 
   unlikely (arcus->is_initializing)
   {
@@ -978,7 +984,7 @@ static inline void do_arcus_update_cachelist(memcached_st *mc,
   }
 
   /* If enabled memcached pooling, repopulate the pool. */
-  if (arcus->pool && changed_serverinfo) {
+  if (arcus->pool && serverlist_changed) {
     memcached_return_t rc= memcached_pool_repopulate(arcus->pool);
     if (rc == MEMCACHED_SUCCESS) {
       ZOO_LOG_WARN(("MEMACHED_POOL=REPOPULATED"));


### PR DESCRIPTION
ZK event에 의해 update cache list 로직이 수행 될 경우,
실제 cache list가 변경 된 경우에만 pool repopulate를 수행도록 수정 했습니다.
pool repopulate 동작은 오버헤드가 큰 동작으로,
현재 수행 비용이 부담되는 상태이기 때문에 실제로 필요 할 때만 수행하도록 최적화 하기 위한 수정 입니다.

@jhpark816 
확인 요청 드립니다.