### PR TITLE
CLEANUP: refactored collection pipe code.

### DIFF
--- a/libmemcached/response.h
+++ b/libmemcached/response.h
@@ -74,10 +74,6 @@ memcached_return_t memcached_coll_response(memcached_server_write_instance_st pt
                                            memcached_coll_result_st *result);
 
 LIBMEMCACHED_LOCAL
- void              memcached_add_coll_pipe_return_code(memcached_server_write_instance_st ptr,
-                                                       memcached_return_t return_code);
-
-LIBMEMCACHED_LOCAL
 memcached_return_t memcached_coll_smget_response(memcached_server_write_instance_st ptr,
                                                  char *buffer, size_t buffer_length,
                                                  memcached_coll_smget_result_st *result);


### PR DESCRIPTION
collection pipe 연산 코드를 리팩토링하였습니다.
- switchover or repl_slave 응답 시에 retry 하는 로직의 복잡성을 줄이기 위하여 collection.cc 에서 연산을 모두 보낸 후에 전체 response 에 대해 aggregation 을 수행하도록 수정하였습니다.