### PR TITLE
CLEANUP: don't occur KEY_TOO_BIG error in response.

### DIFF
--- a/libmemcached/response.cc
+++ b/libmemcached/response.cc
@@ -2381,7 +2381,6 @@ static memcached_return_t memcached_read_one_coll_smget_response(memcached_serve
            rc == MEMCACHED_PROTOCOL_ERROR or
            rc == MEMCACHED_CLIENT_ERROR or
            rc == MEMCACHED_PARTIAL_READ or
-           rc == MEMCACHED_KEY_TOO_BIG or
            rc == MEMCACHED_MEMORY_ALLOCATION_FAILURE )
     memcached_io_reset(ptr);
 


### PR DESCRIPTION
KEY_TOO_BIG 에러는 response 에서 발생하지 않는 에러여서 제거하였습니다.
history를 보니 initial commit 때부터 있었는데 실수로 들어간 것으로 보입니다.