### PR TITLE
FIX: return switchover error code when coll get with delete.

### DIFF
--- a/libmemcached/fetch.cc
+++ b/libmemcached/fetch.cc
@@ -394,6 +394,10 @@ memcached_coll_fetch_result(memcached_st *ptr,
            *error != MEMCACHED_UNREADABLE       and
            *error != MEMCACHED_OUT_OF_RANGE     and
            *error != MEMCACHED_NOTFOUND_ELEMENT and
+#ifdef ENABLE_REPLICATION /* coll get with delete */
+           *error != MEMCACHED_SWITCHOVER       and
+           *error != MEMCACHED_REPL_SLAVE       and
+#endif
            *error != MEMCACHED_TYPE_MISMATCH    and
            *error != MEMCACHED_BKEY_MISMATCH    )
   {


### PR DESCRIPTION
memcached_coll_fetch_result()에서 SWITCHOVER or REPL_SLAVE 응답을 받은 경우에도 NOTFOUND 로 리턴하는 문제가 있습니다.
아래 코드는 coll get 명령을 수행하는 함수에서 response 처리 부분이며 with delete 옵션을 준 경우 해당 응답을 받을 수 있습니다.

```
do_coll_get() :
 #ifdef ENABLE_REPLICATION
 do_action:
 #endif
   rc= memcached_vdo(instance, vector, veclen, to_write);

   if (rc == MEMCACHED_SUCCESS)
   {
     if (to_write == false)
     {
       rc= MEMCACHED_BUFFERED;
     }
     else if (ptr->flags.no_reply || ptr->flags.piped)
     {
       rc= MEMCACHED_SUCCESS;
     }
     else
     {
       /* Fetch results */
       result = memcached_coll_fetch_result(ptr, result, &rc);
 #ifdef ENABLE_REPLICATION
       if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
       {
         ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
                       instance->hostname, instance->port, memcached_strerror(ptr, rc)));
         memcached_rgroup_switchover(ptr, instance);
         instance= memcached_server_instance_fetch(ptr, server_key);
         goto do_action;
       }
 #endif
```
