### PR TITLE
CLEANUP: refactored error codes check

### DIFF
--- a/libmemcached/response.cc
+++ b/libmemcached/response.cc
@@ -679,32 +679,17 @@ memcached_return_t memcached_read_one_response(memcached_server_write_instance_s
   {
     rc= textual_read_one_response(ptr, buffer, buffer_length, result);
   }
-#ifdef IMMEDIATELY_RECONNECT
-  if (rc == MEMCACHED_UNKNOWN_READ_FAILURE or
-      rc == MEMCACHED_PROTOCOL_ERROR or
-      rc == MEMCACHED_CLIENT_ERROR or
-      rc == MEMCACHED_SERVER_ERROR or
-      rc == MEMCACHED_PARTIAL_READ)
-  {
-    memcached_server_set_immediate_reconnect(ptr);
-  }
-#endif
 
+  unlikely(memcached_fatal(rc))
+  {
 #ifdef IMMEDIATELY_RECONNECT
-  unlikely(rc == MEMCACHED_UNKNOWN_READ_FAILURE or
-           rc == MEMCACHED_PROTOCOL_ERROR or
-           rc == MEMCACHED_CLIENT_ERROR or
-           rc == MEMCACHED_SERVER_ERROR or
-           rc == MEMCACHED_PARTIAL_READ or
-           rc == MEMCACHED_MEMORY_ALLOCATION_FAILURE)
-#else
-  unlikely(rc == MEMCACHED_UNKNOWN_READ_FAILURE or
-           rc == MEMCACHED_PROTOCOL_ERROR or
-           rc == MEMCACHED_CLIENT_ERROR or
-           rc == MEMCACHED_PARTIAL_READ or
-           rc == MEMCACHED_MEMORY_ALLOCATION_FAILURE)
+    if (memcached_immediate_reconnect(rc))
+    {
+      memcached_server_set_immediate_reconnect(ptr);
+    }
 #endif
     memcached_io_reset(ptr);
+  }
 
   return rc;
 }
@@ -1786,32 +1771,17 @@ static memcached_return_t memcached_read_one_coll_response(memcached_server_writ
   {
     rc= textual_read_one_coll_response(ptr, buffer, buffer_length, result);
   }
-#ifdef IMMEDIATELY_RECONNECT
-  if (rc == MEMCACHED_UNKNOWN_READ_FAILURE ||
-      rc == MEMCACHED_PROTOCOL_ERROR ||
-      rc == MEMCACHED_CLIENT_ERROR ||
-      rc == MEMCACHED_SERVER_ERROR ||
-      rc == MEMCACHED_PARTIAL_READ)
-  {
-    memcached_server_set_immediate_reconnect(ptr);
-  }
-#endif
 
+  unlikely(memcached_fatal(rc))
+  {
 #ifdef IMMEDIATELY_RECONNECT
-  unlikely(rc == MEMCACHED_UNKNOWN_READ_FAILURE ||
-           rc == MEMCACHED_PROTOCOL_ERROR ||
-           rc == MEMCACHED_CLIENT_ERROR ||
-           rc == MEMCACHED_SERVER_ERROR ||
-           rc == MEMCACHED_PARTIAL_READ ||
-           rc == MEMCACHED_MEMORY_ALLOCATION_FAILURE)
-#else
-  unlikely(rc == MEMCACHED_UNKNOWN_READ_FAILURE ||
-           rc == MEMCACHED_PROTOCOL_ERROR ||
-           rc == MEMCACHED_CLIENT_ERROR ||
-           rc == MEMCACHED_PARTIAL_READ ||
-           rc == MEMCACHED_MEMORY_ALLOCATION_FAILURE)
+    if (memcached_immediate_reconnect(rc))
+    {
+      memcached_server_set_immediate_reconnect(ptr);
+    }
 #endif
     memcached_io_reset(ptr);
+  }
 
   return rc;
 }
