### PR TITLE
ENHANCE: return MEMCACHED_CONNECTION_FAILURE that occurred in memcach…

### DIFF
--- a/libmemcached/fetch.cc
+++ b/libmemcached/fetch.cc
@@ -176,6 +176,7 @@ memcached_result_st *memcached_fetch_result(memcached_st *ptr,
 
   *error= MEMCACHED_MAXIMUM_RETURN; // We use this to see if we ever go into the loop
   memcached_server_st *server;
+  bool connection_failures= false;
   while ((server= memcached_io_get_readable_server(ptr)))
   {
     char buffer[MEMCACHED_DEFAULT_COMMAND_SIZE + MEMCACHED_MAX_KEY];
@@ -183,6 +184,11 @@ memcached_result_st *memcached_fetch_result(memcached_st *ptr,
 
     if (*error == MEMCACHED_IN_PROGRESS)
     {
+      continue;
+    }
+    else if (*error == MEMCACHED_CONNECTION_FAILURE)
+    {
+      connection_failures= true;
       continue;
     }
     else if (*error == MEMCACHED_SUCCESS)
@@ -213,6 +219,14 @@ memcached_result_st *memcached_fetch_result(memcached_st *ptr,
   else if (*error == MEMCACHED_MAXIMUM_RETURN) // while() loop was never entered
   {
     *error= MEMCACHED_NOTFOUND;
+  }
+  else if (connection_failures)
+  {
+    /* If we have a connection failure to some servers, the caller may
+     * wish to treat that differently to getting a definitive NOT_FOUND
+     * from all servers, so return MEMCACHED_CONNECTION_FAILURE to allow that.
+     */
+    *error= MEMCACHED_CONNECTION_FAILURE;
   }
   else if (result->count == 0)
   {


### PR DESCRIPTION
memcached_fetch_result()에서 MEMCACHED_IN_PROGRESS 발생 시 NOT_FOUND 응답 검토 https://github.com/jam2in/arcus-works/issues/213 PR 입니다.

memcached_response() 에서 MEMCACHED_CONNECTION_FAILURE 가 발생한 경우 *error 값을 NOTFOUND 가 아닌 MEMCACHED_CONNECTION_FAILURE 로 설정하도록 변경하였습니다.

추가 수정사항으로 기존 if문 코드가 이해하기가 어려워서 리팩토링하였습니다.
if문쪽의 최신 libmemcached 코드를 리뷰에 참고로 올려둡니다.
```
/* while 코드는 PR 코드와 동일. */

  if (*error == MEMCACHED_NOTFOUND and result->count)
  {
    *error= MEMCACHED_END;
  }
  else if (*error == MEMCACHED_MAXIMUM_RETURN and result->count)
  {
    *error= MEMCACHED_END;
  }
  else if (*error == MEMCACHED_MAXIMUM_RETURN) // while() loop was never entered
  {
    *error= MEMCACHED_NOTFOUND;
  }
  else if (connection_failures)
  {
    /*  
        If we have a connection failure to some servers, the caller may
        wish to treat that differently to getting a definitive NOT_FOUND
        from all servers, so return MEMCACHED_CONNECTION_FAILURE to allow
        that. 
        */
    *error= MEMCACHED_CONNECTION_FAILURE;
  }
  else if (*error == MEMCACHED_SUCCESS)
  {
    *error= MEMCACHED_END;
  }
  else if (result->count == 0)
  {
    *error= MEMCACHED_NOTFOUND;
  }

  /* We have completed reading data */
...
  return NULL;
```

