### PR TITLE
FIX: handled TYPE_MISMATCH in kv response

### DIFF
--- a/libmemcached/response.cc
+++ b/libmemcached/response.cc
@@ -340,6 +340,13 @@ static memcached_return_t textual_read_one_response(memcached_server_write_insta
     }
     break;
 
+  case 'T': /* TYPE MISMATCH */
+    if (memcmp(buffer, "TYPE_MISMATCH", 13) == 0)
+    {
+      return MEMCACHED_TYPE_MISMATCH;
+    }
+    break;
+
   case 'C': /* CLIENT ERROR */
     if (memcmp(buffer, "CLIENT_ERROR", 12) == 0)
     {


### PR DESCRIPTION
collection item 과 동일한 key 로 kv item 저장 요청하면,
TYPE_MISMATCH 가 발생합니다.
```
set c-m001:testkey-17 0 0 3
qwe
TYPE_MISMATCH
```
kv response 모듈에서 TYPE MISMATCH 핸들링이 안되어 있어서
UNKNOWN_READ_FAILURE를 반환 & 이로 인해 connection reconnect하게 되는 버그를 수정하였습니다.