### PR TITLE
FEATURE: request version operation when connect server and move versi…

### DIFF
--- a/libmemcached/connect.cc
+++ b/libmemcached/connect.cc
@@ -650,6 +650,7 @@ memcached_return_t memcached_connect(memcached_server_write_instance_st server)
   if (memcached_success(rc))
   {
     memcached_mark_server_as_clean(server);
+    rc= memcached_version_instance(server);
     return rc;
   }
 

--- a/libmemcached/memcached.h
+++ b/libmemcached/memcached.h
@@ -94,6 +94,7 @@
 #include <libmemcached/quit.h>
 #include <libmemcached/result.h>
 #include <libmemcached/server.h>
+#include <libmemcached/server_instance.h>
 #include <libmemcached/server_list.h>
 #ifdef ENABLE_REPLICATION
 #include <libmemcached/rgroup.h>

--- a/libmemcached/quit.cc
+++ b/libmemcached/quit.cc
@@ -109,6 +109,7 @@ void memcached_quit_server(memcached_server_st *ptr, bool io_death)
   // We reset the version so that if we end up talking to a different server
   // we don't have stale server version information.
   ptr->major_version= ptr->minor_version= ptr->micro_version= UINT8_MAX;
+  ptr->is_enterprise= false;
 
   if (io_death)
   {

--- a/libmemcached/server.cc
+++ b/libmemcached/server.cc
@@ -58,8 +58,9 @@ static inline void _server_init(memcached_server_st *self, memcached_st *root,
   WATCHPOINT_SET(self->io_wait_count.read= 0);
   WATCHPOINT_SET(self->io_wait_count.write= 0);
   self->major_version= UINT8_MAX;
-  self->micro_version= UINT8_MAX;
   self->minor_version= UINT8_MAX;
+  self->micro_version= UINT8_MAX;
+  self->is_enterprise= false;
   self->type= type;
   self->error_messages= NULL;
   self->read_ptr= self->read_buffer;

--- a/libmemcached/server.h
+++ b/libmemcached/server.h
@@ -78,8 +78,9 @@ struct memcached_server_st {
     uint32_t write;
   } io_wait_count;
   uint8_t major_version; // Default definition of UINT8_MAX means that it has not been set.
-  uint8_t micro_version; // ditto
   uint8_t minor_version; // ditto
+  uint8_t micro_version; // ditto
+  bool    is_enterprise;
   memcached_connection_t type;
   char *read_ptr;
   size_t read_buffer_length;

--- a/libmemcached/version.h
+++ b/libmemcached/version.h
@@ -37,6 +37,8 @@
 
 #pragma once
 
+#include <libmemcached/server_instance.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -46,6 +48,9 @@ memcached_return_t memcached_version(memcached_st *ptr);
 
 LIBMEMCACHED_API
 const char * memcached_lib_version(void);
+
+LIBMEMCACHED_LOCAL
+memcached_return_t memcached_version_instance(memcached_server_write_instance_st instance);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
issue: "CLEANUP: enable optimize mget operation with instance version" 리뷰와 수정 https://github.com/naver/arcus-c-client/issues/131 - version 처리 부분에 대한 PR

- version parsing 은 response 모듈에서 수행.
- server connect 시에 version 연산 요청(async 방식). response 처리 (version 등록)은 다른 operation response 처리 시에 수행.
  - io buffer 에만 write 하고, 다른 연산 io flush 시에 전송. 
  - sync 방식보다 효율적이지만, version 정보가 뒤늦게 세팅됨. 이로 인한 문제는 없음.
  - binary protocol 의 경우는 pending response 처리할 수 없어서 지원하지 않도록 함. (memcached_version_instance())
     - response count 만큼 io read 처리를 하지 않음.
     - 최신 libmemcached 도 마찬가지로 처리할 수 없는데도 지원하고 있는 상태. 버그로 생각됨.
- memcached_version() 요청은 병렬 수행하도록 최적화
- enable_mget_optimized flag 설정은 mget PR 시에 넣을 예정
- make error - server_instance.h 관련
  - arcus 폴더에 있는 example c 파일 compile 시에 No such file 에러가 발생하네요. 이것 때문에 예전에 PR 한것으로 추측합니다.
  - libmemcached/memcached.h 에 include 하여 해결하였습니다.