### PR TITLE
FEATURE: immediate reconnect about UNKNOWN_READ_FAILURE

### DIFF
--- a/libmemcached/response.cc
+++ b/libmemcached/response.cc
@@ -680,7 +680,8 @@ memcached_return_t memcached_read_one_response(memcached_server_write_instance_s
     rc= textual_read_one_response(ptr, buffer, buffer_length, result);
   }
 #ifdef IMMEDIATELY_RECONNECT
-  if (rc == MEMCACHED_PROTOCOL_ERROR or
+  if (rc == MEMCACHED_UNKNOWN_READ_FAILURE or
+      rc == MEMCACHED_PROTOCOL_ERROR or
       rc == MEMCACHED_CLIENT_ERROR or
       rc == MEMCACHED_SERVER_ERROR or
       rc == MEMCACHED_PARTIAL_READ)
@@ -1789,7 +1790,8 @@ static memcached_return_t memcached_read_one_coll_response(memcached_server_writ
     rc= textual_read_one_coll_response(ptr, buffer, buffer_length, result);
   }
 #ifdef IMMEDIATELY_RECONNECT
-  if (rc == MEMCACHED_PROTOCOL_ERROR ||
+  if (rc == MEMCACHED_UNKNOWN_READ_FAILURE ||
+      rc == MEMCACHED_PROTOCOL_ERROR ||
       rc == MEMCACHED_CLIENT_ERROR ||
       rc == MEMCACHED_SERVER_ERROR ||
       rc == MEMCACHED_PARTIAL_READ)
@@ -2501,7 +2503,8 @@ static memcached_return_t memcached_read_one_coll_smget_response(memcached_serve
     rc= textual_read_one_coll_smget_response(ptr, buffer, buffer_length, result);
   }
 #ifdef IMMEDIATELY_RECONNECT
-  if (rc == MEMCACHED_PROTOCOL_ERROR or
+  if (rc == MEMCACHED_UNKNOWN_READ_FAILURE or
+      rc == MEMCACHED_PROTOCOL_ERROR or
       rc == MEMCACHED_CLIENT_ERROR or
       rc == MEMCACHED_SERVER_ERROR or
       rc == MEMCACHED_PARTIAL_READ)


### PR DESCRIPTION
 immediate reconnect about UNKNOWN_READ_FAILURE

MEMCACHED_UNKNOWN_READ_FAILURE 에러가 발생하는 경우는
- client 가 기대하는 server response가 오지 않은 경우 : protocol 차이일 뿐이므로 immediate reconnect
- socket error(recv < 0)의 응용 오류 코드. 에를 들어 recv() 에서 EXXX 에러 발생한 경우 이를 그대로 응용에게 전달하지 않고, MEMCACHED_UNKNOWN_READ_FAILURE로 전달. 이 경우에 io 모듈단에서 delayed reconnect 하도록 되어 있음.