### PR TITLE
FIX: set purge recursion flag to false before return

### DIFF
--- a/libmemcached/purge.cc
+++ b/libmemcached/purge.cc
@@ -23,7 +23,7 @@ memcached_return_t memcached_purge(memcached_server_write_instance_st ptr)
     requests buffered up.. */
   if (memcached_io_write(ptr, NULL, 0, true) == -1)
   {
-    memcached_set_purging(root, true);
+    memcached_set_purging(root, false);
 
     return memcached_set_error(*ptr, MEMCACHED_WRITE_FAILURE, MEMCACHED_AT);
   }


### PR DESCRIPTION
memcached_purge() 함수 리턴 전에 flag 를 false 로 세팅하는 것이 맞아보입니다.