### PR TITLE
CLEANUP: change max element bytes

### DIFF
--- a/libmemcached/collection.h
+++ b/libmemcached/collection.h
@@ -37,7 +37,7 @@
 #define MEMCACHED_COLL_UPD_FILTER_STR_LENGTH    80
 #define MEMCACHED_COLL_MAX_BYTE_ARRAY_LENGTH    31  /* server maximum, not client limitation */
 #define MEMCACHED_COLL_MAX_BYTE_STRING_LENGTH   MEMCACHED_COLL_MAX_BYTE_ARRAY_LENGTH*2+1
-#define MEMCACHED_COLL_MAX_ELEMENT_SIZE         4*1024  /* server maximum, not client limitation */
+#define MEMCACHED_COLL_MAX_ELEMENT_SIZE         16*1024  /* server maximum, not client limitation */
 #define MEMCACHED_COLL_MAX_PIPED_CMD_SIZE       500
 #if 1 // MAP_COLLECTION_SUPPORT
 #define MEMCACHED_COLL_MAX_MOP_MKEY_LENG        250


### PR DESCRIPTION
arcus-memcached의 max element bytes 변경에 따라
MEMCACHED_COLL_MAX_ELEMENT_SIZE macro 값을 16K로 변경했습니다.

MEMCACHED_COLL_MAX_ELEMENT_SIZE macro는 unit test 중
max element bytes test 에서 사용하고 있습니다.
- MEMCACHED_COLL_MAX_ELEMENT_SIZE+1 만큼 value insert/update 요청하여 error가 return 되는지 확인 합니다.

@jhpark816 
확인 요청 드립니다.