### PR TITLE
CLEANUP: remove calling memcached_io_reset in duplicate.

### DIFF
--- a/libmemcached/purge.cc
+++ b/libmemcached/purge.cc
@@ -57,12 +57,11 @@ memcached_return_t memcached_purge(memcached_server_write_instance_st ptr)
        * Purge doesn't care for what kind of command results that is received.
        * The only kind of errors I care about if is I'm out of sync with the
        * protocol or have problems reading data from the network..
-     */
-      if (rc== MEMCACHED_PROTOCOL_ERROR || rc == MEMCACHED_UNKNOWN_READ_FAILURE)
+       */
+      if (rc == MEMCACHED_PROTOCOL_ERROR || rc == MEMCACHED_UNKNOWN_READ_FAILURE)
       {
         WATCHPOINT_ERROR(rc);
         ret= rc;
-        memcached_io_reset(ptr);
         memcached_set_error(*ptr, rc, MEMCACHED_AT);
       }
 

--- a/libmemcached/stats.cc
+++ b/libmemcached/stats.cc
@@ -378,7 +378,6 @@ static memcached_return_t binary_stats_fetch(memcached_stat_st *memc_stat,
 
     unlikely (rc != MEMCACHED_SUCCESS)
     {
-      memcached_io_reset(instance);
       return rc;
     }
 
@@ -403,8 +402,8 @@ static memcached_return_t binary_stats_fetch(memcached_stat_st *memc_stat,
   } while (1);
 
   /* shit... memcached_response will decrement the counter, so I need to
-   ** reset it.. todo: look at this and try to find a better solution.
- */
+   * reset it.. todo: look at this and try to find a better solution.
+   */
   instance->cursor_active= 0;
 
   return MEMCACHED_SUCCESS;

--- a/libmemcached/version.cc
+++ b/libmemcached/version.cc
@@ -204,7 +204,6 @@ static inline memcached_return_t memcached_version_binary(memcached_st *ptr)
       rrc= memcached_response(instance, buffer, sizeof(buffer), NULL);
       if (rrc != MEMCACHED_SUCCESS) 
       {
-        memcached_io_reset(instance);
         rc= MEMCACHED_SOME_ERRORS;
         continue;
       }


### PR DESCRIPTION
response 쪽에서 에러 발생 시 io_reset을 수행하는데도 불구하고 io_reset을 중복으로 호출하는 부분 제거하였습니다.
//response 쪽에서 에러 발생 시 io_reset을 수행
```
 memcached_return_t memcached_read_one_response(memcached_server_write_instance_st ptr,
                                                char *buffer, size_t buffer_length,
                                                memcached_result_st *result)
 {
...
   if (ptr->root->flags.binary_protocol)
   {
     rc= binary_read_one_response(ptr, buffer, buffer_length, result);
   }
   else
   {
     rc= textual_read_one_response(ptr, buffer, buffer_length, result);
   }

   unlikely(rc == MEMCACHED_UNKNOWN_READ_FAILURE or
            rc == MEMCACHED_PROTOCOL_ERROR or
            rc == MEMCACHED_CLIENT_ERROR or
            rc == MEMCACHED_PARTIAL_READ or
            rc == MEMCACHED_MEMORY_ALLOCATION_FAILURE)
     memcached_io_reset(ptr);

   return rc;
 }
```