### PR TITLE
CLEANUP: Fix warning -Wstringop-truncation #190

### DIFF
--- a/libtest/socket.cc
+++ b/libtest/socket.cc
@@ -39,7 +39,7 @@ void set_default_socket(const char *socket)
 {
   if (socket)
   {
-    strncpy(global_socket, socket, strlen(socket));
+    strncpy(global_socket, socket, sizeof(global_socket)-1);
   }
 }
 


### PR DESCRIPTION
https://github.com/naver/arcus-c-client/issues/190#issuecomment-1002869511
13번 워닝 수정했습니다. 
- 테스트 결과, `dest`의 크기가 `src`보다 큰 경우엔 세 번째 인자에 `sizeof(dest)`를 넣어도, `sizeof(dest)-1`을 넣어도 정상적으로 동작합니다. 그러나 `dest`의 크기가 `src`보다 작은 경우엔 `sizeof(dest)-1`을 넣어야 정상적으로 동작합니다.
- 다른 `strncpy` 함수 사용처에서 `sizeof(dest)`를 그대로 이용하는 곳은 별도로 수정하여 PR 남기겠습니다.