### PR TITLE
DOC: decrease header level to improve document system's UI

### DIFF
--- a/docs/01-arcus-cloud-basics.md
+++ b/docs/01-arcus-cloud-basics.md
@@ -1,4 +1,4 @@
-## Arcus Cloud 기본 사항
+# Arcus Cloud 기본 사항
 
 Arcus는 확장된 key-value 데이터 모델을 제공한다.
 하나의 key는 하나의 데이터만을 가지는 simple key-value 유형 외에도
@@ -23,7 +23,7 @@ Arcus cache server의 key-value 모델은 아래의 기본 제약 사항을 가�
 - [Expiration, Eviction, and Sticky Item](01-arcus-cloud-basics.md#expiration-eviction-and-sticky-item)
 
 
-### 서비스코드
+## 서비스코드
 
 서비스코드(service code)는 Arcus에서 cache cloud를 구분하는 코드이다. 
 Arcus cache cloud 서비스를 응용들에게 제공한다는 의미에서 "서비스코드"라는 용어를 사용하게 되었다.
@@ -33,7 +33,7 @@ Arcus java client 객체는 하나의 Arcus 서비스코드만을 가지며, 하
 해당 응용이 둘 이상의 Arcus cache cloud에 접근해야 한다면,
 각 Arcus cache cloud의 서비스코드를 가지는 Arcus java client 객체를 따로 생성하여 사용하여야 한다.
 
-### Arcus Admin
+## Arcus Admin
 
 Arcus admin은 ZooKeeper를 이용하여 각 서비스 코드에 해당하는 Arcus cache cloud를 관리한다.
 특정 서비스 코드에 대한 cache server list를 관리하며,
@@ -42,7 +42,7 @@ cache server 추가 및 삭제에 대해 cache server list를 최신 상태로 �
 Arcus admin은 highly available하여야 하므로, 
 여러 ZooKeeper 서버들을 하나의 ZeeKeeper ensemble로 구성하여 사용한다.
 
-### Cache Key
+## Cache Key
 
 Cache key는 Arcus cache에 저장하는 cache item을 유일하게 식별한다. Cache key 형식은 아래와 같다.
 
@@ -62,7 +62,7 @@ Prefix와 subkey는 아래의 명명 규칙을 가진다.
   이 중에 하이픈(-)은 prefix 명의 첫번째 문자로 올 수 없다.
 - Subkey는 공백을 포함할 수 없으며, 기본적으로 alphanumeric만을 사용하길 권장한다.
 
-### Cache Item
+## Cache Item
 
 Arcus cache는 simple key-value item 외에 다양한 collection item 유형을 가진다.
 
@@ -73,7 +73,7 @@ Arcus cache는 simple key-value item 외에 다양한 collection item 유형을 
   - map item - \<mkey, value\>쌍으로 구성된 데이터 집합을 가지는 item
   - b+tree item - b+tree key 기반으로 정렬된 데이터 집합을 가지는 item
 
-### Expiration, Eviction, and Sticky Item
+## Expiration, Eviction, and Sticky Item
 
 각 cache item은 expiration time 속성을 가진다.
 이 값의 설정으로 자동 expiration을 지정하거나 expire되지 않도록 지정할 수 있다.

--- a/docs/02-arcus-c-client.md
+++ b/docs/02-arcus-c-client.md
@@ -1,4 +1,4 @@
-## Arcus C Client
+# Arcus C Client
 
 Arcus client는 Arcus admin과 Arcus cache server군 들과의 연결을 유지하며 client로 들어온 명령을 처리하여 그 결과를 반환한다
 
@@ -18,7 +18,7 @@ Arcus cache server에서 제공하는 failover 기능과 collection 기능 등�
 - [서버 모델에 따른 초기화](02-arcus-c-client.md#%EC%84%9C%EB%B2%84-%EB%AA%A8%EB%8D%B8%EC%97%90-%EB%94%B0%EB%A5%B8-%EC%B4%88%EA%B8%B0%ED%99%94)
 - [Client 설정과 사용](02-arcus-c-client.md#client-%EC%84%A4%EC%A0%95%EA%B3%BC-%EC%82%AC%EC%9A%A9)
 
-### 서버 모델에 따른 초기화
+## 서버 모델에 따른 초기화
 
 서버 모델에 따른 초기화 메소드는 아래와 같다.
 
@@ -60,7 +60,7 @@ consistent hashing을 위한 초기화 작업을 수행한다.
 * ensemble_list : Arcus admin의 주소.
 * svc_code : 부여 받은 서비스코드.
 
-#### Multi-Threaded Example
+### Multi-Threaded Example
 
 많은 서비스에서 사용되는 Multi-threaded 서버에서는 다음과 같이 초기화 할 수 있다.
 
@@ -102,7 +102,7 @@ int main(int argc, char** argv)
 memcached_st 구조체는 Arcus cache server 연결 정보 및 각종 설정이 포함된 기본 자료구조로서 모든 캐시 요청 API에서 사용된다.
 완전한 예제는 소스 패키지에 포함된 arcus/multi_threaded.c를 참고하기 바란다.
 
-#### Multi-Process Example
+### Multi-Process Example
 
 일부 서비스에서는 Apache와 비슷한 프로세스 prefork 모델을 이용하기도 한다.
 이 같은 멀티 프로세스 방식의 서버에서 Arcus C client를 초기화 하는 방법은 다음과 같다.
@@ -244,9 +244,9 @@ RELEASE:
 자식 프로세스에서는 부모의 memcached_st 구조체를 이용하여 Arcus admin과의 연결 없이 캐시 서버 리스트를 얻어 온다.
 특히, 각 자식 프로세스가 내부적으로 멀티 쓰레드로 동작하는 상황에서 pool을 사용하는 방법도 확인할 수 있다.
 
-### Client 설정과 사용
+## Client 설정과 사용
 
-#### 로그 남기기
+### 로그 남기기
 
 Arcus C client는 Arcus admin과의 연결 상태 및 Arcus cache server 리스트의 변경 사항에 대해 로그를 남긴다.
 로그는 ZooKeeper client에 내장된 로깅 API를 사용하고 있으며 기본적으로 표준 에러(stderr )로 출력된다.
@@ -298,7 +298,7 @@ if (rc != MEMCACHED_SUCCESS) {
 }
 ```
 
-#### 캐시 명령에 대한 OPERATION TIMEOUT 지정
+### 캐시 명령에 대한 OPERATION TIMEOUT 지정
 
 캐시 명령을 보내고 응답을 받기까지의 timeout 시간을 지정할 수 있다.
 
@@ -309,7 +309,7 @@ memcached_behavior_set(mc, MEMCACHED_BEHAVIOR_POLL_TIMEOUT, (uint64_t)timeout);
 
 timeout 시간은 밀리초(ms) 단위이며, 기본 값은 MEMCACHED_DEFAULT_TIMEOUT (500ms) 이다.
 
-#### 캐시 노드에 대한 CONNECTION TIMEOUT 지정
+### 캐시 노드에 대한 CONNECTION TIMEOUT 지정
 
 캐시연결이 끊어진 후 재연결 요청 시의 timeout 시간을 지정할 수 있다.
 
@@ -337,7 +337,7 @@ ARCUS의 admin인 ZooKeeper에 의해 failed 캐시 노드로 감지되어 cache
 그리고, 정상적으로 연결되지 않은 캐시 노드로의 요청에 대해서는
 MEMCACHED_SERVER_TEMPORARILY_DISABLED (“SERVER HAS FAILED AND IS DISABLED UNTIL TIMED RETRY”) 오류가 발생한다.
  
-#### 캐시 API의 응답코드 확인
+### 캐시 API의 응답코드 확인
 
 캐시 명령을 실행한 후에 캐시 서버로부터 받은 응답 코드를 확인할 수 있다.
 이 응답코드는 명령의 실행 결과에 대한 추가 정보를 제공한다.

--- a/docs/03-key-value-API.md
+++ b/docs/03-key-value-API.md
@@ -1,4 +1,4 @@
-## Key-Value Item
+# Key-Value Item
 
 Key-value item은 하나의 key에 대해 하나의 value만을 저장하는 item이다.
 
@@ -13,7 +13,7 @@ Key-value item에 대해 수행 가능한 연산들은 아래와 같다.
 - [Key-Value Item 값의 증감](03-key-value-API.md#key-value-item-%EA%B0%92%EC%9D%98-%EC%A6%9D%EA%B0%90)
 - [Key-Value Item 삭제](03-key-value-API.md#key-value-item-%EC%82%AD%EC%A0%9C)
 
-### Key-Value Item 저장
+## Key-Value Item 저장
 
 key-value item을 저장하는 API로 set, add, replace, prepend/append가 있다.
 
@@ -48,7 +48,7 @@ Key-value item 저장 연산에서 주요 파라미터는 아래와 같다.
   - -1: key를 sticky item으로 만든다. Sticky item은 expire 되지 않으며 LRU에 의해 삭제되지도 않는다.
 - flags: value와는 별도로 저장할 수 있는 값으로서 Java client 등에서 내부적으로 사용하는 경우가 많으므로 사용하지 않기를 권한다.
 
-### Key-Value Item 조회
+## Key-Value Item 조회
 
 Key-value item을 조회하는 API는 두 가지가 있다.
 
@@ -73,7 +73,7 @@ keys 인자는 key pointer array이고, key_length 인자는 key length array이
 error 값이 MEMCACHED_END가 될 때까지 실행하면 되며, 그 이후에 fetch를 수행하면 MEMCACHED_NOTFOUND가 반환된다.
 
 
-### Key-Value Item 값의 증감
+## Key-Value Item 값의 증감
 
 Key-value item에서 숫자형 value 값에 대해서만 아래 증감 연산을 수행할 수 있다.
 
@@ -100,7 +100,7 @@ memcached_return_t memcached_decrement_with_initial(memcached_st *ptr, const cha
 주어진 key가 존재하지 않으면, initial 값으로 저장한다.
 
 
-### Key-Value Item 삭제
+## Key-Value Item 삭제
 
 ```C
 memcached_return_t memcached_delete(memcached_st *ptr, const char *key, size_t key_length, time_t expiration);

--- a/docs/04-list-API.md
+++ b/docs/04-list-API.md
@@ -1,4 +1,4 @@
-## List Item
+# List Item
 
 List item은 하나의 key에 대해 여러 value들을 double linked list 구조로 유지한다.
 
@@ -20,7 +20,7 @@ List item에 대해 수행 가능한 기본 연산들은 아래와 같다.
 - [List Element 일괄 삽입](04-list-API.md#list-element-%EC%9D%BC%EA%B4%84-%EC%82%BD%EC%9E%85)
 
 
-### List Item 생성
+## List Item 생성
 
 
 새로운 empty list item을 생성한다.
@@ -103,7 +103,7 @@ void arcus_list_item_create(memcached_st *memc)
 }
 ```
 
-### List Element 삽입
+## List Element 삽입
 
 
 List에 하나의 element를 삽입하는 함수이다.
@@ -168,7 +168,7 @@ void arcus_list_element_insert(memcached_st *memc)
 }
 ```
 
-### List Element 삭제
+## List Element 삭제
 
 List element를 삭제하는 함수는 두 가지가 있다.
 
@@ -240,7 +240,7 @@ void arcus_list_element_delete(memcached_st *memc)
 }
 ```
 
-### List Element 조회
+## List Element 조회
 
 List element를 조회하는 함수는 두 가지가 있다.
 
@@ -351,7 +351,7 @@ void arcus_list_element_get(memcached_st *memc)
 }
 ```
 
-### List Element 일괄 삽입
+## List Element 일괄 삽입
 
 List에 여러 element를 한번에 삽입하는 함수는 두 가지가 있다.
 

--- a/docs/05-set-API.md
+++ b/docs/05-set-API.md
@@ -1,4 +1,4 @@
-## Set Item
+# Set Item
 
 Set item은 하나의 key에 대해 unique value의 집합을 저장한다. 주로 membership checking에 유용하게 사용할 수 있다.
 
@@ -21,7 +21,7 @@ Set item에 수행 가능한 기본 연산들은 다음과 같다.
 - [Set Element 일괄 존재 여부 확인](05-set-API.md#set-element-일괄-존재-여부-확인)
 
 
-### Set Item 생성
+## Set Item 생성
 
 새로운 empty set item을 생성한다.
 
@@ -90,7 +90,7 @@ void arcus_set_item_create(memcached_st *memc)
 }
 ```
 
-### Set Element 삽입
+## Set Element 삽입
 
 Set에 하나의 element를 삽입하는 함수이다.
 
@@ -156,7 +156,7 @@ void arcus_set_element_insert(memcached_st *memc)
 }
 ```
 
-### Set Element 삭제
+## Set Element 삭제
 
 Set에서 주어진 value를 가진 element를 삭제하는 함수이다.
 
@@ -219,7 +219,7 @@ void arcus_set_element_delete(memcached_st *memc)
 }
 ```
 
-### Set Element 존재 여부 확인
+## Set Element 존재 여부 확인
 
 Set에서 주어진 value를 가진 element의 존재 여부를 확인한다.
 
@@ -271,7 +271,7 @@ void arcus_set_element_exist(memcached_st *memc)
 }
 ```
 
-### Set Element 조회
+## Set Element 조회
 
 Set element를 조회하는 함수이다. 이 함수는 임의의 count 개 element를 조회한다.
 
@@ -361,7 +361,7 @@ void arcus_set_element_get(memcached_st *memc)
 }
 ```
 
-### Set Element 일괄 삽입
+## Set Element 일괄 삽입
 
 Set에 여러 element를 한번에 삽입하는 함수는 두 가지가 있다.
 
@@ -451,7 +451,7 @@ void arcus_set_element_piped_insert(memcached_st *memc)
 }
 ```
 
