### PR TITLE
ENHANCE: do memcached_quit_server if poll_timeout occurs in io_flush().

### DIFF
--- a/libmemcached/io.cc
+++ b/libmemcached/io.cc
@@ -402,14 +402,16 @@ static ssize_t io_flush(memcached_server_write_instance_st ptr,
           {
             continue;
           }
-          else if (rc == MEMCACHED_TIMEOUT)
-          {
-            *error= memcached_set_error(*ptr, MEMCACHED_TIMEOUT, MEMCACHED_AT);
-            return -1;
-          }
 
           memcached_quit_server(ptr, true);
-          *error= memcached_set_errno(*ptr, get_socket_errno(), MEMCACHED_AT);
+          if (rc == MEMCACHED_TIMEOUT)
+          {
+            *error= memcached_set_error(*ptr, MEMCACHED_TIMEOUT, MEMCACHED_AT);
+          }
+          else
+          {
+            *error= memcached_set_errno(*ptr, get_socket_errno(), MEMCACHED_AT);
+          }
           return -1;
         }
       case ENOTCONN:


### PR DESCRIPTION
io_flush() 에서 poll timeout 발생에 대한 처리 검토(https://github.com/naver/arcus-c-client/issues/146) PR 입니다.

io_flush() 에서 poll timeout 발생한 경우 memcached_quit_server() 호출하여 delayed reconnect 하도록 수정하였습니다.