### PR TITLE
DOC: amended btree document.

### DIFF
--- a/docs/07-btree-API.md
+++ b/docs/07-btree-API.md
@@ -261,7 +261,7 @@ void arcus_btree_item_create(memcached_st *memc)
     // 이미 존재하는 key를 갖는 B+tree를 생성하려 하면 오류를 반환한다.
     rc= memcached_bop_create(memc, "btree:an_empty_btree", strlen("btree:an_empty_btree"),
                              &attributes);
-    assert(MEMCACHED_SUCCESS == rc);
+    assert(MEMCACHED_SUCCESS != rc);
     assert(MEMCACHED_EXISTS == memcached_get_last_response_code(memc));
 }
 ```


### PR DESCRIPTION
이미 콜렉션 아이템이 존재하는 경우에 rc 값은 MEMCACHED_EXISTS 이므로 수정하였습니다.
다른 콜렉션 타입에서의 create 연산 예제 코드는 이상 없습니다.