### PR TITLE
FIX: amended compile option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ main(int argc, char *argv[])
 To compile, specify the include and library paths and link against this library.
 
 ```
-gcc -Wall -I/install/directory/include -L/install/directory/lib -lmemcached -lmemcachedutil -o sample sample.c
+gcc -o sample sample.c -Wall -I/install/directory/include -L/install/directory/lib -lmemcached -lmemcachedutil
 ```
 
 Then start the memcached instance.


### PR DESCRIPTION
README.md 에 compile option 이 gcc5 에서 수행되지 않아 수정하였습니다.
gcc4 버전까지는 기존과 같이 컴파일하여도 수행되었지만 아래와 같이 gcc5 에서 수행해본 결과 library 를 찾지 못합니다. 

```
[suhwan@jam2in-t003:arcus|suhwan/develop $]$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/5/lto-wrapper
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 5.4.0-6ubuntu1~16.04.12' --with-bugurl=file:///usr/share/doc/gcc-5/README.Bugs --enable-languages=c,ada,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-5 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-5-amd64/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-5-amd64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-5-amd64 --with-arch-directory=amd64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.12)

[suhwan@jam2in-t003:arcus|suhwan/develop $]$ gcc -I/home/suhwan/develop/arcus-c-client-develop/arcus/include -L/home/suhwan/develop/arcus-c-client-develop/arcus/lib -lmemcached -lmemcachedutil -o sample sample.c
/tmp/ccXBkn1e.o: In function `main':
sample.c:(.text+0x64): undefined reference to `memcached_create'
sample.c:(.text+0x98): undefined reference to `memcached_server_add'
sample.c:(.text+0xc4): undefined reference to `memcached_coll_create_attrs_init'
sample.c:(.text+0x11b): undefined reference to `memcached_bop_insert'
sample.c:(.text+0x150): undefined reference to `memcached_coll_result_create'
sample.c:(.text+0x199): undefined reference to `memcached_bop_get'
sample.c:(.text+0x1bc): undefined reference to `memcached_coll_result_get_value'
sample.c:(.text+0x1dd): undefined reference to `memcached_coll_result_free'
collect2: error: ld returned 1 exit status
```

-o XX XX.c 옵션을 먼저 주었을 때는 정상적으로 컴파일하는 것을 확인하였습니다.
gcc5 부터는 위와 같이 주어야만 컴파일 옵션을 정상적으로 해석하는 것으로 보입니다.
