### PR TITLE
CLEANUP: move the initializing to zk_st depending on usage

### DIFF
--- a/libmemcached/arcus_priv.h
+++ b/libmemcached/arcus_priv.h
@@ -44,6 +44,7 @@ struct arcus_zk_st
   size_t     maxbytes;
   int        last_rc;
   struct String_vector last_strings;
+  bool       is_initializing;
 #ifdef ENABLE_REPLICATION
   bool       is_repl_enabled;
 #endif
@@ -72,7 +73,6 @@ typedef struct arcus_st {
 
   memcached_pool_st *pool;
 
-  bool is_initializing;
   bool is_proxy;
 } arcus_st;
 


### PR DESCRIPTION
#72 관련 PR 입니다.

기존 `arcus->is_initializing` 변수는 zookeeper 초기화를
기다리는 목적으로만 되었습니다.
사용 목적에 따라서 `arcus_zk_st`로 옮기는게 맞는것 같아
`arcus->zk.is_initializing`으로 사용하도록 변경 하였습니다.

변수가 이동됨에 따라 zookeeper close 하는 부분에서 초기화를 진행하도록 수정 했습니다.
arcus_close(), arcus_pool_close(), arcus_proxy_close() 모두 do_arcus_zk_close()를 호출하여
close 작업을 진행하므로 do_arcus_zk_close() 에서만 초기화 해주면 됩니다.

@SuhwanJang @jhpark816 
확인 요청 드립니다.