@@ -2499,32 +2469,17 @@ static memcached_return_t memcached_read_one_coll_smget_response(memcached_serve
   {
     rc= textual_read_one_coll_smget_response(ptr, buffer, buffer_length, result);
   }
-#ifdef IMMEDIATELY_RECONNECT
-  if (rc == MEMCACHED_UNKNOWN_READ_FAILURE or
-      rc == MEMCACHED_PROTOCOL_ERROR or
-      rc == MEMCACHED_CLIENT_ERROR or
-      rc == MEMCACHED_SERVER_ERROR or
-      rc == MEMCACHED_PARTIAL_READ)
-  {
-    memcached_server_set_immediate_reconnect(ptr);
-  }
-#endif
 
+  unlikely(memcached_fatal(rc))
+  {
 #ifdef IMMEDIATELY_RECONNECT
-  unlikely(rc == MEMCACHED_UNKNOWN_READ_FAILURE or
-           rc == MEMCACHED_PROTOCOL_ERROR or
-           rc == MEMCACHED_CLIENT_ERROR or
-           rc == MEMCACHED_SERVER_ERROR or
-           rc == MEMCACHED_PARTIAL_READ or
-           rc == MEMCACHED_MEMORY_ALLOCATION_FAILURE )
-#else
-  unlikely(rc == MEMCACHED_UNKNOWN_READ_FAILURE or
-           rc == MEMCACHED_PROTOCOL_ERROR or
-           rc == MEMCACHED_CLIENT_ERROR or
-           rc == MEMCACHED_PARTIAL_READ or
-           rc == MEMCACHED_MEMORY_ALLOCATION_FAILURE )
+    if (memcached_immediate_reconnect(rc))
+    {
+      memcached_server_set_immediate_reconnect(ptr);
+    }
 #endif
     memcached_io_reset(ptr);
+  }
 
   return rc;
 }

--- a/libmemcached/return.h
+++ b/libmemcached/return.h
@@ -174,13 +174,25 @@ static inline bool memcached_failed(memcached_return_t rc)
 
 static inline bool memcached_fatal(memcached_return_t rc)
 {
-  return (rc != MEMCACHED_SUCCESS && 
-          rc != MEMCACHED_END && 
-          rc != MEMCACHED_STORED && 
-          rc != MEMCACHED_STAT && 
-          rc != MEMCACHED_DELETED &&
-          rc != MEMCACHED_BUFFERED &&
-          rc != MEMCACHED_VALUE);
+  return (rc == MEMCACHED_UNKNOWN_READ_FAILURE ||
+          rc == MEMCACHED_PROTOCOL_ERROR ||
+          rc == MEMCACHED_CLIENT_ERROR ||
+#ifdef IMMEDIATELY_RECONNECT
+          rc == MEMCACHED_SERVER_ERROR ||
+#endif
+          rc == MEMCACHED_PARTIAL_READ ||
+          rc == MEMCACHED_MEMORY_ALLOCATION_FAILURE);
 }
+
+#ifdef IMMEDIATELY_RECONNECT
+static inline bool memcached_immediate_reconnect(memcached_return_t rc)
+{
+  return (rc == MEMCACHED_UNKNOWN_READ_FAILURE ||
+          rc == MEMCACHED_PROTOCOL_ERROR ||
+          rc == MEMCACHED_CLIENT_ERROR ||
+          rc == MEMCACHED_SERVER_ERROR ||
+          rc == MEMCACHED_PARTIAL_READ);
+}
+#endif
 
 #define memcached_continue(__memcached_return_t) ((__memcached_return_t) == MEMCACHED_IN_PROGRESS)


### PR DESCRIPTION
에러 코드 체크를 함수화하였습니다.

memcached_immediate_reconnect(rc) : immediate reconnect 가 필요한 에러코드들
memcached_fatal(rc) : io_reset이 필요한 에러코드들

참고로, 기존 memcached_fatal 함수를 사용하고 있는 곳은 없었습니다.