### PR TITLE
FIX: called memcached_connect() to check space_separated_keys support in do_coll_get().

### DIFF
--- a/libmemcached/collection.cc
+++ b/libmemcached/collection.cc
@@ -1637,6 +1637,14 @@ static memcached_return_t do_coll_get(memcached_st *ptr,
   uint32_t server_key= memcached_generate_hash_with_redistribution(ptr, key, key_length);
   memcached_server_write_instance_st instance= memcached_server_instance_fetch(ptr, server_key);
 
+  /* For check space_separated_keys_is_supported */
+  rc= memcached_connect(instance);
+  if (memcached_failed(rc))
+  {
+    memcached_set_error(*instance, rc, MEMCACHED_AT);
+    return rc;
+  }
+
   /* Query header */
 
   /* 1. sub key */


### PR DESCRIPTION
**mop get 에서 space_separated_keys 지원 여부 확인 로직 수정** : https://github.com/naver/arcus-c-client/issues/160

아직 캐시 서버와 연결되지 않은 상태에서 mop get 명령 요청 처리 시 서버 버전이 등록되있지 않아 실제로 서버가 space_separated_keys 를 지원하는 경우에도 comma_separated_keys 사용할 수 있는 문제를 수정했습니다.
- space_separated_keys_is_supported() 함수 안에서 memcached_connect() 를 호출하여 서버 버전 등록하도록 처리하였습니다.
  - 이미 connected 상태이면 memcached_connect() 는 즉각 MEMCACHED_SUCCESS 를 return 합니다.

```
 memcached_return_t memcached_connect(memcached_server_write_instance_st server)
 {
   if (server->fd != INVALID_SOCKET)
   {
     return MEMCACHED_SUCCESS;
   }

   LIBMEMCACHED_MEMCACHED_CONNECT_START();

   bool in_timeout= false;
   memcached_return_t rc;
   if (memcached_failed(rc= backoff_handling(server, in_timeout)))
   {
     set_last_disconnected_host(server);
     return rc;
   }

...
}
```

- mget_command_is_supported() 에도 위와 같이 처리하는 것이 일관적인데 그 전에 명령 생성 및 전송하는 로직을 mget / get  를 분리하는 작업이 선행되어야 합니다.
- 아래 코드를 보면 get, mget 별로 key 전송 실패 시 처리방식이 다르기 때문에 hosts_failed 는 enable_mget 값을 같이 확인해야 합니다. mget_command_is_supported() 호출이 매번 수행되기 때문에 현재 상태에서 memcached_connect()를 넣으면 이 함수 호출도 매번 수행하게 됩니다. mget 로직을 분리한다면 enable_mget 확인 없이 hosts_failed 만 확인할 수 있어 문제가 해결됩니다.

```
   for (uint32_t x= 0; x < number_of_keys; x++)
   {
     memcached_server_write_instance_st instance;
     uint32_t server_key;

     if (is_group_key_set)
     {
       server_key= master_server_key;
     }
     else
     {
       server_key= key_to_serverkey[x];
     }

     instance= memcached_server_instance_fetch(ptr, server_key);
     bool enable_mget= mget_command_is_supported(ptr, instance);
     if (enable_mget)
     {
       if (hosts_failed[server_key])
       {
         /* For mget command, the number of keys and length are mismatched,
          * so the remaining requests are not sent.
          */
         continue;
       }
     }
```
