### PR TITLE
CLEANUP: Change strncpy(dest, src, sizeof(dest)) and strncpy(dest, src, sizeof(src)) to strncpy(dest, src, sizeof(dest)-1)

### DIFF
--- a/libmemcached/arcus.cc
+++ b/libmemcached/arcus.cc
@@ -288,7 +288,7 @@ static inline arcus_return_t do_arcus_proxy_create(memcached_st *mc,
   void *mapped_addr;
   arcus_st *arcus= static_cast<arcus_st *>(memcached_get_server_manager(mc));
 
-  strncpy(arcus->proxy.name, name, 256);
+  strncpy(arcus->proxy.name, name, 255);
   arcus->is_proxy= true;
 
   /* Mmap */
@@ -333,7 +333,7 @@ static inline arcus_return_t do_arcus_proxy_connect(memcached_st *mc,
   arcus_st *arcus= static_cast<arcus_st *>(memcached_get_server_manager(mc));
   arcus_st *proxy_arcus= static_cast<arcus_st *>(memcached_get_server_manager(proxy));
 
-  strncpy(arcus->proxy.name, proxy_arcus->proxy.name, 256);
+  strncpy(arcus->proxy.name, proxy_arcus->proxy.name, 255);
   arcus->proxy.data= proxy_arcus->proxy.data;
   arcus->pool = pool;
 #ifdef ENABLE_REPLICATION
@@ -1153,7 +1153,7 @@ static inline void do_arcus_zk_update_cachelist_by_string(memcached_st *mc,
     return;
   }
 
-  strncpy(buffer, serverlist, ARCUS_MAX_PROXY_FILE_LENGTH);
+  strncpy(buffer, serverlist, ARCUS_MAX_PROXY_FILE_LENGTH-1);
 
   /* Parse the cache server list strings. */
   if (size > 0) {

--- a/libmemcached/connect.cc
+++ b/libmemcached/connect.cc
@@ -357,7 +357,7 @@ static memcached_return_t unix_socket_connect(memcached_server_st *server)
 
   memset(&servAddr, 0, sizeof (struct sockaddr_un));
   servAddr.sun_family= AF_UNIX;
-  strncpy(servAddr.sun_path, server->hostname, sizeof(servAddr.sun_path)); /* Copy filename */
+  strncpy(servAddr.sun_path, server->hostname, sizeof(servAddr.sun_path)-1); /* Copy filename */
 
   do {
     if (connect(server->fd, (struct sockaddr *)&servAddr, sizeof(servAddr)) < 0)

--- a/libmemcached/fetch.cc
+++ b/libmemcached/fetch.cc
@@ -125,7 +125,7 @@ char *memcached_fetch(memcached_st *ptr, char *key, size_t *key_length,
 
       return NULL;
     }
-    strncpy(key, result_buffer->item_key, result_buffer->key_length); // For the binary protocol we will cut off the key :(
+    strncpy(key, result_buffer->item_key, MEMCACHED_MAX_KEY-1); // For the binary protocol we will cut off the key :(
     if (key_length)
       *key_length= result_buffer->key_length;
   }

--- a/libmemcached/hash.cc
+++ b/libmemcached/hash.cc
@@ -116,8 +116,8 @@ static inline uint32_t _generate_hash_wrapper(const memcached_st *ptr, const cha
     if (temp_length > MEMCACHED_MAX_KEY -1)
       return 0;
 
-    strncpy(temp, memcached_array_string(ptr->_namespace), memcached_array_size(ptr->_namespace));
-    strncpy(temp + memcached_array_size(ptr->_namespace), key, key_length);
+    strncpy(temp, memcached_array_string(ptr->_namespace), MEMCACHED_MAX_KEY-1);
+    strncpy(temp + memcached_array_size(ptr->_namespace), key, MEMCACHED_MAX_KEY-1);
 
     return generate_hash(ptr, temp, temp_length);
   }

--- a/libmemcached/sasl.cc
+++ b/libmemcached/sasl.cc
@@ -341,7 +341,7 @@ memcached_return_t memcached_set_sasl_auth_data(memcached_st *ptr,
 
   callbacks[0].id= SASL_CB_USER;
   callbacks[0].proc= (int (*)())get_username;
-  callbacks[0].context= strncpy(name, username, username_length +1);
+  callbacks[0].context= strncpy(name, username, username_length);
   callbacks[1].id= SASL_CB_AUTHNAME;
   callbacks[1].proc= (int (*)())get_username;
   callbacks[1].context= name;
@@ -453,7 +453,7 @@ memcached_return_t memcached_clone_sasl(memcached_st *clone, const  memcached_st
   {
     if (callbacks[x].id == SASL_CB_USER || callbacks[x].id == SASL_CB_AUTHNAME)
     {
-      callbacks[x].context= (sasl_callback_t*)libmemcached_malloc(clone, strlen((const char*)source->sasl.callbacks[x].context));
+      callbacks[x].context= (sasl_callback_t*)libmemcached_malloc(clone, strlen((const char*)source->sasl.callbacks[x].context)+1);
 
       if (callbacks[x].context == NULL)
       {
@@ -466,7 +466,7 @@ memcached_return_t memcached_clone_sasl(memcached_st *clone, const  memcached_st
         libmemcached_free(clone, callbacks);
         return MEMCACHED_MEMORY_ALLOCATION_FAILURE;
       }
-      strncpy((char*)callbacks[x].context, (const char*)source->sasl.callbacks[x].context, sizeof(callbacks[x].context));
+      strncpy((char*)callbacks[x].context, (const char*)source->sasl.callbacks[x].context, strlen((const char*)source->sasl.callbacks[x].context));
     }
     else
     {

--- a/tests/mem_functions.cc
+++ b/tests/mem_functions.cc
@@ -837,7 +837,7 @@ static memcached_return_t  server_function(const memcached_st *ptr,
 static test_return_t memcached_server_cursor_test(memcached_st *memc)
 {
   char context[10];
-  strncpy(context, "foo bad", sizeof(context));
+  strncpy(context, "foo bad", sizeof(context)-1);
   memcached_server_fn callbacks[1];
 
   callbacks[0]= server_function;
@@ -4005,12 +4005,12 @@ static test_return_t selection_of_namespace_tests(memcached_st *memc)
 
     /* Test a long key for failure */
     /* TODO, extend test to determine based on setting, what result should be */
-    strncpy(long_key, "Thisismorethentheallottednumberofcharacters", sizeof(long_key));
+    strncpy(long_key, "Thisismorethentheallottednumberofcharacters", sizeof(long_key)-1);
     test_compare(MEMCACHED_SUCCESS,
                  memcached_callback_set(memc, MEMCACHED_CALLBACK_NAMESPACE, long_key));
 
     /* Now test a key with spaces (which will fail from long key, since bad key is not set) */
-    strncpy(long_key, "This is more then the allotted number of characters", sizeof(long_key));
+    strncpy(long_key, "This is more then the allotted number of characters", sizeof(long_key)-1);
     test_compare(memcached_behavior_get(memc, MEMCACHED_BEHAVIOR_BINARY_PROTOCOL) ? MEMCACHED_SUCCESS : MEMCACHED_BAD_KEY_PROVIDED,
                  memcached_callback_set(memc, MEMCACHED_CALLBACK_NAMESPACE, long_key));
 


### PR DESCRIPTION
https://github.com/naver/arcus-c-client/pull/198#issue-1091387600
테스트 결과 바탕으로 strncpy(dest, src, sizeof(dest))와 strncpy(dest, src, sizeof(src))를 strncpy(dest, src, sizeof(dest)-1)로 수정했습니다.