### PR TITLE
CLEANUP: defined element fetch buffer size as MEMCACHED_COLL_MAX_MOP_…

### DIFF
--- a/libmemcached/response.cc
+++ b/libmemcached/response.cc
@@ -1097,7 +1097,7 @@ static memcached_return_t textual_coll_element_fetch(memcached_server_write_inst
                                                      size_t count, memcached_coll_result_st *result)
 {
   memcached_return_t rc;
-  const size_t MAX_ELEMENT_BUFFER_SIZE= MEMCACHED_MAX_KEY; /* MEMCACHED_COLL_MAX_MOP_MKEY_LENG(250)+1 */
+  const size_t MAX_ELEMENT_BUFFER_SIZE= MEMCACHED_COLL_MAX_MOP_MKEY_LENG+1; /* add one to have it null terminated */
 
   char *string_ptr;
   size_t i= 0, to_read= 0, value_length= 0;


### PR DESCRIPTION
textual_coll_element_fetch() 의 버퍼 크기 정의 변경
- MEMCACHED_MAX_KEY(251) -> MEMCACHED_COLL_MAX_MOP_MKEY_LENG(250)+1
- 필요한 버퍼 크기는 콜렉션 연산 결과의 value 부분만을 담기 때문에 key 가 포함되지 않으므로 max key length macro 에 종속적이지 않도록 변경
