### PR TITLE
ENHANCE: update mc fetched from pool based on ketama_version of master

### DIFF
--- a/libmemcached/arcus.cc
+++ b/libmemcached/arcus.cc
@@ -139,6 +139,16 @@ arcus_return_t arcus_close(memcached_st *mc)
   if (arcus) {
 #ifdef UPDATE_HASH_RING_OF_FETCHED_MC
     if (arcus->serverinfo) {
+      for (uint32_t i= 0; i < arcus->servercount; i++) {
+#ifdef ENABLE_REPLICATION
+        if (arcus->serverinfo[i].groupname) {
+          free(arcus->serverinfo[i].groupname);
+        }
+#endif
+        if (arcus->serverinfo[i].hostname) {
+          free(arcus->serverinfo[i].hostname);
+        }
+      }
       libmemcached_free(mc, arcus->serverinfo);
       arcus->serverinfo= NULL;
     }

--- a/libmemcached/arcus_priv.h
+++ b/libmemcached/arcus_priv.h
@@ -115,7 +115,7 @@ static inline void arcus_server_check_for_update(memcached_st *)
 }
 
 #ifdef UPDATE_HASH_RING_OF_FETCHED_MC
-static inline void do_arcus_update_cachelist_of_pool_member(memcached_st *ptr)
+static inline void do_arcus_update_cachelist_of_pool_member(memcached_st *)
 {
   /* Nothing */
 }

--- a/libmemcached/arcus_priv.h
+++ b/libmemcached/arcus_priv.h
@@ -70,6 +70,11 @@ typedef struct arcus_st {
     arcus_proxy_data_st *data;
   } proxy;
 
+#ifdef UPDATE_HASH_RING_OF_FETCHED_MC
+  struct memcached_server_info *serverinfo;
+  uint32_t                      servercount;
+#endif
+
   memcached_pool_st *pool;
 
   bool is_initializing;
@@ -98,6 +103,9 @@ struct memcached_server_info
 
 LIBMEMCACHED_API
 void arcus_server_check_for_update(memcached_st *ptr);
+#ifdef UPDATE_HASH_RING_OF_FETCHED_MC
+void arcus_update_cachelist_of_pool_member(memcached_st *ptr);
+#endif
 
 #else /* LIBMEMCACHED_WITH_ZK_INTEGRATION */
 
@@ -105,6 +113,13 @@ static inline void arcus_server_check_for_update(memcached_st *)
 {
   /* Nothing */
 }
+
+#ifdef UPDATE_HASH_RING_OF_FETCHED_MC
+static inline void do_arcus_update_cachelist_of_pool_member(memcached_st *ptr)
+{
+  /* Nothing */
+}
+#endif
 #endif
 
 #endif /* __LIBMEMCACHED_ARCUS_PRIV_H__ */

--- a/libmemcached/constants.h
+++ b/libmemcached/constants.h
@@ -59,6 +59,7 @@
 #endif
 
 #define USE_SHARED_HASHRING_IN_ARCUS_MC_POOL 1
+#define UPDATE_HASH_RING_OF_FETCHED_MC 1
 
 /* Public defines */
 #define MEMCACHED_DEFAULT_PORT 11211

--- a/libmemcached/memcached.cc
+++ b/libmemcached/memcached.cc
@@ -151,10 +151,8 @@ static inline bool _memcached_init(memcached_st *self)
   self->configure.max_pool_size= 1;
 #ifdef UPDATE_HASH_RING_OF_FETCHED_MC
   self->configure.ketama_version= -1;
-  self->configure.behavior_version= -1;
-#else
-  self->configure.version= -1;
 #endif
+  self->configure.version= -1;
   self->configure.filename= NULL;
 
   self->flags.piped= false;
@@ -424,10 +422,8 @@ memcached_st *memcached_clone(memcached_st *clone, const memcached_st *source)
   new_clone->configure.filename= memcached_array_clone(new_clone, source->_namespace);
 #ifdef UPDATE_HASH_RING_OF_FETCHED_MC
   new_clone->configure.ketama_version= source->configure.ketama_version;
-  new_clone->configure.behavior_version= source->configure.behavior_version;
-#else
-  new_clone->configure.version= source->configure.version;
 #endif
