### PR TITLE
CLEANUP: refactored snprintf codes

### DIFF
--- a/libmemcached/collection.h
+++ b/libmemcached/collection.h
@@ -30,7 +30,7 @@
  * refer to the filter format: " %u %s 0x%s %s 0x%s"
  */
 #define MEMCACHED_COLL_ONE_FILTER_STR_LENGTH    150 /* 64*2 + 22 */
-#define MEMCACHED_COLL_MAX_FILTER_STR_LENGTH    150 + (MEMCACHED_COLL_MAX_EFLAGS_COUNT-1)*63
+#define MEMCACHED_COLL_MAX_FILTER_STR_LENGTH    150 + (MEMCACHED_COLL_MAX_EFLAGS_COUNT-1)*65 /* 64 + comma(1) */
 /* update filter string length: 80 = 64+16
  * refer to the filter format: " %u %s 0x%s"
  */

--- a/libmemcached/dump.cc
+++ b/libmemcached/dump.cc
@@ -39,19 +39,18 @@ static memcached_return_t ascii_dump(memcached_st *ptr, memcached_dump_fn *callb
     /* 200 : the upper limit of slabs */
     for (uint32_t x= 0; x < 200; x++)
     {
-      char buffer[MEMCACHED_DEFAULT_COMMAND_SIZE];
-      char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-      int send_length;
-      send_length= snprintf(buffer, MEMCACHED_DEFAULT_COMMAND_SIZE,
-                            "stats cachedump %u 0\r\n", x);
+      const size_t buffer_length= MEMCACHED_DEFAULT_COMMAND_SIZE;
+      char buffer[buffer_length];
+      int write_length= 0;
+      write_length= snprintf(buffer, buffer_length, "stats cachedump %u 0\r\n", x);
 
-      if (send_length >= MEMCACHED_DEFAULT_COMMAND_SIZE || send_length < 0)
+      if ((size_t)write_length >= buffer_length || write_length < 0)
       {
         return memcached_set_error(*ptr, MEMCACHED_MEMORY_ALLOCATION_FAILURE, MEMCACHED_AT, 
                                    memcached_literal_param("snprintf(MEMCACHED_DEFAULT_COMMAND_SIZE)"));
       }
 
-      rc= memcached_do(instance, buffer, (size_t)send_length, true);
+      rc= memcached_do(instance, buffer, (size_t)write_length, true);
 
       if (rc != MEMCACHED_SUCCESS)
       {
@@ -61,6 +60,7 @@ static memcached_return_t ascii_dump(memcached_st *ptr, memcached_dump_fn *callb
       while (1)
       {
         uint32_t callback_counter;
+        char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
         rc= memcached_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
 
         if (rc == MEMCACHED_ITEM)

--- a/libmemcached/stats.cc
+++ b/libmemcached/stats.cc
@@ -414,25 +414,26 @@ static memcached_return_t ascii_stats_fetch(memcached_stat_st *memc_stat,
                                             memcached_server_write_instance_st instance,
                                             struct local_context *check)
 {
-  char buffer[MEMCACHED_DEFAULT_COMMAND_SIZE];
-  int send_length;
+  const size_t buffer_length= MEMCACHED_DEFAULT_COMMAND_SIZE;
+  char buffer[buffer_length];
+  int write_length;
 
   if (args)
   {
-    send_length= (size_t) snprintf(buffer, MEMCACHED_DEFAULT_COMMAND_SIZE, "stats %s\r\n", args);
+    write_length= snprintf(buffer, buffer_length, "stats %s\r\n", args);
   }
   else
   {
-    send_length= (size_t) snprintf(buffer, MEMCACHED_DEFAULT_COMMAND_SIZE, "stats\r\n");
+    write_length= snprintf(buffer, buffer_length, "stats\r\n");
   }
 
-  if (send_length >= MEMCACHED_DEFAULT_COMMAND_SIZE || send_length < 0)
+  if ((size_t)write_length >= buffer_length || write_length < 0)
   {
     return memcached_set_error(*instance, MEMCACHED_MEMORY_ALLOCATION_FAILURE, MEMCACHED_AT, 
                                memcached_literal_param("snprintf(MEMCACHED_DEFAULT_COMMAND_SIZE)"));
   }
 
-  memcached_return_t rc= memcached_do(instance, buffer, (size_t)send_length, true);
+  memcached_return_t rc= memcached_do(instance, buffer, (size_t)write_length, true);
   if (memcached_success(rc))
   {
     char result[MEMCACHED_DEFAULT_COMMAND_SIZE];


### PR DESCRIPTION
snprintf 관련 코드를 리팩토링하였습니다.
- 한 함수 내에서 macro 를 여러번 사용하는 곳에서는 변수에 할당하여 사용하도록 변경.
```
MEMCACHED_DEFAULT_COMMAND_SIZE
MEMCACHED_MAXIMUM_COMMAND_SIZE
```
- 아래와 같은 패턴으로 사용하도록 수정
```
snprintf(buffer, buffer_length, ...)
snprintf(buffer + write_length, buffer_length - write_length, ...)
```
- error handling 추가
```
   if ((size_t)write_length >= buffer_length || write_length < 0)
   {
     return memcached_set_error(*ptr, MEMCACHED_MEMORY_ALLOCATION_FAILURE, MEMCACHED_AT,
                                memcached_literal_param("snprintf(MEMCACHED_DEFAULT_COMMAND_SIZE)"));
   }
```