### PR TITLE
CLEANUP: do not assertion fail on connection failure

### DIFF
--- a/libmemcached/get.cc
+++ b/libmemcached/get.cc
@@ -333,7 +333,10 @@ static memcached_return_t memcached_mget_by_key_real(memcached_st *ptr,
 
       if (memcached_failed(rc))
       {
-        memcached_set_error(*instance, rc, MEMCACHED_AT);
+        if (rc != MEMCACHED_ERRNO)
+        {
+          memcached_set_error(*instance, rc, MEMCACHED_AT);
+        }
         continue;
       }
       hosts_connected++;


### PR DESCRIPTION
connection 실패로 MEMCACHED_ERRNO error 가 발생했을 때
assertion fail 시키지 않도록 하기 위한 PR 입니다.

@jhpark816 
확인 요청 드립니다.