+  new_clone->configure.version= source->configure.version;
 
   if (LIBMEMCACHED_WITH_SASL_SUPPORT and source->sasl.callbacks)
   {

--- a/libmemcached/memcached.cc
+++ b/libmemcached/memcached.cc
@@ -149,7 +149,12 @@ static inline bool _memcached_init(memcached_st *self)
   self->_namespace= NULL;
   self->configure.initial_pool_size= 1;
   self->configure.max_pool_size= 1;
+#ifdef UPDATE_HASH_RING_OF_FETCHED_MC
+  self->configure.ketama_version= -1;
+  self->configure.behavior_version= -1;
+#else
   self->configure.version= -1;
+#endif
   self->configure.filename= NULL;
 
   self->flags.piped= false;
@@ -417,7 +422,12 @@ memcached_st *memcached_clone(memcached_st *clone, const memcached_st *source)
 
   new_clone->_namespace= memcached_array_clone(new_clone, source->_namespace);
   new_clone->configure.filename= memcached_array_clone(new_clone, source->_namespace);
+#ifdef UPDATE_HASH_RING_OF_FETCHED_MC
+  new_clone->configure.ketama_version= source->configure.ketama_version;
+  new_clone->configure.behavior_version= source->configure.behavior_version;
+#else
   new_clone->configure.version= source->configure.version;
+#endif
 
   if (LIBMEMCACHED_WITH_SASL_SUPPORT and source->sasl.callbacks)
   {

--- a/libmemcached/memcached.h
+++ b/libmemcached/memcached.h
@@ -219,10 +219,8 @@ struct memcached_st {
     uint32_t max_pool_size;
 #ifdef UPDATE_HASH_RING_OF_FETCHED_MC
     int32_t ketama_version;
-    int32_t behavior_version;
-#else
-    int32_t version; // This is used by pool and others to determine if the memcached_st is out of date.
 #endif
+    int32_t version; // This is used by pool and others to determine if the memcached_st is out of date.
     struct memcached_array_st *filename;
   } configure;
   struct {

--- a/libmemcached/memcached.h
+++ b/libmemcached/memcached.h
@@ -217,7 +217,12 @@ struct memcached_st {
   struct {
     uint32_t initial_pool_size;
     uint32_t max_pool_size;
+#ifdef UPDATE_HASH_RING_OF_FETCHED_MC
+    int32_t ketama_version;
+    int32_t behavior_version;
+#else
     int32_t version; // This is used by pool and others to determine if the memcached_st is out of date.
+#endif
     struct memcached_array_st *filename;
   } configure;
   struct {

--- a/libmemcached/util/pool.cc
+++ b/libmemcached/util/pool.cc
@@ -584,7 +584,6 @@ memcached_return_t memcached_pool_repopulate(memcached_pool_st* pool)
   }
 
 #ifdef UPDATE_HASH_RING_OF_FETCHED_MC
-  pool->increment_ketama_version();
 #else
   pool->increment_version();
 #endif
@@ -592,8 +591,9 @@ memcached_return_t memcached_pool_repopulate(memcached_pool_st* pool)
   /* update the clones */
 #ifdef UPDATE_HASH_RING_OF_FETCHED_MC
   arcus_st *arcus= static_cast<arcus_st *>(memcached_get_server_manager(pool->mc_pool[0]));
-  if (arcus && arucs->pool)
+  if (arcus && arcus->pool)
   {
+    pool->increment_ketama_version();
     for (int xx= 0; xx <= pool->top; ++xx)
     {
       arcus_update_cachelist_of_pool_member(pool->mc_pool[xx]);
@@ -601,6 +601,7 @@ memcached_return_t memcached_pool_repopulate(memcached_pool_st* pool)
   }
   else
   {
+    pool->increment_version();
     for (int xx= 0; xx <= pool->top; ++xx)
     {
       memcached_st *memc;

--- a/libmemcached/util/pool.cc
+++ b/libmemcached/util/pool.cc
@@ -373,7 +373,18 @@ bool memcached_pool_st::release(memcached_st *released, memcached_return_t& rc)
   /* 
     Someone updated the behavior on the object, so we clone a new memcached_st with the new settings. If we fail to clone, we keep the old one around.
   */
-  if (compare_version(released) == false)
+#ifdef UPDATE_HASH_RING_OF_FETCHED_MC
+  bool make_new_memcached= false;
+  if (compare_version(released) == false) {
+    make_new_memcached= true;
+  } else if (compare_ketama_version(released) == false) {
+    make_new_memcached= true;
+#ifdef LIBMEMCACHED_WITH_ZK_INTEGRATION
+    arcus_update_cachelist_of_pool_member(released);
+    make_new_memcached= false;
+#endif
+  }
+  if (make_new_memcached)
   {
     memcached_st *memc;
     if ((memc= memcached_clone(NULL, master)))
@@ -382,10 +393,15 @@ bool memcached_pool_st::release(memcached_st *released, memcached_return_t& rc)
       released= memc;
     }
   }
-#ifdef UPDATE_HASH_RING_OF_FETCHED_MC
-  else if (compare_ketama_version(released) == false)
+#else
+  if (compare_version(released) == false)
   {
-    arcus_update_cachelist_of_pool_member(released);
+    memcached_st *memc;
+    if ((memc= memcached_clone(NULL, master)))
+    {
+      memcached_free(released);
+      released= memc;
+    }
   }
 #endif
 
@@ -592,9 +608,12 @@ memcached_return_t memcached_pool_repopulate(memcached_pool_st* pool)
   {
 #ifdef UPDATE_HASH_RING_OF_FETCHED_MC
     arcus_st *arcus= static_cast<arcus_st *>(memcached_get_server_manager(pool->mc_pool[xx]));
-    if (arcus && arcus->pool) {
+    if (arcus && arcus->pool)
+    {
       arcus_update_cachelist_of_pool_member(pool->mc_pool[xx]);
-    } else {
+    }
+    else
+    {
       memcached_st *memc;
       if ((memc= memcached_clone(NULL, pool->master)))
       {


### PR DESCRIPTION
arcus cluster와 pool을 사용하는 상황에서,
fetch 된 memcached_st로 release 하지 않은 상태로 여러개의 operation을 처리 할 경우
cache list가 변경 되었더라도 반영하지 못해 잘못된 서버에게 요청을 보내는 상황이 발생할 수 있습니다.

operation을 요청하기 전 master_mc와 ketama_version 비교를 통해
old cache list로 동작 할 경우 fetch 된 memcached_st의 server list & hash ring을 update 하고
짧은 시간 안에 최신 상태의 cache list 기반으로 요청을 보낼 수 있도록 수정 했습니다.

@hjyun328 @jhpark816 
확인 요청 드립니다.