### PR TITLE
CLEANUP: add arcus_zk_manager for process requests of ZooKeeper

### DIFF
--- a/libmemcached/arcus.cc
+++ b/libmemcached/arcus.cc
@@ -28,6 +28,9 @@
 
 #define ARCUS_ZK_SESSION_TIMEOUT_IN_MS        15000
 #define ARCUS_ZK_HEARTBEAT_INTERVAL_IN_SEC    1
+#ifdef ARCUS_ZK_MANAGER
+#define ARCUS_ZK_RETRY_RECONNECT_DELAY_IN_MS  1000 /* 1 sec */
+#endif
 #define ZOO_NO_FLAGS 0
 
 #define ARCUS_ZK_CACHE_LIST                   "/arcus/cache_list"
@@ -47,7 +50,10 @@ static inline arcus_return_t do_arcus_connect(memcached_st *mc, memcached_pool_s
                                               const char *ensemble_list, const char *svc_code);
 static inline arcus_return_t do_arcus_init(memcached_st *mc, memcached_pool_st *pool,
                                            const char *ensemble_list, const char *svc_code);
+#ifdef ARCUS_ZK_MANAGER
+#else
 static inline void           do_arcus_exit(memcached_st *mc);
+#endif
 
 /**
  * ARCUS_PROXY
@@ -74,7 +80,23 @@ static inline void do_arcus_zk_watcher_cachelist(zhandle_t *zh, int type, int st
  */
 static inline void do_arcus_zk_update_cachelist(memcached_st *mc, const struct String_vector *strings);
 static inline void do_arcus_zk_update_cachelist_by_string(memcached_st *mc, char *serverlist, const size_t size);
+#ifdef ARCUS_ZK_MANAGER
+static inline void do_arcus_zk_watch_and_update_cachelist(memcached_st *mc, bool *retry);
+static inline int  do_arcus_cluster_validation_check(memcached_st *mc, arcus_st *arcus);
+#else
 static inline void do_arcus_zk_watch_and_update_cachelist(memcached_st *mc, watcher_fn watcher);
+#endif
+
+#ifdef ARCUS_ZK_MANAGER
+/**
+ * ARCUS_ZK_MANAGER
+ */
+/* zk manager functions */
+static inline arcus_return_t  do_arcus_zk_manager_start(memcached_st *mc);
+static inline void            do_arcus_zk_manager_stop(memcached_st *mc);
+static void                   do_arcus_zk_manager_wakeup(memcached_st *mc, bool locked);
+static void                  *arcus_zk_manager_thread_main(void *arg);
+#endif
 
 /**
  * UTILITIES
@@ -88,8 +110,15 @@ static inline int do_add_server_to_cachelist(struct arcus_zk_st *zkinfo, char *n
 static inline void do_update_serverlist_with_master(memcached_st *ptr, memcached_st *master);
 #endif
 
+#ifdef ARCUS_ZK_MANAGER
+/* async routine synchronization */
+static pthread_mutex_t azk_mtx  = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t  azk_cond = PTHREAD_COND_INITIALIZER;
+static int             azk_count;
+#endif
+
 pthread_mutex_t lock_arcus = PTHREAD_MUTEX_INITIALIZER;
-pthread_cond_t cond_arcus = PTHREAD_COND_INITIALIZER;
+pthread_cond_t  cond_arcus = PTHREAD_COND_INITIALIZER;
 
 /* Mutex via OS file lock */
 static int proc_mutex_create(struct arcus_proc_mutex *m, const char *fname);
@@ -118,6 +147,9 @@ arcus_return_t arcus_close(memcached_st *mc)
   arcus_return_t rc;
 
   /* Close the ZooKeeper client. */
