### PR TITLE
FIX: don't use typedef defined in server_instance.h to not link it.

### DIFF
--- a/libmemcached/memcached.h
+++ b/libmemcached/memcached.h
@@ -94,7 +94,6 @@
 #include <libmemcached/quit.h>
 #include <libmemcached/result.h>
 #include <libmemcached/server.h>
-#include <libmemcached/server_instance.h>
 #include <libmemcached/server_list.h>
 #ifdef ENABLE_REPLICATION
 #include <libmemcached/rgroup.h>

--- a/libmemcached/version.cc
+++ b/libmemcached/version.cc
@@ -69,7 +69,7 @@ static inline memcached_return_t memcached_version_textual(memcached_st *ptr)
   bool errors_happened= false;
   for (uint32_t x= 0; x < memcached_server_count(ptr); x++)
   {
-    memcached_server_write_instance_st instance=
+    memcached_server_st *instance=
       memcached_server_instance_fetch(ptr, x);
 
     /* Optimization, we only fetch version once. */
@@ -92,7 +92,7 @@ static inline memcached_return_t memcached_version_textual(memcached_st *ptr)
   if (success)
   {
     /* Collect the returned items */
-    memcached_server_write_instance_st instance;
+    memcached_server_st *instance;
     while ((instance= memcached_io_get_readable_server(ptr)))
     {
       char buffer[32];
@@ -123,7 +123,7 @@ static inline memcached_return_t memcached_version_binary(memcached_st *ptr)
   bool errors_happened= false;
   for (uint32_t x= 0; x < memcached_server_count(ptr); x++)
   {
-    memcached_server_write_instance_st instance=
+    memcached_server_st *instance=
       memcached_server_instance_fetch(ptr, x);
 
     /* Optimization, we only fetch version once. */
@@ -146,7 +146,7 @@ static inline memcached_return_t memcached_version_binary(memcached_st *ptr)
   if (success)
   {
     /* Collect the returned items */
-    memcached_server_write_instance_st instance;
+    memcached_server_st *instance;
     while ((instance= memcached_io_get_readable_server(ptr)))
     {
       char buffer[32];
@@ -161,7 +161,7 @@ static inline memcached_return_t memcached_version_binary(memcached_st *ptr)
   return errors_happened ? MEMCACHED_SOME_ERRORS : MEMCACHED_SUCCESS;
 }
 
-static inline memcached_return_t version_ascii_instance(memcached_server_write_instance_st instance)
+static inline memcached_return_t version_ascii_instance(memcached_server_st *instance)
 {
   memcached_return_t rc= MEMCACHED_SUCCESS;
   if (instance->major_version == UINT8_MAX)
@@ -194,7 +194,7 @@ static inline memcached_return_t version_ascii_instance(memcached_server_write_i
   return rc;
 }
 
-static inline memcached_return_t version_binary_instance(memcached_server_write_instance_st instance)
+static inline memcached_return_t version_binary_instance(memcached_server_st *instance)
 {
   memcached_return_t rc= MEMCACHED_SUCCESS;
   if (instance->major_version == UINT8_MAX)
@@ -259,7 +259,7 @@ memcached_return_t memcached_version(memcached_st *ptr)
   return MEMCACHED_INVALID_ARGUMENTS;
 }
 
-memcached_return_t memcached_version_instance(memcached_server_write_instance_st instance)
+memcached_return_t memcached_version_instance(memcached_server_st *instance)
 {
   if (instance && instance->root)
   {

--- a/libmemcached/version.h
+++ b/libmemcached/version.h
@@ -37,8 +37,6 @@
 
 #pragma once
 
-#include <libmemcached/server_instance.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -50,7 +48,7 @@ LIBMEMCACHED_API
 const char * memcached_lib_version(void);
 
 LIBMEMCACHED_LOCAL
-memcached_return_t memcached_version_instance(memcached_server_write_instance_st instance);
+memcached_return_t memcached_version_instance(memcached_server_st *instance);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
**문제**
- c-client 링크하여 컴파일할 때 include directory 에 있는 server_instance.h 를 못 찾는 문제.
error: arcus/include/libmemcached/server_instance.h: No such file or directory

- 아래 PR 대로 libmemcached/include.am 에 nobase_include_HEADERS에 server_instance.h 추가 필요. (nobase_include_HEADERS 에 명시한 파일들은 ${prefix}/include 에 생성됨.)
https://github.com/naver/arcus-c-client/pull/38/commits/dffd4fa3191a41b255e72dcacf9195d545c2ad90 
  => test 시에 실수가 있어서 위 PR이 필요한 이유를 발견하지 못햇엇습니다.

**해결**
- server_instance.h 에 정의된 typedef 를 사용하지 않아 include.am 수정하지 않는 방향으로 수정하였습니다. 
- typedef 참고
```
//types.h
typedef struct memcached_server_st memcached_server_st;
//server_instance.h 
typedef struct memcached_server_st * memcached_server_write_instance_st;
```
- 향후에 위 typedef 를 types.h 에 정의하고 server_instance.h 을 제거하는 편이 좋겠습니다.
  - 최신 코드도 위와 같이 되어 있어요.