### PR TITLE
CLEANUP: Fix warning -Wunused-function #190

### DIFF
--- a/example/byteorder.cc
+++ b/example/byteorder.cc
@@ -41,6 +41,20 @@
 
 #include <example/byteorder.h>
 
+#ifdef HAVE_HTONLL
+
+uint64_t example_ntohll(uint64_t value)
+{
+  return ntohll(value);
+}
+
+uint64_t example_htonll(uint64_t value)
+{
+  return htonll(value);
+}
+
+#else // HAVE_HTONLL
+
 /* Byte swap a 64-bit number. */
 #ifndef swap64
 static inline uint64_t swap64(uint64_t in)
@@ -61,20 +75,6 @@ static inline uint64_t swap64(uint64_t in)
 #endif // WORDS_BIGENDIAN
 }
 #endif
-
-#ifdef HAVE_HTONLL
-
-uint64_t example_ntohll(uint64_t value)
-{
-  return ntohll(value);
-}
-
-uint64_t example_htonll(uint64_t value)
-{
-  return htonll(value);
-}
-
-#else // HAVE_HTONLL
 
 uint64_t example_ntohll(uint64_t value)
 {


### PR DESCRIPTION
https://github.com/naver/arcus-c-client/issues/190#issuecomment-1002869511
기존 2번 워닝 수정을 `libmemcached/byteorder.cc` 파일에만 적용했으나 `example/byteorder.cc` 파일에도 같은 워닝이 있다는 것을 뒤늦게 알게 되었습니다.