-### Set Element 일괄 존재 여부 확인
+## Set Element 일괄 존재 여부 확인
 
 Set에서 여러 element의 존재 여부를 한번에 확인하는 함수이다.
 

--- a/docs/06-map-API.md
+++ b/docs/06-map-API.md
@@ -1,4 +1,4 @@
-## Map Item
+# Map Item
 
 Map item은 하나의 key에 대해 hash 구조 기반으로 mkey & value 쌍을 data 집합으로 가진다.
 
@@ -20,7 +20,7 @@ Map item에 대해 수행 가능한 기본 연산들은 아래와 같다.
 - [Map Element 일괄 삽입](06-map-API.md#map-element-일괄-삽입)
 
 
-### Map Item 생성
+## Map Item 생성
 
 
 새로운 empty map item을 생성한다.
@@ -103,7 +103,7 @@ void arcus_map_item_create(memcached_st *memc)
 }
 ```
 
-### Map Element 삽입
+## Map Element 삽입
 
 
 Map에 하나의 element를 삽입하는 함수이다.
@@ -162,7 +162,7 @@ void arcus_map_element_insert(memcached_st *memc)
 }
 ```
 
-### Map Element 변경
+## Map Element 변경
 
 
 Map에 하나의 element를 변경하는 함수이다. 주어진 mkey를 가진 element의 value를 변경한다.
