### PR TITLE
CLEANUP: added master check when pool repopulate from cachelist update

### DIFF
--- a/libmemcached/arcus.cc
+++ b/libmemcached/arcus.cc
@@ -984,7 +984,7 @@ static inline void do_arcus_update_cachelist(memcached_st *mc,
   }
 
   /* If enabled memcached pooling, repopulate the pool. */
-  if (arcus->pool && serverlist_changed) {
+  if (arcus->pool && mc == memcached_pool_get_master(arcus->pool) && serverlist_changed) {
     memcached_return_t rc= memcached_pool_repopulate(arcus->pool);
     if (rc == MEMCACHED_SUCCESS) {
       ZOO_LOG_WARN(("MEMACHED_POOL=REPOPULATED"));


### PR DESCRIPTION
cachelist update 동작 중 memcached_pool_repopulate() 동작을
pool의 memcached_st가 수행할 수 있었던 상황을 회피하기 위해
master memcached_st만 repopulate를 할 수 있도록 조건 추가 했습니다.

@jhpark816 
확인 요청 드립니다.