### PR TITLE
DOC: fix dead link

### DIFF
--- a/docs/07-btree-API.md
+++ b/docs/07-btree-API.md
@@ -3,12 +3,13 @@
 B+tree item은 하나의 key에 대해 b+tree 구조 기반으로 b+tree key(bkey)로 정렬된 data의 집합을 가진다.
 
 **제약 조건**
+
 - 저장 가능한 최대 element 개수 : 디폴트 4,000개 (attribute 설정으로 최대 50,000개 확장 가능)
 - 각 element에서 value 최대 크기 : 16KB
 - 하나의 b+tree 내에서 모든 element는 동일한 bkey 유형을 가져야 한다. 
   즉, 8바이트 unsigned integer bkey 유형과 byte array bkey 유형이 혼재할 수 없다.
 
-B+tree item 구조와 기본 특징은 **[ARCUS Server Ascii Protocol 문서의 내용](https://github.com/naver/arcus-memcached/blob/master/doc/arcus-collection-concept.md)**을
+B+tree item 구조와 기본 특징은 [ARCUS Server Ascii Protocol 문서의 내용](https://github.com/naver/arcus-memcached/blob/master/doc/ch02-collection-items.md)을
 먼저 참고하기 바란다.
 
 B+tree item 연산의 설명에 앞서, b+tree 조회 및 변경에 사용하는 자료구조를 설명한다.

--- a/docs/08-attribute-API.md
+++ b/docs/08-attribute-API.md
@@ -1,7 +1,7 @@
 # Item Attributes
 
 Item attributes는 각 cache item의 메타데이터를 의미한다.
-Item attributes의 기본 설명은 [ARCUS cache server의 item attributes 부분](https://github.com/naver/arcus-memcached/blob/master/doc/arcus-item-attribute.md)을 참고하길 바란다.
+Item attributes의 기본 설명은 [ARCUS cache server의 item attributes 부분](https://github.com/naver/arcus-memcached/blob/master/doc/ch03-item-attributes.md)을 참고하길 바란다.
 
 Item attributes를 변경하거나 조회하는 함수들을 설명한다.
 


### PR DESCRIPTION
링크가 잘못된 문서 주소를 참조하고 있어 수정합니다.

볼드 효과가 적용되지 않고 있어 제거했습니다. 