@@ -211,7 +211,7 @@ void arcus_map_element_update(memcached_st *memc)
 }
 ```
 
-### Map Element 삭제
+## Map Element 삭제
 
 Map element를 삭제하는 함수는 두 가지가 있다.
 
@@ -276,7 +276,7 @@ void arcus_map_element_delete(memcached_st *memc)
 }
 ```
 
-### Map Element 조회
+## Map Element 조회
 
 Map element를 조회하는 함수는 세 가지가 있다.
 
@@ -408,7 +408,7 @@ void arcus_map_element_get(memcached_st *memc)
 }
 ```
 
-### Map Element 일괄 삽입
+## Map Element 일괄 삽입
 
 Map에 여러 element를 한번에 삽입하는 함수는 두 가지가 있다.
 

--- a/docs/07-btree-API.md
+++ b/docs/07-btree-API.md
@@ -1,4 +1,4 @@
-## B+Tree Item
+# B+Tree Item
 
 B+tree item은 하나의 key에 대해 b+tree 구조 기반으로 b+tree key(bkey)로 정렬된 data의 집합을 가진다.
 
@@ -43,7 +43,7 @@ B+Tree내에서 element 순위(position)와 관련하여 아래 연산들을 제
 - [B+Tree 순위 기반의 Element 조회](07-btree-API.md#btree-순위-기반의-element-조회)
 - [B+Tree 순위와 Element 동시 조회](07-btree-API.md#btree-순위와-element-동시-조회)
 
-### BKey(B+Tree Key)와 EFlag(Element Flag)
+## BKey(B+Tree Key)와 EFlag(Element Flag)
 
 B+tree item에서 사용 가능한 bkey 데이터 타입은 아래 두 가지이다.
 
@@ -54,7 +54,7 @@ eflag는 현재 b+tree element에만 존재하는 필드이다.
 eflag 데이터 타입은 최대 31 크기의 byte array 타입만 가능하다.
 
 
-### Element Flag Filter 구조체
+## Element Flag Filter 구조체
 
 B+tree의 element flag에 대한 filtering을 지정하기 위해선, `eflag_filter` 구조체를 사용해야 한다.
 
@@ -113,7 +113,7 @@ memcached_return_t memcached_coll_eflag_filter_set_bitwise(memcached_coll_eflag_
 - foperand: eflag에서 bitwise 연산을 취할 operand를 지정한다.
 
 
-### Element Flag Update 구조체
+## Element Flag Update 구조체
 
 B+tree의 element flag를 변경하기 위해선 `eflag_update` 구조체를 사용해야 한다.
 
@@ -141,7 +141,7 @@ memcached_return_t memcached_coll_eflag_update_set_bitwise(memcached_coll_eflag_
   - MEMCACHED_COLL_BITWISE_XOR
 
 
-### B+Tree Query 구조체
+## B+Tree Query 구조체
 
 memcached_bop_query_st 구조체는 B+tree 조회 조건을 추상화하고 있으며 다양한 API에 사용될 수 있다.
 
@@ -171,7 +171,7 @@ memcached_return_t memcached_bop_ext_range_query_init (memcached_bop_query_st *p
 ```
 
 
