### PR TITLE
FEATURE: increased max key length : 250 => 4K.

### DIFF
--- a/libmemcached/constants.h
+++ b/libmemcached/constants.h
@@ -65,7 +65,7 @@
 
 /* Public defines */
 #define MEMCACHED_DEFAULT_PORT 11211
-#define MEMCACHED_MAX_KEY 251 /* We add one to have it null terminated */
+#define MEMCACHED_MAX_KEY 4097 /* We add one to have it null terminated */
 #define MEMCACHED_MAX_BUFFER 8196
 #define MEMCACHED_MAX_HOST_SORT_LENGTH 86 /* Used for Ketama */
 #define MEMCACHED_POINTS_PER_SERVER 100

--- a/libmemcached/fetch.cc
+++ b/libmemcached/fetch.cc
@@ -178,7 +178,7 @@ memcached_result_st *memcached_fetch_result(memcached_st *ptr,
   memcached_server_st *server;
   while ((server= memcached_io_get_readable_server(ptr)))
   {
-    char buffer[MEMCACHED_DEFAULT_COMMAND_SIZE];
+    char buffer[MEMCACHED_DEFAULT_COMMAND_SIZE + MEMCACHED_MAX_KEY];
     *error= memcached_response(server, buffer, sizeof(buffer), result);
 
     if (*error == MEMCACHED_IN_PROGRESS)
@@ -327,7 +327,7 @@ memcached_coll_fetch_result(memcached_st *ptr,
   memcached_server_st *server;
   while ((server= memcached_io_get_readable_server(ptr)))
   {
-    char buffer[MEMCACHED_DEFAULT_COMMAND_SIZE];
+    char buffer[MEMCACHED_DEFAULT_COMMAND_SIZE + MEMCACHED_MAX_KEY];
     *error= memcached_coll_response(server, buffer, sizeof(buffer), result);
     memcached_set_last_response_code(ptr, *error);
 

--- a/libmemcached/response.cc
+++ b/libmemcached/response.cc
@@ -55,7 +55,7 @@
 #include <libmemcached/string.hpp>
 
 static memcached_return_t textual_value_fetch(memcached_server_write_instance_st ptr,
-                                              char *buffer,
+                                              char *buffer, size_t buffer_length,
                                               memcached_result_st *result)
 {
   char *string_ptr;
@@ -69,7 +69,7 @@ static memcached_return_t textual_value_fetch(memcached_server_write_instance_st
     return memcached_set_error(*ptr, MEMCACHED_NOT_SUPPORTED, MEMCACHED_AT);
 
   WATCHPOINT_ASSERT(ptr->root);
-  end_ptr= buffer + MEMCACHED_DEFAULT_COMMAND_SIZE;
+  end_ptr= buffer + buffer_length;
 
   memcached_result_reset(result);
 
@@ -207,7 +207,7 @@ static memcached_return_t textual_read_one_response(memcached_server_write_insta
     {
       /* We add back in one because we will need to search for END */
       memcached_server_response_increment(ptr);
-      return textual_value_fetch(ptr, buffer, result);
+      return textual_value_fetch(ptr, buffer, buffer_length, result);
     }
     else if (memcmp(buffer, "VERSION", 7) == 0)
     {


### PR DESCRIPTION
key 최대 길이 제한을 4K로 변경하였습니다. (issue : https://github.com/naver/arcus-c-client/issues/121)

수정 사항
- key max length macro(MEMCACHED_MAX_KEY) 값 변경
- response string copy buffer 크기 증가. (in fetch.cc)
  - get 종류 명령의 응답은 first line 에 key string 을 포함되어 있음.
- long key test 코드 추가
  - simple kv set / get
  - smget 1.9v