+#ifdef ARCUS_ZK_MANAGER
+  do_arcus_zk_manager_stop(mc);
+#endif
   rc= do_arcus_zk_close(mc);
   if (rc != ARCUS_SUCCESS) {
     ZOO_LOG_ERROR(("Failed to close zookeeper client"));
@@ -196,6 +228,14 @@ arcus_return_t arcus_proxy_create(memcached_st *mc,
   if (rc != ARCUS_SUCCESS) {
     return ARCUS_ERROR;
   }
+
+#ifdef ARCUS_ZK_MANAGER
+  /* Creates a new ZooKeeper Manager thread. */
+  rc= do_arcus_zk_manager_start(mc);
+  if (rc != ARCUS_SUCCESS) {
+    return ARCUS_ERROR;
+  }
+#endif
   return rc;
 }
 
@@ -252,6 +292,14 @@ static inline arcus_return_t do_arcus_connect(memcached_st *mc,
   if (rc != ARCUS_SUCCESS) {
     return ARCUS_ERROR;
   }
+
+#ifdef ARCUS_ZK_MANAGER
+  /* Creates a new ZooKeeper Manager thread. */
+  rc= do_arcus_zk_manager_start(mc);
+  if (rc != ARCUS_SUCCESS) {
+    return ARCUS_ERROR;
+  }
+#endif
   return rc;
 }
 
@@ -355,6 +403,10 @@ const char *arcus_strerror(arcus_return_t rc)
     return "ARCUS_SUCCESS";
   case ARCUS_ERROR:
     return "ARCUS_ERROR";
+#ifdef ARCUS_ZK_MANAGER
+  case ARCUS_AUTH_FAILED:
+    return "ARCUS_AUTH_FAILED";
+#endif
   case ARCUS_ALREADY_INITIATED:
     return "arcus is already initiated";
   default:
@@ -416,6 +468,9 @@ static inline arcus_return_t do_arcus_init(memcached_st *mc,
     arcus->zk.session_timeout= ARCUS_ZK_SESSION_TIMEOUT_IN_MS;
     arcus->zk.maxbytes= 0;
     arcus->zk.last_rc= !ZOK;
+#ifdef ARCUS_ZK_MANAGER
+    arcus->zk.conn_result= ARCUS_SUCCESS;
+#endif
     arcus->zk.is_initializing= true;
 
     arcus->pool = pool;
@@ -431,12 +486,24 @@ static inline arcus_return_t do_arcus_init(memcached_st *mc,
 
     /* Set the Arcus to memcached as a server manager.  */
     memcached_set_server_manager(mc, (void *)arcus);
+
+#ifdef ARCUS_ZK_MANAGER
+    /* clear zk_manager structure */
+    memset(&arcus->zk_mgr.request, 0, sizeof(struct arcus_zk_request_st));
+    pthread_mutex_init(&arcus->zk_mgr.lock, NULL);
+    pthread_cond_init(&arcus->zk_mgr.cond, NULL);
+    arcus->zk_mgr.notification= false;
+    arcus->zk_mgr.reqstop= false;
+    arcus->zk_mgr.running= false;
+#endif
   } while(0);
   pthread_mutex_unlock(&lock_arcus);
 
   return rc;
 }
 
+#ifdef ARCUS_ZK_MANAGER
+#else
 /**
  * Clean up the Arcus and exit the program.
  */
@@ -450,8 +517,13 @@ static inline void do_arcus_exit(memcached_st *mc)
 
   exit(1);
 }
+#endif
 
+#ifdef ARCUS_ZK_MANAGER
+static inline int do_add_client_info(arcus_st *arcus)
+#else
 static inline void do_add_client_info(arcus_st *arcus)
+#endif
 {
   int result;
   char path[250];
@@ -465,8 +537,16 @@ static inline void do_add_client_info(arcus_st *arcus)
   gethostname(hostname, 50);
   host = (struct hostent *) gethostbyname(hostname);
 
+#ifdef ARCUS_ZK_MANAGER
+  /* create the ephemeral znode
+   * "/arcus or arcus_repl/client_list/{service_code}/
+   *  {client hostname}_{ip address}_{pool count}_c_{client version}_{YYYYMMDDHHIISS}_{zk session id}"
+   * it means administrator has to create the {service_code} node before using.
+   */
+#else
   // create the ephemeral znode "/arcus or arcus_repl/client_list/{service_code}/{client hostname}_{ip address}_{pool count}_{client language}_{client version}_{YYYYMMDDHHIISS}_{zk session id}"
   // it means administrator has to create the {service_code} node before using.
+#endif
   char* client_info_znode = (char*)ARCUS_ZK_CLIENT_INFO_NODE;
 #ifdef ENABLE_REPLICATION
   if (arcus->zk.is_repl_enabled) {
@@ -500,8 +580,53 @@ static inline void do_add_client_info(arcus_st *arcus)
   }
   if (result != ZOK) {
     ZOO_LOG_ERROR(("the znode of client info can not create"));
+#ifdef ARCUS_ZK_MANAGER
+    return -1;
+#endif
   }
+#ifdef ARCUS_ZK_MANAGER
+  return 0;
+#endif
 }
