### PR TITLE
FIX: prevent master_mc from being freed while using pool

### DIFF
--- a/libmemcached/memcached.cc
+++ b/libmemcached/memcached.cc
@@ -62,6 +62,7 @@
 static inline bool _memcached_init(memcached_st *self)
 {
   self->state.is_purging= false;
+  self->state.is_pool_master= false;
   self->state.is_processing_input= false;
   self->state.is_time_for_rebuild= false;
 
@@ -171,6 +172,12 @@ static inline bool _memcached_init(memcached_st *self)
 
 static void _free(memcached_st *ptr, bool release_st)
 {
+  /* If ptr is being used as the master of the pool, do not free it */
+  if (ptr->state.is_pool_master) {
+    fprintf(stderr, "%s\n", "Failed free: used as the master of the pool");
+    return;
+  }
+
   /* If we have anything open, lets close it now */
   send_quit(ptr);
 #ifdef ENABLE_REPLICATION

--- a/libmemcached/memcached.h
+++ b/libmemcached/memcached.h
@@ -122,6 +122,7 @@ struct memcached_st {
   */
   struct {
     bool is_purging:1;
+    bool is_pool_master:1;
     bool is_processing_input:1;
     bool is_time_for_rebuild:1;
   } state;

--- a/libmemcached/util/pool.cc
+++ b/libmemcached/util/pool.cc
@@ -229,6 +229,7 @@ memcached_pool_st *memcached_pool_create(memcached_st* master, uint32_t initial,
     return NULL;
   }
 
+  master->state.is_pool_master= true;
   return object;
 }
 
@@ -267,6 +268,10 @@ memcached_st*  memcached_pool_destroy(memcached_pool_st* pool)
   else
   {
     ret= pool->master;
+  }
+
+  if (pool->master != NULL) {
+    pool->master->state.is_pool_master= false;
   }
 
   delete pool;


### PR DESCRIPTION
pool 사용 시 master_mc 객체에 대해 free할 수 없도록 하기 위한 PR 입니다.
#51 다음 PR입니다.

memcached_st 객체 내부 state에 is_pool_master 라는 변수를 추가했고, true로 세팅되어 있을 경우 free할 수 없도록 했습니다.

is_pool_master 변수는 memcached_pool_create() 호출 시 master_mc 객체에 true로 세팅,
memcached_pool_destory() 호출 시 master_mc 객체에 false로 세팅 하는 방식으로 동작합니다.

@jhpark816 
확인 요청 드립니다.