### PR TITLE
FIX: prevented operation from continuing if switchover peer is not fo…

### DIFF
--- a/libmemcached/auto.cc
+++ b/libmemcached/auto.cc
@@ -127,9 +127,10 @@ do_action:
     {
       ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
                     instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-      memcached_rgroup_switchover(ptr, instance);
-      instance= memcached_server_instance_fetch(ptr, server_key);
-      goto do_action;
+      if (memcached_rgroup_switchover(ptr, instance) == true) {
+        instance= memcached_server_instance_fetch(ptr, server_key);
+        goto do_action;
+      }
     }
 #endif
     return memcached_set_error(*instance, rc, MEMCACHED_AT);
@@ -229,9 +230,10 @@ do_action:
   {
     ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
                   instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-    memcached_rgroup_switchover(ptr, instance);
-    instance= memcached_server_instance_fetch(ptr, server_key);
-    goto do_action;
+    if (memcached_rgroup_switchover(ptr, instance) == true) {
+      instance= memcached_server_instance_fetch(ptr, server_key);
+      goto do_action;
+    }
   }
 #endif
   return rc;

--- a/libmemcached/collection.cc
+++ b/libmemcached/collection.cc
@@ -754,9 +754,10 @@ do_action:
       {
         ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
                       instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-        memcached_rgroup_switchover(ptr, instance);
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
+        if (memcached_rgroup_switchover(ptr, instance) == true) {
+          instance= memcached_server_instance_fetch(ptr, server_key);
+          goto do_action;
+        }
       }
 #endif
     }
@@ -1031,9 +1032,10 @@ do_action:
       {
         ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
                       instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-        memcached_rgroup_switchover(ptr, instance);
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
+        if (memcached_rgroup_switchover(ptr, instance) == true) {
+          instance= memcached_server_instance_fetch(ptr, server_key);
+          goto do_action;
+        }
       }
 #endif
       memcached_set_last_response_code(ptr, rc);
@@ -1408,9 +1410,10 @@ do_action:
       {
         ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
                       instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-        memcached_rgroup_switchover(ptr, instance);
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
+        if (memcached_rgroup_switchover(ptr, instance) == true) {
+          instance= memcached_server_instance_fetch(ptr, server_key);
+          goto do_action;
+        }
       }
 #endif
       memcached_set_last_response_code(ptr, rc);
@@ -1641,9 +1644,10 @@ do_action:
       {
         ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
                       instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-        memcached_rgroup_switchover(ptr, instance);
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
+        if (memcached_rgroup_switchover(ptr, instance) == true) {
+          instance= memcached_server_instance_fetch(ptr, server_key);
+          goto do_action;
+        }
       }
 #endif
       memcached_set_last_response_code(ptr, rc);
@@ -1936,9 +1940,10 @@ do_action:
       {
         ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
                       instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-        memcached_rgroup_switchover(ptr, instance);
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
+        if (memcached_rgroup_switchover(ptr, instance) == true) {
+          instance= memcached_server_instance_fetch(ptr, server_key);
+          goto do_action;
+        }
       }
 #endif
 
