### PR TITLE
CLEANUP: Fix warning -Wvisibility #190

### DIFF
--- a/libmemcached/memcached.h
+++ b/libmemcached/memcached.h
@@ -94,10 +94,10 @@
 #include <libmemcached/quit.h>
 #include <libmemcached/result.h>
 #include <libmemcached/server.h>
-#include <libmemcached/server_list.h>
 #ifdef ENABLE_REPLICATION
 #include <libmemcached/rgroup.h>
 #endif
+#include <libmemcached/server_list.h>
 #include <libmemcached/storage.h>
 #include <libmemcached/strerror.h>
 #include <libmemcached/verbosity.h>


### PR DESCRIPTION
https://github.com/naver/arcus-c-client/issues/190#issuecomment-1016272432

- rgroup.h 파일에서 워닝이 뜨지 않는 점에서 `#include <libmemcached/rgroup.h>`가 실행되는 시점에서는 memcached_server_info 구조체 정보가 주어진 것으로 판단했습니다.
- memcached_server_info 구조체 정보가 주어져야 하는 server_list.h 파일의 `#include <libmemcached/server_list.h>` 수행을 `#include <libmemcached/rgroup.h>` 뒤로 미뤘습니다.
- 해당 조치 취하자 워닝이 뜨지 않게 되었습니다.