### PR TITLE
FIX: allocate N replicas size in do_update_serverlist_with_master().

### DIFF
--- a/libmemcached/arcus.cc
+++ b/libmemcached/arcus.cc
@@ -1188,7 +1188,7 @@ static inline void do_update_serverlist_with_master(memcached_st *ptr, memcached
 #ifdef ENABLE_REPLICATION
   if (ptr->flags.repl_enabled)
   {
-    serverinfo= static_cast<memcached_server_info *>(libmemcached_malloc(ptr, sizeof(memcached_server_info)*(memcached_server_count(master)*2)));
+    serverinfo= static_cast<memcached_server_info *>(libmemcached_malloc(ptr, sizeof(memcached_server_info)*(memcached_server_count(master)*RGROUP_MAX_REPLICA)));
     if (not serverinfo) {
       return;
     }


### PR DESCRIPTION
memcached_server_count(master) 가 리턴하는 값은 서버 개수가 아닌 그룹 개수입니다.
기존 이중화 의존성 코드로 인해 실제 서버 개수보다 부족하게 메모리를 할당한 후에 for 문에서 할당하지 않은 영역까지 접근하는 문제가 있습니다.