### PR TITLE
CLEANUP: removed unreachable code.

### DIFF
--- a/libmemcached/fetch.cc
+++ b/libmemcached/fetch.cc
@@ -214,10 +214,6 @@ memcached_result_st *memcached_fetch_result(memcached_st *ptr,
   {
     *error= MEMCACHED_NOTFOUND;
   }
-  else if (*error == MEMCACHED_SUCCESS)
-  {
-    *error= MEMCACHED_END;
-  }
   else if (result->count == 0)
   {
     *error= MEMCACHED_NOTFOUND;


### PR DESCRIPTION
*error == MEMCACHED_SUCCESS 인 경우 바로 return 하기 때문에 아래 if 문에서 확인할 필요 없어 보입니다.
참고로, 최신 libmemcached 코드는 기존과 같은 형태로 같은 문제를 갖고 있긴 합니다.