### PR TITLE
FIX: exclude from switchover_peer string to spacebar.

### DIFF
--- a/libmemcached/response.cc
+++ b/libmemcached/response.cc
@@ -245,7 +245,7 @@ static void textual_switchover_peer_check(memcached_server_write_instance_st ins
 
   int str_length;
   int buf_length;
-  char *startptr= buffer;
+  char *startptr= buffer+1;
   char *endptr= startptr;
   while (*endptr != '\r' && *endptr != '\n') endptr++;
 


### PR DESCRIPTION
인자 buffer 가 spacebar 부터 가리키는데, switchover_peer string 에 포함하는 문제를 수정하였습니다.