### PR TITLE
FIX: wrong aggregate pipe return code in case of failure.

### DIFF
--- a/libmemcached/response.cc
+++ b/libmemcached/response.cc
@@ -1480,7 +1480,10 @@ static void aggregate_pipe_return_code(memcached_st *ptr, memcached_return_t res
     }
     else /* failure */
     {
-      *pipe_return_code= MEMCACHED_ALL_FAILURE; /* FIXME */
+      if (*pipe_return_code == MEMCACHED_MAXIMUM_RETURN)
+        *pipe_return_code= MEMCACHED_ALL_FAILURE;
+      else if (*pipe_return_code == MEMCACHED_ALL_EXIST)
+        *pipe_return_code= MEMCACHED_SOME_EXIST;
     }
     break;
 


### PR DESCRIPTION
exist pipe 연산에서 failure 시에 MEMCACHED_SOME_EXIST 설정이 필요하여 추가하였습니다.
이에 해당하는 예시를 보이겠습니다.

```
sop exist s0 3 pipe
qwe
sop exist s0 3
qwer
RESPONSE 2
EXIST
CLIENT_ERROR bad data chunk
PIPE_ERROR bad error
```

마지막 exist 연산은 value 입력을 value length 보다 길게 입력하여 CLIENT_ERROR 를 발생시켰습니다.
첫번째 연산은 EXIST 이므로 c-client 는 이 경우에 ALL_FAILURE가 아닌 SOME_EXIST 로 설정해야 합니다.