-### B+Tree Item 생성
+## B+Tree Item 생성
 
 새로운 empty b+tree item을 생성한다.
 
@@ -241,7 +241,7 @@ void arcus_btree_item_create(memcached_st *memc)
 }
 ```
 
-### B+Tree Element 삽입
+## B+Tree Element 삽입
 
 B+Tree에 하나의 element를 삽입한다.
 전자는 8바이트 unsigned integer 타입의 bkey를, 후자는 최대 31 크기의 byte array 타입의 bkey를 사용한다.
@@ -321,7 +321,7 @@ void arcus_btree_element_insert(memcached_st *memc)
 하지만, C client에서는 이 기능을 아직 제공하지 않고 있다.
 
 
-### B+Tree Element Upsert
+## B+Tree Element Upsert
 
 B+Tree에 하나의 element를 upsert하는 함수들이다.
 Upsert 연산은 해당 element가 없으면 insert하고, 있으면 update하는 연산이다.
@@ -389,7 +389,7 @@ void arcus_btree_element_upsert(memcached_st *memc)
 }
 ```
 
-### B+Tree Element 변경
+## B+Tree Element 변경
 
 B+Tree에서 하나의 element를 변경하는 함수이다. Element의 eflag 그리고/또는 value를 변경한다.
 전자는 8바이트 unsigned integer 타입의 bkey를, 후자는 최대 31 크기의 byte array 타입의 bkey를 사용한다.
