### PR TITLE
CLEANUP: check __server_create_with() return NULL.

### DIFF
--- a/libmemcached/memcached.cc
+++ b/libmemcached/memcached.cc
@@ -554,9 +554,9 @@ do_memcached_update_grouplist(memcached_st *mc,
   ZOO_LOG_INFO(("__do_arcus_update_grouplist: count=%u\n", servercount));
   for (x= 0; x < servercount; x++) {
     ZOO_LOG_INFO(("server[%u] groupname=%s %s hostname=%s port=%u\n",
-            x, serverinfo[x].groupname, 
+            x, serverinfo[x].groupname,
             serverinfo[x].master ? "master" : "slave",
-            serverinfo[x].hostname, 
+            serverinfo[x].hostname,
             serverinfo[x].port));
   }
 
@@ -602,7 +602,7 @@ do_memcached_update_grouplist(memcached_st *mc,
       }
       rc= memcached_rgroup_push_with_groupinfo(mc, groupinfo, groupcount);
     } else {
-      assert(prune_flag); 
+      assert(prune_flag);
       memcached_rgroup_prune(mc, false); /* prune dead rgroups only */
       rc= run_distribution(mc);
     }
@@ -703,13 +703,13 @@ do_memcached_update_grouplist_with_master(memcached_st *mc, memcached_st *master
     return memcached_rgroup_push(mc, master->rgroups, memcached_server_count(master));
   }
 
-  /* compare member mc with master mc */ 
+  /* compare member mc with master mc */
   prune_flag= false;
   y= 0;
   for (x= 0; x < memcached_server_count(mc); x++)
   {
     if (y < memcached_server_count(master) and
-        strcmp(mc->rgroups[x].groupname, master->rgroups[y].groupname) == 0) 
+        strcmp(mc->rgroups[x].groupname, master->rgroups[y].groupname) == 0)
     {
       memcached_rgroup_update(&mc->rgroups[x], &master->rgroups[y]);
       y++;

--- a/libmemcached/rgroup.cc
+++ b/libmemcached/rgroup.cc
@@ -194,6 +194,10 @@ do_rgroup_server_insert(memcached_rgroup_st *rgroup, int sindex,
   assert(server != NULL);
   server= __server_create_with(rgroup->root, server, _hostname, port, 0,
                                MEMCACHED_CONNECTION_TCP);
+  if (server == NULL) {
+    do_rgroup_server_free(rgroup->root, server);
+    return;
+  }
   /* set group index */
   server->groupindex= (int32_t)rgroup->groupindex;
 
@@ -252,6 +256,10 @@ do_rgroup_server_replace(memcached_rgroup_st *rgroup, int sindex,
   assert(new_server != NULL);
   new_server= __server_create_with(rgroup->root, new_server, _hostname, port, 0,
                                    MEMCACHED_CONNECTION_TCP);
+  if (new_server == NULL) {
+    do_rgroup_server_free(rgroup->root, new_server);
+    return;
+  }
   /* set group index */
   new_server->groupindex= (int32_t)rgroup->groupindex;
 


### PR DESCRIPTION
__server_create_with() 에서 NULL 리턴하는 지를 검사하고 사용합니다. 
NULL 리턴하는 경우는 hostname invalid 한 경우 밖에 없는데 (server allocation 은 이미 한 상태이므로) 서버에서 hostname valid 를 확인하고 znode 를 생성하기 때문에 NULL 리턴할 일은 없을 것 같아 assert 로 두어도 될 것 같긴 합니다.