### PR TITLE
FIX: enable email notification for pull request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ script:
 
 notifications:
   email:
-    - junhyun.park@jam2in.com
-    - minkikim89@jam2in.com
-    - alsdn653@jam2in.com
+    if: fork = false OR type = pull_request
+    recipients:
+      - junhyun.park@jam2in.com
+      - minkikim89@jam2in.com
+      - alsdn653@jam2in.com


### PR DESCRIPTION
[서버 PR 446](https://github.com/naver/arcus-memcached/pull/446/commits/303d794214fd169a02f30af5eb39d9239ca020b3)처럼 noti 조건을 변경했습니다.

기존의 조건: forked repo가 아닐 때에만 noti

변경된 조건: forked repo가 아니거나, PR을 했을 때에만 noti