@@ -433,7 +433,7 @@ void arcus_btree_element_update(memcached_st *memc)
 }
 ```
 
-### B+Tree Element 삭제
+## B+Tree Element 삭제
 
 B+tree에서 element를 삭제하는 함수들은 두 유형이 있다.
 
@@ -527,7 +527,7 @@ void arcus_btree_element_delete(memcached_st *memc)
 }
 ```
 
-### B+Tree Element 값의 증감
+## B+Tree Element 값의 증감
 
 B+tree element의 값을 증가/감소시키는 함수는 아래와 같다. 
 Element의 값은 숫자형 값이어야 한다.
@@ -626,7 +626,7 @@ void arcus_btree_element_decr(memcached_st *memc)
 }
 ```
 
-### B+Tree Element 개수 확인
+## B+Tree Element 개수 확인
 
 B+tree element 개수를 확인하는 함수는 두 유형이 있다.
 
@@ -709,7 +709,7 @@ void arcus_btree_element_count(memcached_st *memc)
 }
 ```
 
-### B+Tree Element 조회
+## B+Tree Element 조회
 
 B+tree element를 조회하는 함수는 세 유형이 있다.
 
@@ -847,7 +847,7 @@ void arcus_btree_element_get(memcached_st *memc)
 }
 ```
 
-### B+Tree Element 일괄 삽입
+## B+Tree Element 일괄 삽입
 
 B+tree에 여러 element를 한번에 삽입하는 함수는 두 유형이 있다.
 
@@ -972,7 +972,7 @@ void arcus_btree_element_piped_insert(memcached_st *memc)
 }
 ```
 
-### B+tree Element 일괄 조회
+## B+tree Element 일괄 조회
 
 서로 다른 key로 분산되어 있는 b+tree들의 element들을 한 번의 요청으로 조회할 수 있는 기능이다.
 이 기능은 비동기(asynchronous) 방식으로 수행하며,
