### PR TITLE
DOC: fix syntax highlighting

### DIFF
--- a/docs/02-arcus-c-client.md
+++ b/docs/02-arcus-c-client.md
@@ -24,14 +24,14 @@ ARCUS cache server에서 제공하는 failover 기능과 collection 기능 등�
 
 - Single-Threaded
 
-  ```C
+  ```c
   arcus_return_t arcus_connect(memcached_st *mc, const char *ensemble_list, const char *svc_code)
   ```
   싱글 스레드 서버에서 ARCUS에 연결하기 위해 사용한다.
   
 - Multi-Threaded
  
-  ```C
+  ```c
   arcus_return_t arcus_pool_connect(memcached_pool_st *pool, const char *ensemble_list, const char *svc_code) 
   ```
 
@@ -39,7 +39,7 @@ ARCUS cache server에서 제공하는 failover 기능과 collection 기능 등�
   
 - Multi-Process
 
-  ```C
+  ```c
   arcus_return_t arcus_proxy_create(memcached_st *mc, const char *ensemble_list, const char *svc_code)
   arcus_return_t arcus_proxy_connect(memcached_st *mc, memcached_pool_st *pool, memcached_st *proxy)
   ```
@@ -64,7 +64,7 @@ consistent hashing을 위한 초기화 작업을 수행한다.
 
 많은 서비스에서 사용되는 Multi-threaded 서버에서는 다음과 같이 초기화 할 수 있다.
 
-```C
+```c
 #include "libmemcached/memcached.h"
 
 int main(int argc, char** argv)
@@ -107,7 +107,7 @@ memcached_st 구조체는 ARCUS cache server 연결 정보 및 각종 설정이 
 일부 서비스에서는 Apache와 비슷한 프로세스 prefork 모델을 이용하기도 한다.
 이 같은 멀티 프로세스 방식의 서버에서 ARCUS C client를 초기화 하는 방법은 다음과 같다.
 
-```C
+```c
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>

--- a/docs/03-key-value-API.md
+++ b/docs/03-key-value-API.md
@@ -52,14 +52,14 @@ Key-value item 저장 연산에서 주요 파라미터는 아래와 같다.
 
 Key-value item을 조회하는 API는 두 가지가 있다.
 
-```C
+```c
 char *             memcached_get(memcached_st *ptr, const char *key, size_t key_length, size_t *value_length,
                                  uint32_t *flags, memcached_return_t *error);
 ```
 
 주어진 key에 대한 value를 조회한다. 반환된 결과는 NULL이 아닌 경우 반드시 free 해주어야 한다.
 
-```C
+```c
 memcached_return_t memcached_mget(memcached_st *ptr, const char * const *keys,  const size_t *key_length,
                                   size_t number_of_keys);
 char *             memcached_fetch(memcached_st *ptr, char *key, size_t *key_length, size_t *value_length,
@@ -87,7 +87,7 @@ memcached_return_t memcached_decrement(memcached_st *ptr, const char *key, size_
 주어진 key의 value를 offset 만큼 증가/감소 시킨다.
 주어진 key가 존재하지 않으면, 오류를 낸다.
 
-```C
+```c
 memcached_return_t memcached_increment_with_initial(memcached_st *ptr, const char *key, size_t key_length, 
                                                     uint64_t offset, uint64_t initial, uint32_t flags,
                                                     time_t expiration, uint64_t *value)
@@ -102,7 +102,7 @@ memcached_return_t memcached_decrement_with_initial(memcached_st *ptr, const cha
 
 ## Key-Value Item 삭제
 
-```C
+```c
 memcached_return_t memcached_delete(memcached_st *ptr, const char *key, size_t key_length, time_t expiration);
 ```
 

--- a/docs/05-set-API.md
+++ b/docs/05-set-API.md
@@ -54,7 +54,7 @@ memcached_return_t memcached_coll_create_attrs_init(memcached_coll_create_attrs_
 그 외에, 선택적 속성들은 attributes 구조체를 초기화한 이후,
 아래의 함수를 이용하여 개별적으로 지정할 수 있다.
 
-```C
+```c
 memcached_return_t memcached_coll_create_attrs_set_flags(memcached_coll_create_attrs_st *attributes, uint32_t flags)
 memcached_return_t memcached_coll_create_attrs_set_expiretime(memcached_coll_create_attrs_st *attributes, uint32_t expiretime)
 memcached_return_t memcached_coll_create_attrs_set_maxcount(memcached_coll_create_attrs_st *attributes,

--- a/docs/09-other-API.md
+++ b/docs/09-other-API.md
@@ -10,7 +10,7 @@
 ARCUS는 cache server에 있는 모든 items 또는 특정 prefix의 items을 flush(or delete)하는 기능을 제공한다.
 전자의 함수는 모든 items을 flush하고 후자의 함수는 특정 prefix의 items을 flush한다.
 
-```C
+```c
 memcached_return_t memcached_flush(memcached_st *ptr, time_t expiration);
 memcached_return_t memcached_flush_by_prefix(memcached_st *ptr,
                                              const char *prefix, size_t prefix_length,


### PR DESCRIPTION
문서시스템에서 다음과 같이 문법 하이라이팅이 이루어지지 않는 버그가 있습니다. 

![image](https://user-images.githubusercontent.com/26251856/90727779-c69d7580-e2fe-11ea-886f-d75d7211b6fd.png)

문법 하이라이팅을 위해 코드 블록에 어떤 언어인지 힌트를 주는데, C가 대문자로 입력된 것이 원인입니다. 

이 패치를 적용할 경우 다음과 같이 바뀝니다. 

![image](https://user-images.githubusercontent.com/26251856/90727897-f8164100-e2fe-11ea-9e29-6221aeeaf67b.png)
