### PR TITLE
CLEANUP: refactored memcached_send_ascii() in storage.cc

### DIFF
--- a/libmemcached/common.h
+++ b/libmemcached/common.h
@@ -153,6 +153,7 @@ memcached_return_t memcached_server_execute(memcached_st *ptr,
 #endif
 
 #define MEMCACHED_BLOCK_SIZE 1024
+#define MEMCACHED_MAXIMUM_INTEGER_DISPLAY_LENGTH 20
 #define MEMCACHED_DEFAULT_COMMAND_SIZE 512  /* maybe, enough */
 #define MEMCACHED_MAXIMUM_COMMAND_SIZE 6812 /* 512 + 6300(100 filter values) */
 #define SMALL_STRING_LEN 1024


### PR DESCRIPTION
기존 storage.cc 의 memcached_send_ascii() 함수는 코드가 복잡하고, 고정 버퍼를 사용하여 command string 을 만드는 방식은 버퍼 크기가 필드 길이에 의존하는 문제를 갖고 있어서 리팩토링 하였습니다.
- key length limit 변경 또는 옵션 필드가 추가될 때마다 버퍼 크기 변경이 필요하게 됨.

최신 libmemcached code 를 포팅하였고, 기존 동작의 로직은 그대로 유지하게끔 수정하였습니다.