@@ -1080,7 +1080,7 @@ static void arcus_btree_element_mget(memcached_st *memc)
 }
 ```
 
-### B+tree Element Sort-Merge 조회
+## B+tree Element Sort-Merge 조회
 
 서로 다른 key로 분산되어 있는 b+Tree들의 element를 sort-merge 방식으로 조회하는 기능이다.
 이는 서로 다른 b+tree들이지만, 논리적으로 하나로 합쳐진 거대한 b+tree에 대해 element 조회 연산하는 것과
@@ -1311,7 +1311,7 @@ void arcus_btree_element_smget(memcached_st *memc)
 }
 ```
 
-### B+Tree Element 순위 조회
+## B+Tree Element 순위 조회
 
 B+Tree element 순위를 조회하는 함수는 아래와 같다.
 전자는 8바이트 unsigned integer 타입의 bkey를, 후자는 최대 31 크기의 byte array 타입의 bkey를 사용한다.
@@ -1380,7 +1380,7 @@ void arcus_btree_find_position(memcached_st *memc)
 }
 ```
 
-### B+Tree 순위 기반의 Element 조회
+## B+Tree 순위 기반의 Element 조회
 
 B+Tree에서 순위 범위로 element를 조회하는 함수는 아래와 같다.
 
@@ -1483,7 +1483,7 @@ void arcus_btree_get_by_position(memcached_st *memc)
 }
 ```
 
-### B+Tree 순위와 Element 동시 조회
+## B+Tree 순위와 Element 동시 조회
 
 B+Tree에서 주어진 bkey에 대한 순위를 조회하면서 그 bkey의 element를 포함하여
 앞뒤 양방향으로 각 N개의 elements를 함께 조회하는 함수는 아래와 같다.

--- a/docs/08-attribute-API.md
+++ b/docs/08-attribute-API.md
@@ -1,4 +1,4 @@
-## Item Attributes
+# Item Attributes
 
 Item attributes는 각 cache item의 메타데이터를 의미한다.
 Item attributes의 기본 설명은 [Arcus cache server의 item attributes 부분](https://github.com/naver/arcus-memcached/blob/master/doc/arcus-item-attribute.md)을 참고하길 바란다.
@@ -9,7 +9,7 @@ Item attributes를 변경하거나 조회하는 함수들을 설명한다.
 - [Attribute 조회](08-attribute-API.md#attribute-%EC%A1%B0%ED%9A%8C)
 
 
-### Attribute 변경
+## Attribute 변경
 
 주어진 key의 attributes를 변경하는 함수이다.
 
@@ -51,7 +51,7 @@ memcached_return_t memcached_coll_attrs_set_readable(memcached_coll_attrs_st *at
 - memcached_coll_attrs_set_readable : Attribute를 Readable 상태로 변경하도록 설정한다.
 
 
-### Attribute 조회
+## Attribute 조회
 
 주어진 key의 attributes를 조회하는 함수이다.
 

--- a/docs/09-other-API.md
+++ b/docs/09-other-API.md
@@ -1,11 +1,11 @@
-## Other API
+# Other API
 
 본 절에서는 아래의 나머지 API들을 설명한다.
 
 - [Flush](09-other-API.md#flush)
 
 
-### Flush
+## Flush
 
 Arcus는 cache server에 있는 모든 items 또는 특정 prefix의 items을 flush(or delete)하는 기능을 제공한다.
 전자의 함수는 모든 items을 flush하고 후자의 함수는 특정 prefix의 items을 flush한다.

--- a/docs/10-appendix.md
+++ b/docs/10-appendix.md
@@ -1,6 +1,6 @@
-## Appendix
+# Appendix
 
-### 문제 해결
+## 문제 해결
 
 32-bit 환경에서는 ./configure 옵션에 다음을 추가한다.
 
@@ -20,7 +20,7 @@ CC=gcc4 CXX=g++4
 $ for i in `ipcs -s | awk '/USERID/ {print $2}'`; do (ipcrm -s $i); done
 ```
 
-### 설치 확인 : 샘플 프로그램을 정적 링크하기
+## 설치 확인 : 샘플 프로그램을 정적 링크하기
 
 (sample applications can be found in $SRC/arcus)
 


### PR DESCRIPTION
문서시스템에서 최상단 제목을 H1(# 한 개)보다 낮게 설정할 경우, 다음과 같이 문서 제목이 사이드 바의 목차에 보이는 현상이 있습니다.

![image](https://user-images.githubusercontent.com/26251856/90496018-405b2500-e180-11ea-98c2-a6484248aded.png)
(문서의 최상단 제목인 Key-Value Item이 목차에 표시 됨)

이 현상을 해결하기 위해 제목의 레벨을 하나씩 올렸습니다. 

