### PR TITLE
FIX: removed possibility of returning deallocated pointer

### DIFF
--- a/libmemcached/protocol/protocol_handler.c
+++ b/libmemcached/protocol/protocol_handler.c
@@ -292,6 +292,7 @@ struct memcached_protocol_st *memcached_protocol_create_instance(void)
     {
       free(ret->input_buffer);
       free(ret);
+      return NULL;
     }
   }
 


### PR DESCRIPTION
codacy 에 다음과 같은 오류가 나와서 수정 PR을 보냅니다.

```
Returning/dereferencing 'ret' after it is deallocated / released
```