+
+#ifdef ARCUS_ZK_MANAGER
+/* mutex for async operations */
+static void inc_count(int delta)
+{
+  pthread_mutex_lock(&azk_mtx);
+  azk_count += delta;
+  pthread_cond_broadcast(&azk_cond);
+  pthread_mutex_unlock(&azk_mtx);
+}
+
+static void clear_count(void)
+{
+  pthread_mutex_lock(&azk_mtx);
+  azk_count= 0;
+  pthread_mutex_unlock(&azk_mtx);
+}
+
+static int wait_count(int timeout)
+{
+    struct timeval  tv;
+    struct timespec ts;
+    int rc= 0;
+    pthread_mutex_lock(&azk_mtx);
+    while (azk_count > 0 && rc == 0) {
+        if (timeout == 0) {
+            rc= pthread_cond_wait(&azk_cond, &azk_mtx);
+        } else {
+            gettimeofday(&tv, NULL);
+            ts.tv_sec = tv.tv_sec;
+            ts.tv_nsec= tv.tv_usec*1000;
+            ts.tv_sec += timeout/1000; /* timeout: msec */
+            rc= pthread_cond_timedwait(&azk_cond, &azk_mtx, &ts);
+        }
+    }
+    pthread_mutex_unlock(&azk_mtx);
+    return rc;
+}
+#endif
 
 /**
  * Creates a new ZooKeeper client thread.
@@ -511,6 +636,9 @@ static inline arcus_return_t do_arcus_zk_connect(memcached_st *mc)
   arcus_st *arcus;
   arcus_return_t rc= ARCUS_SUCCESS;
 
+#ifdef ARCUS_ZK_MANAGER
+  inc_count(1);
+#endif
   pthread_mutex_lock(&lock_arcus);
   do {
     arcus= static_cast<arcus_st *>(memcached_get_server_manager(mc));
@@ -547,6 +675,45 @@ static inline arcus_return_t do_arcus_zk_connect(memcached_st *mc)
     return ARCUS_ERROR;
   }
 
+#ifdef ARCUS_ZK_MANAGER
+  /* Wait for zk connected
+   * We need to wait until ZOO_CONNECTED_STATE
+   */
+  do {
+    if (wait_count(arcus->zk.session_timeout) != 0) {
+      ZOO_LOG_ERROR(("ZooKeeper connection failed until the session timeout."));
+      inc_count(-1);
+      rc= ARCUS_ERROR; break;
+    }
+
+    pthread_mutex_lock(&lock_arcus);
+    if (arcus->zk.conn_result != ARCUS_SUCCESS) {
+      ZOO_LOG_ERROR(("ZooKeeper connection failed, result=%d", arcus->zk.conn_result));
+      pthread_mutex_unlock(&lock_arcus);
+      rc= ARCUS_ERROR; break;
+    }
+
+    if (do_arcus_cluster_validation_check(mc, arcus) < 0) {
+      pthread_mutex_unlock(&lock_arcus);
+      rc= ARCUS_ERROR; break;
+    }
+    pthread_mutex_unlock(&lock_arcus);
+
+    if (do_add_client_info(arcus) < 0) {
+      rc= ARCUS_ERROR; break;
+    }
+  } while(0);
+
+  if (rc != ARCUS_SUCCESS) {
+      pthread_mutex_lock(&lock_arcus);
+      zookeeper_close(arcus->zk.handle);
+      arcus->zk.handle= NULL;
+      pthread_mutex_unlock(&lock_arcus);
+  }
+#endif
+
+#ifdef ARCUS_ZK_MANAGER
+#else
   ZOO_LOG_WARN(("Waiting for the cache server list..."));
 
   pthread_mutex_lock(&lock_arcus);
