### PR TITLE
FIX: fix nullpointer dereferencing

### DIFF
--- a/libmemcached/allocators.cc
+++ b/libmemcached/allocators.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -60,7 +60,7 @@ void *_libmemcached_calloc(const memcached_st *self, size_t nelem, size_t size, 
   if (self->allocators.malloc != _libmemcached_malloc)
   {
      void *ret = _libmemcached_malloc(self, nelem * size, context);
-     if (not ret)
+     if (ret)
      {
        memset(ret, 0, nelem * size);
      }
@@ -90,7 +90,7 @@ memcached_return_t memcached_set_memory_allocators(memcached_st *self,
   }
 
   /* All should be set, or none should be set */
-  if (mem_malloc == NULL && mem_free == NULL && mem_realloc == NULL && mem_calloc == NULL) 
+  if (mem_malloc == NULL && mem_free == NULL && mem_realloc == NULL && mem_calloc == NULL)
   {
     self->allocators= memcached_allocators_return_default();
   }


### PR DESCRIPTION
codacy 검사 결과 Null pointer dereference 경고가 나온 부분을 수정했습니다.

if문 조건이 반대로 되어 있는데 최근 libmemcached에서는 이미 수정되었습니다. (https://github.com/trondn/libmemcached/blob/master/libmemcached/allocators.c)

추가로 파일의 trailling whitespace도 제거했습니다. 

 