@@ -3068,12 +3073,13 @@ static memcached_return_t do_coll_piped_insert(memcached_st *ptr, const char *ke
       if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE) {
         ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
                       instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-        memcached_rgroup_switchover(ptr, instance);
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        ptr->pipe_responses_length-= 1; /* try again from the last request. */
-        i= ptr->pipe_responses_length-1; /* for-statement increments i variable. */
-        requested_items= 0; /* reset */
-        continue; /* retry */
+        if (memcached_rgroup_switchover(ptr, instance) == true) {
+          instance= memcached_server_instance_fetch(ptr, server_key);
+          ptr->pipe_responses_length-= 1; /* try again from the last request. */
+          i= ptr->pipe_responses_length-1; /* for-statement increments i variable. */
+          requested_items= 0; /* reset */
+          continue; /* retry */
+        }
       }
 #endif
       if (requested_items == 1) { /* received not pipe response */
@@ -3287,12 +3293,13 @@ static memcached_return_t do_coll_piped_insert_bulk(memcached_st *ptr,
         if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE) {
           ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
                         instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-          memcached_rgroup_switchover(ptr, instance);
-          instance= memcached_server_instance_fetch(ptr, i);
-          ptr->pipe_responses_length-= 1; /* try again from the last request. */
-          j= ptr->pipe_responses_length-1; /* for-statement increments j variable. */
-          requested_items= 0; /* reset */
-          continue; /* retry */
+          if (memcached_rgroup_switchover(ptr, instance) == true) {
+            instance= memcached_server_instance_fetch(ptr, i);
+            ptr->pipe_responses_length-= 1; /* try again from the last request. */
+            j= ptr->pipe_responses_length-1; /* for-statement increments j variable. */
+            requested_items= 0; /* reset */
+            continue; /* retry */
+          }
         }
 #endif
         memcached_set_last_response_code(ptr, rc);
@@ -3495,9 +3502,10 @@ do_action:
       {
         ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
                       instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-        memcached_rgroup_switchover(ptr, instance);
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
+        if (memcached_rgroup_switchover(ptr, instance) == true) {
+          instance= memcached_server_instance_fetch(ptr, server_key);
+          goto do_action;
+        }
       }
 #endif
       memcached_set_last_response_code(ptr, rc);
@@ -3640,9 +3648,10 @@ do_action:
       {
         ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
                       instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-        memcached_rgroup_switchover(ptr, instance);
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
+        if (memcached_rgroup_switchover(ptr, instance) == true) {
+          instance= memcached_server_instance_fetch(ptr, server_key);
+          goto do_action;
+        }
       }
 #endif
       memcached_set_last_response_code(ptr, rc);

--- a/libmemcached/delete.cc
+++ b/libmemcached/delete.cc
@@ -121,9 +121,10 @@ do_action:
       {
         ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
                       instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-        memcached_rgroup_switchover(ptr, instance);
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
+        if (memcached_rgroup_switchover(ptr, instance) == true) {
+          instance= memcached_server_instance_fetch(ptr, server_key);
+          goto do_action;
+        }
       }
 #endif
     }
@@ -232,9 +233,10 @@ do_action:
     {
       ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
                     instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-      memcached_rgroup_switchover(ptr, instance);
-      instance= memcached_server_instance_fetch(ptr, server_key);
-      goto do_action;
+      if (memcached_rgroup_switchover(ptr, instance) == true) {
+        instance= memcached_server_instance_fetch(ptr, server_key);
+        goto do_action;
+      }
     }
 #endif
   }

--- a/libmemcached/rgroup.cc
+++ b/libmemcached/rgroup.cc
@@ -556,7 +556,7 @@ memcached_rgroup_push(memcached_st *memc,
   return run_distribution(memc);
 }
 
-void
+bool
 memcached_rgroup_switchover(memcached_st *memc, memcached_server_st *server)
 {
   /* find rgroup */
@@ -591,10 +591,13 @@ memcached_rgroup_switchover(memcached_st *memc, memcached_server_st *server)
       }
     }
     if (server->switchover_sidx == -1) {
-      return; /* Something is wrong. do not perform switchover */
+      /* Something is wrong. do not perform switchover */
+      ZOO_LOG_WARN(("Can't find switchover peer(%s:%d)", hostname, port));
+      return false;
     }
   }
   do_rgroup_server_switchover(rgroup, server->switchover_sidx);
+  return true;
 }
 
 void

--- a/libmemcached/rgroup.h
+++ b/libmemcached/rgroup.h
@@ -121,7 +121,7 @@ LIBMEMCACHED_API
                         const memcached_rgroup_st *grouplist,
                         uint32_t groupcount);
 LIBMEMCACHED_API
-  void
+  bool
   memcached_rgroup_switchover(memcached_st *memc, memcached_server_st *server);
 LIBMEMCACHED_API
   void

--- a/libmemcached/storage.cc
+++ b/libmemcached/storage.cc
@@ -245,9 +245,10 @@ do_action:
   {
     ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
                   server->hostname, server->port, memcached_strerror(ptr, rc)));
-    memcached_rgroup_switchover(ptr, server);
-    server= memcached_server_instance_fetch(ptr, server_key);
-    goto do_action;
+    if (memcached_rgroup_switchover(ptr, server) == true) {
+      server= memcached_server_instance_fetch(ptr, server_key);
+      goto do_action;
+    }
   }
 #endif
   return rc;
@@ -377,9 +378,10 @@ do_action:
       {
         ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
                       instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-        memcached_rgroup_switchover(ptr, instance);
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
+        if (memcached_rgroup_switchover(ptr, instance) == true) {
+          instance= memcached_server_instance_fetch(ptr, server_key);
+          goto do_action;
+        }
       }
 #endif
     }


### PR DESCRIPTION
issue(https://github.com/naver/arcus-c-client/issues/169) : switchover peer 못 찾을 시에 handling 검토

memcached_rgroup_switchover() 실패 시 계속 retry 하지 않도록 수정하였습니다.