### PR TITLE
CLEANUP: change to create version using m4 file

### DIFF
--- a/config/version.pl
+++ b/config/version.pl
@@ -43,8 +43,8 @@ if (scalar @arcus_versions > 1) {
 my $arcus_version = join('_', @arcus_versions);
 
 # VERSION_NUMBER
-my $version = $libmemcached_version."-arcus-".$arcus_version;
-write_file('m4/version.m4', "m4_define([VERSION_NUMBER], [$version])\n");
+#my $version = $libmemcached_version."-arcus-".$arcus_version;
+write_file('m4/version.m4', "m4_define([VERSION_NUMBER], [$arcus_version])\n");
 
 sub write_file {
     my $file = shift;

--- a/configure.ac
+++ b/configure.ac
@@ -190,7 +190,7 @@ AS_IF([test "x$enable_zk_integration" = "xyes"],
       [ARCUS_CLUSTER_API_ENABLED="#define ARCUS_CLUSTER_API_ENABLED 1"])
 AC_SUBST(ARCUS_CLUSTER_API_ENABLED)
 
-AC_DEFINE([ARCUS_VERSION_STRING],["1.10.3"],[Arcus Version String])
+AC_DEFINE([ARCUS_VERSION_STRING],["VERSION_NUMBER"],[Arcus Version String])
 
 if test "x$enable_zk_integration" = "xyes"; then
   tryzookeeperdir=""


### PR DESCRIPTION
https://github.com/jam2in/arcus-memcached-EE/issues/869 c client의 version 관리 방법 변경을 위한 PR 입니다.

기존의 arcus-c-client는 version이 release 되면 직접 configure.ac의 ARCUS_VERSION_STRING 값을 변경해주어야 했습니다. 이러한 관리 포인트를 줄이기 위해 m4 file로 생성하는 version 정보를 이용하여 c client version을 생성하도록 변경합니다.

m4 file로 생성하는 version 정보는 libmemcached version을 포함하며 아래와 같이 client info에 생성됩니다.
`<host>_<addr>_<pool-size>_c_<1.10.3_10>_<20200204135808_16e344388040055>`
기존에 생성되던 정보에서 "1.10.3_10" 부분이 변경된 부분이며 기존에는 "1.10.3"만 표시되었습니다.
변경 부분의 의미는 `c client version _ head 이후 commit 개수` 입니다.

@jhpark816 
확인 요청 드립니다.