### PR TITLE
FIX: expand rgroup considering N replicas in memcached_rgroup_push().

### DIFF
--- a/libmemcached/rgroup.cc
+++ b/libmemcached/rgroup.cc
@@ -532,7 +532,7 @@ memcached_rgroup_push(memcached_st *memc,
     return MEMCACHED_SUCCESS;
   }
 
-  if (memcached_rgroup_expand(memc, groupcount, (groupcount*2)) != 0) {
+  if (memcached_rgroup_expand(memc, groupcount, (groupcount*RGROUP_MAX_REPLICA)) != 0) {
     return MEMCACHED_MEMORY_ALLOCATION_FAILURE;
   }
 


### PR DESCRIPTION
assert 지점:
- available server 가 부족하여 do_rgroup_server_alloc() 에서 NULL 이 리턴됨.
```
 static void
 do_rgroup_server_insert(memcached_rgroup_st *rgroup, int sindex,
                         const char *hostname, in_port_t port)
 {
   assert(rgroup->nreplica < RGROUP_MAX_REPLICA);
   assert(sindex >= -1 && sindex <= (int)rgroup->nreplica);
   memcached_server_st *server;

   /* create a new memcached server */
   memcached_string_t _hostname= { memcached_string_make_from_cstr(hostname) };
   server= do_rgroup_server_alloc(rgroup->root);
   assert(server != NULL);  // SUHWAN: ASSERT 발생 
   server= __server_create_with(rgroup->root, server, _hostname, port, 0,
                                MEMCACHED_CONNECTION_TCP);
```

memcached_rgroup_push() 는 source mc 의 rgroup 정보를 clone mc 로 copy 시에 사용하는 함수이며,
memcached_rgroup_expand() 로 전달하는 servercount를 `groupcount*2`로 줍니다. 
기존에 이중화 기능만 있어 최대 replicas 가 2개이므로 위와 같이 준 것으로 생각되는데,
삼중화 그룹이 2개 이상 있으면 available server 가 모자랍니다.
따라서 실제 server 개수를 카운팅하여 전달하도록 수정하였고, 추가 메모리 사용을 하더라도 좀 더 간단한 방법으로는 기존 코드와 같은 형태로 `groupcount*RGROUP_MAX_REPLICA` 로 줄 수 있습니다.