@@ -570,6 +737,7 @@ static inline arcus_return_t do_arcus_zk_connect(memcached_st *mc)
   if (rc == ARCUS_SUCCESS) {
     ZOO_LOG_WARN(("Done"));
   }
+#endif
   return rc;
 }
 
@@ -581,6 +749,10 @@ static inline arcus_return_t do_arcus_zk_close(memcached_st *mc)
   arcus_st *arcus;
   arcus_return_t rc= ARCUS_SUCCESS;
 
+#ifdef ARCUS_ZK_MANAGER
+  clear_count();
+#endif
+
   pthread_mutex_lock(&lock_arcus);
   do {
     arcus= static_cast<arcus_st *>(memcached_get_server_manager(mc));
@@ -591,8 +763,13 @@ static inline arcus_return_t do_arcus_zk_close(memcached_st *mc)
     /* Delete the (expired) session. */
     arcus->zk.myid.client_id= 0;
 
+#ifdef ARCUS_ZK_MANAGER
+    /* Clear connect result */
+    arcus->zk.conn_result= ARCUS_SUCCESS;
+#else
     /* Clear initializing flag */
     arcus->zk.is_initializing= true;
+#endif
 
     /* Close the ZooKeeper handle. */
     if (arcus->zk.handle) {
@@ -1168,6 +1345,39 @@ static inline void do_update_serverlist_with_master(memcached_st *ptr, memcached
 }
 #endif
 
+#ifdef ARCUS_ZK_MANAGER
+static inline int do_arcus_zk_process_reconnect(memcached_st *mc, bool *retry)
+{
+  int ret= 0;
+  arcus_return_t rc;
+  arcus_st *arcus= static_cast<arcus_st *>(memcached_get_server_manager(mc));
+
+  ZOO_LOG_WARN(("process reconnect to ZooKeeper"));
+  do {
+    rc= do_arcus_zk_close(mc);
+    if (rc != ARCUS_SUCCESS)
+      break;
+
+    rc= do_arcus_zk_connect(mc);
+    if (rc != ARCUS_SUCCESS)
+      break;
+  } while(0);
+
+  if (rc == ARCUS_SUCCESS) {
+    ZOO_LOG_WARN(("Success reconnect to ZooKeeper"));
+
+    pthread_mutex_lock(&arcus->zk_mgr.lock);
+    arcus->zk_mgr.request.update_cache_list= true;
+    pthread_mutex_unlock(&arcus->zk_mgr.lock);
+    *retry= true;
+    ret= 0;
+  } else {
+    ZOO_LOG_WARN(("Failed reconnect to ZooKeeper, retry after 1sec."));
+    ret= -1;
+  }
+  return ret;
+}
+#endif
 
 /**
  * Rebuild the memcached server list.
@@ -1209,8 +1419,13 @@ static inline void do_arcus_zk_update_cachelist(memcached_st *mc,
   pthread_mutex_unlock(&lock_arcus);
 }
 
+#ifdef ARCUS_ZK_MANAGER
+static inline void do_arcus_zk_watch_and_update_cachelist(memcached_st *mc,
+                                                          bool *retry)
+#else
 static inline void do_arcus_zk_watch_and_update_cachelist(memcached_st *mc,
                                                           watcher_fn watcher)
+#endif
 {
   arcus_st *arcus;
   struct String_vector strings = { 0, NULL };
@@ -1223,14 +1438,33 @@ static inline void do_arcus_zk_watch_and_update_cachelist(memcached_st *mc,
   }
 
   /* Make a new watch on Arcus cache list. */
+#ifdef ARCUS_ZK_MANAGER
+  zkrc= zoo_wget_children(arcus->zk.handle, arcus->zk.path,
+                          do_arcus_zk_watcher_cachelist,
+                          (void *)mc, &strings);
+#else
   zkrc= zoo_wget_children(arcus->zk.handle, arcus->zk.path, watcher, (void *)mc, &strings);
+#endif
   if (zkrc == ZOK) {
+#ifdef ARCUS_ZK_MANAGER
+    /* TODO (next commit)
+     * Error handling of update_chacelist process,
+     * must distinguish retrys by failure and by event.
+     * If it is retrys by failure, watcher should not register.
+     */
+#endif
     /* Update the cache server list. */
     do_arcus_zk_update_cachelist(mc, &strings);
     deallocate_String_vector(&strings);
   } else {
     ZOO_LOG_ERROR(("zoo_wget_children() failed, reason=%s, zookeeper=%s",
                   zerror(zkrc), arcus->zk.ensemble_list));
+#ifdef ARCUS_ZK_MANAGER
+    pthread_mutex_lock(&arcus->zk_mgr.lock);
+    arcus->zk_mgr.request.update_cache_list= true;
+    pthread_mutex_unlock(&arcus->zk_mgr.lock);
+    *retry= true;
+#endif
   }
 }
 
@@ -1243,10 +1477,32 @@ static inline void do_arcus_zk_watcher_cachelist(zhandle_t *zh __attribute__((un
                                                  const char *path __attribute__((unused)),
                                                  void *ctx_mc)
 {
+#ifdef ARCUS_ZK_MANAGER
+  if (type == ZOO_CHILD_EVENT) {
+    ZOO_LOG_INFO(("ZOO_CHILD_EVENT from ZK cache list"));
+
+    memcached_st *mc= static_cast<memcached_st *>(ctx_mc);
+    pthread_mutex_lock(&lock_arcus);
+    arcus_st *arcus= static_cast<arcus_st *>(memcached_get_server_manager(mc));
+    pthread_mutex_unlock(&lock_arcus);
+    if (not arcus || not arcus->zk.handle) {
+      ZOO_LOG_ERROR(("arcus is null"));
+      return;
+    }
+
+    pthread_mutex_lock(&arcus->zk_mgr.lock);
+    arcus->zk_mgr.request.update_cache_list= true;
+    do_arcus_zk_manager_wakeup(mc, true);
+    pthread_mutex_unlock(&arcus->zk_mgr.lock);
+  } else {
+    ZOO_LOG_WARN(("Unexpected event gotten by watcher_cachelist"));
+  }
+#else
   if (type == ZOO_CHILD_EVENT) {
     memcached_st *mc= static_cast<memcached_st *>(ctx_mc);
     do_arcus_zk_watch_and_update_cachelist(mc, do_arcus_zk_watcher_cachelist);
   }
+#endif
 }
 
 /**
@@ -1260,7 +1516,10 @@ static inline void do_arcus_zk_watcher_global(zhandle_t *zh,
 {
   memcached_st *mc= static_cast<memcached_st *>(ctx_mc);
   arcus_st *arcus;
+#ifdef ARCUS_ZK_MANAGER
+#else
   arcus_return_t rc;
+#endif
 
   if (type != ZOO_SESSION_EVENT) {
     return;
@@ -1268,7 +1527,11 @@ static inline void do_arcus_zk_watcher_global(zhandle_t *zh,
 
   pthread_mutex_lock(&lock_arcus);
   arcus= static_cast<arcus_st *>(memcached_get_server_manager(mc));
+#ifdef ARCUS_ZK_MANAGER
+  if (not arcus || not arcus->zk.handle) {
+#else
   if (not arcus) {
+#endif
     ZOO_LOG_ERROR(("arcus is null"));
     pthread_mutex_unlock(&lock_arcus);
     return;
@@ -1278,13 +1541,18 @@ static inline void do_arcus_zk_watcher_global(zhandle_t *zh,
   {
     ZOO_LOG_WARN(("SESSION_STATE=CONNECTED, to %s", arcus->zk.ensemble_list));
 
+#ifdef ARCUS_ZK_MANAGER
+#else
     bool process_initializing= false;
+#endif
     const clientid_t *id= zoo_client_id(zh);
     if (arcus->zk.myid.client_id == 0 or arcus->zk.myid.client_id != id->client_id) {
       ZOO_LOG_DEBUG(("Previous sessionid : 0x%llx", (long long) arcus->zk.myid.client_id));
       arcus->zk.myid= *id;
       ZOO_LOG_DEBUG(("Current sessionid  : 0x%llx", (long long) arcus->zk.myid.client_id));
     }
+#ifdef ARCUS_ZK_MANAGER
+#else
     if (arcus->zk.is_initializing) {
       if (do_arcus_cluster_validation_check(mc, arcus) < 0) {
         pthread_mutex_unlock(&lock_arcus);
@@ -1292,12 +1560,17 @@ static inline void do_arcus_zk_watcher_global(zhandle_t *zh,
       }
       process_initializing= true;
     }
+#endif
     pthread_mutex_unlock(&lock_arcus);
+#ifdef ARCUS_ZK_MANAGER
+    inc_count(-1);
+#else
 
     if (process_initializing) {
       do_add_client_info(arcus);
       do_arcus_zk_watch_and_update_cachelist(mc, do_arcus_zk_watcher_cachelist);
     }
+#endif
   }
   else if (state == ZOO_CONNECTING_STATE or state == ZOO_ASSOCIATING_STATE)
   {
@@ -1306,14 +1579,39 @@ static inline void do_arcus_zk_watcher_global(zhandle_t *zh,
   }
   else if (state == ZOO_AUTH_FAILED_STATE)
   {
+#ifdef ARCUS_ZK_MANAGER
+    arcus->zk.conn_result= ARCUS_AUTH_FAILED;
+#else
     ZOO_LOG_WARN(("SESSION_STATE=AUTH_FAILED, shutting down the application"));
+#endif
     pthread_mutex_unlock(&lock_arcus);
+#ifdef ARCUS_ZK_MANAGER
+    if (arcus->zk_mgr.running) {
+      ZOO_LOG_WARN(("SESSION_STATE=AUTH_FAILED, create a new client after closing failed one"));
+      pthread_mutex_lock(&arcus->zk_mgr.lock);
+      arcus->zk_mgr.request.reconnect_process= true;
+      do_arcus_zk_manager_wakeup(mc, true);
+      pthread_mutex_unlock(&arcus->zk_mgr.lock);
+    } else {
+      ZOO_LOG_WARN(("SESSION_STATE=AUTH_FAILED, close the failed client on the first connection"));
+    }
+    inc_count(-1);
+#else
     do_arcus_exit(mc);
+#endif
   }
   else if (state == ZOO_EXPIRED_SESSION_STATE)
   {
     ZOO_LOG_WARN(("SESSION_STATE=EXPIRED_SESSION, create a new client after closing expired one"));
     pthread_mutex_unlock(&lock_arcus);
+#ifdef ARCUS_ZK_MANAGER
+    if (arcus->zk_mgr.running) {
+      pthread_mutex_lock(&arcus->zk_mgr.lock);
+      arcus->zk_mgr.request.reconnect_process= true;
+      do_arcus_zk_manager_wakeup(mc, true);
+      pthread_mutex_unlock(&arcus->zk_mgr.lock);
+    }
+#else
 
     /* Respawn the expired zookeeper client. */
     rc= do_arcus_zk_close(mc);
@@ -1321,8 +1619,189 @@ static inline void do_arcus_zk_watcher_global(zhandle_t *zh,
     if (rc != ARCUS_SUCCESS) {
       ZOO_LOG_ERROR((arcus_strerror(rc)));
     }
+#endif
   }
 }
+
+#ifdef ARCUS_ZK_MANAGER
+/**
+ * ZooKeeper manager
+ */
+static inline arcus_return_t do_arcus_zk_manager_start(memcached_st *mc)
+{
+  arcus_st *arcus;
+  arcus_return_t rc= ARCUS_SUCCESS;
+
+  /* Start arcus zk manager thread */
+  pthread_mutex_lock(&lock_arcus);
+  do {
+    arcus= static_cast<arcus_st *>(memcached_get_server_manager(mc));
+    if (not arcus || not arcus->zk.handle) {
+      rc= ARCUS_ERROR; break;
+    }
+
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM);
+
+    /* zk manager thread */
+    if (0 != pthread_create(&arcus->zk_mgr.tid, &attr, arcus_zk_manager_thread_main, (void *)mc)) {
+      ZOO_LOG_ERROR(("Cannot create zk manager thread: %s(%d)", strerror(errno), errno));
+      zookeeper_close(arcus->zk.handle);
+      arcus->zk.handle= NULL;
+      rc= ARCUS_ERROR; break;
+    }
+
+    pthread_mutex_lock(&arcus->zk_mgr.lock);
+    arcus->zk_mgr.request.update_cache_list= true;
+    do_arcus_zk_manager_wakeup(mc, true);
+    pthread_mutex_unlock(&arcus->zk_mgr.lock);
+  } while(0);
+  pthread_mutex_unlock(&lock_arcus);
+
+  if (rc != ARCUS_SUCCESS) {
+      return rc;
+  }
+
+  ZOO_LOG_WARN(("Waiting for the cache server list..."));
+
+  pthread_mutex_lock(&lock_arcus);
+  arcus= static_cast<arcus_st *>(memcached_get_server_manager(mc));
+  if (arcus && arcus->zk.is_initializing) {
+    struct timeval now;
+    struct timespec ts;
+
+    /* Wait for the cache list (timed out after 5 sec.) */
+    gettimeofday(&now, NULL);
+    ts.tv_sec= now.tv_sec + (ARCUS_ZK_SESSION_TIMEOUT_IN_MS / 1000 / 3);
+    ts.tv_nsec= now.tv_usec * 1000;
+
+    if (pthread_cond_timedwait(&cond_arcus, &lock_arcus, &ts)) {
+      ZOO_LOG_ERROR(("pthread_cond_timedwait failed. %s(%d)", strerror(errno), errno));
+      rc= ARCUS_ERROR;
+    }
+  }
+  pthread_mutex_unlock(&lock_arcus);
+
+  if (rc == ARCUS_SUCCESS) {
+    ZOO_LOG_WARN(("Done"));
+  }
+  return rc;
+}
+
+static inline void do_arcus_zk_manager_stop(memcached_st *mc)
+{
+  arcus_st *arcus;
+
+  pthread_mutex_lock(&lock_arcus);
+  arcus= static_cast<arcus_st *>(memcached_get_server_manager(mc));
+  pthread_mutex_unlock(&lock_arcus);
+  if (arcus && arcus->zk_mgr.running) {
+    ZOO_LOG_WARN(("Wait for the arcus zookeeper manager to stop"));
+    arcus->zk_mgr.reqstop= true;
+    do_arcus_zk_manager_wakeup(mc, false);
+
+    /* Do not call zookeeper_close (do_arcus_zk_close) and zoo_wget_children at
+     * the same time.  Otherwise, this thread (main thread) and the watcher
+     * thread (zoo_wget_children) may hang forever until the user manually
+     * kills the process.  The root cause is within the zookeeper library.
+     * Its handling of concurrent API calls like zoo_wget_children and
+     * zookeeper_close still has holes...
+     */
+    while (arcus->zk_mgr.running) {
+      usleep(10000); // 10ms wait
+    }
+  }
+}
+
+static void do_arcus_zk_manager_wakeup(memcached_st *mc, bool locked)
+{
+  arcus_st *arcus= static_cast<arcus_st *>(memcached_get_server_manager(mc));
+  if (not arcus) {
+    return;
+  }
+
+  if (!locked)
+    pthread_mutex_lock(&arcus->zk_mgr.lock);
+  if (!arcus->zk_mgr.notification) {
+    arcus->zk_mgr.notification= true;
+    pthread_cond_signal(&arcus->zk_mgr.cond);
+  }
+  if (!locked)
+    pthread_mutex_unlock(&arcus->zk_mgr.lock);
+}
+
+static void *arcus_zk_manager_thread_main(void *arg)
+{
+  memcached_st *manager_mc= (memcached_st*)arg;
+  arcus_st *arcus= static_cast<arcus_st *>(memcached_get_server_manager(manager_mc));
+  struct arcus_zk_request_st zkreq;
+  struct timeval  tv;
+  struct timespec ts;
+  size_t elapsed_time = 0; /* unit : millisecond */
+  bool zk_retry= false;
+  bool reconnect_retry= false;
+
+  ZOO_LOG_WARN(("Running arcus zookeeper manager thread"));
+  arcus->zk_mgr.running= true;
+  while (!arcus->zk_mgr.reqstop)
+  {
+    pthread_mutex_lock(&arcus->zk_mgr.lock);
+    while (!arcus->zk_mgr.notification && !arcus->zk_mgr.reqstop) {
+      /* Poll if requested.
+       * Otherwise, wait till the ZK watcher wakes us up.
+       */
+      if (zk_retry || reconnect_retry) {
+        gettimeofday(&tv, NULL);
+        tv.tv_usec += 100000; /* Wake up in 100 ms. Magic number. */
+        if (tv.tv_usec >= 1000000) {
+          tv.tv_sec += 1;
+          tv.tv_usec -= 1000000;
+        }
+        ts.tv_sec= tv.tv_sec;
+        ts.tv_nsec= tv.tv_usec * 1000;
+        pthread_cond_timedwait(&arcus->zk_mgr.cond, &arcus->zk_mgr.lock, &ts);
+        if (zk_retry) zk_retry= false;
+        if (reconnect_retry) elapsed_time += 100; /* 100 ms */
+        break;
+      }
+      pthread_cond_wait(&arcus->zk_mgr.cond, &arcus->zk_mgr.lock);
+    }
+    arcus->zk_mgr.notification= false;
+    zkreq = arcus->zk_mgr.request;
+    memset(&arcus->zk_mgr.request, 0, sizeof(struct arcus_zk_request_st));
+    pthread_mutex_unlock(&arcus->zk_mgr.lock);
+
+    if (arcus->zk_mgr.reqstop)
+      break;
+
+    /* Process request by order */
+    /* 1. reconnect process.
+     * 2. update cache list
+     */
+    if (zkreq.reconnect_process || reconnect_retry) {
+      if (reconnect_retry) {
+        if (elapsed_time < ARCUS_ZK_RETRY_RECONNECT_DELAY_IN_MS) {
+          continue;
+        }
+        reconnect_retry= false;
+        elapsed_time= 0;
+      }
+      if (do_arcus_zk_process_reconnect(manager_mc, &zk_retry) < 0) {
+        reconnect_retry= true;
+      }
+    } else {
+      if (zkreq.update_cache_list) {
+        do_arcus_zk_watch_and_update_cachelist(manager_mc, &zk_retry);
+      }
+    }
+  }
+  ZOO_LOG_WARN(("Stop arcus zookeeper manager thread"));
+  arcus->zk_mgr.running= false;
+
+  return NULL;
+}
+#endif
 
 /* flock is modified from Apache Portable Runtime */
 /* Licensed to the Apache Software Foundation (ASF) under one or more

--- a/libmemcached/arcus.h.in
+++ b/libmemcached/arcus.h.in
@@ -24,6 +24,8 @@
 #include <libmemcached/memcached.h>
 #include <libmemcached/memcached_util.h>
 
+#define ARCUS_ZK_MANAGER 1
+
 /**
  * Function return code.  The names are self descriptive.
  * In case of an error (non-success), most functions leave log messages.
@@ -33,6 +35,9 @@ typedef enum arcus_return_t
 {
   ARCUS_SUCCESS,
   ARCUS_ERROR,
+#ifdef ARCUS_ZK_MANAGER
+  ARCUS_AUTH_FAILED,
+#endif
   ARCUS_ALREADY_INITIATED
 } arcus_return_t;
 


### PR DESCRIPTION
현재 zookeeper event 처리를 zookeeper client의
completion thread가 담당하는 동작으로 인해 SESSION_EXPIRED 처리 도중
에러가 발생하면 zookeeper client만 종료되어 event를 받지 못한다는 문제가 있는 상태입니다.

이러한 문제를 해결하기 위해 zookeeper event 처리를 담당하는 별도의 daemon thread를 두고
daemon thread가 모든 zookeeper event 처리를 담당하도록 수정하기 위한 PR 입니다.

@minkikim89 @hjyun328 리뷰 요청 드립니다.