### PR TITLE
CLEANUP: ignore variadic-macro compile warning.

### DIFF
--- a/m4/pandora_warnings.m4
+++ b/m4/pandora_warnings.m4
@@ -156,7 +156,7 @@ AC_DEFUN([PANDORA_WARNINGS],[
         [ac_cv_safe_to_use_Wextra_=no])
       CFLAGS="$save_CFLAGS"])
 
-      BASE_WARNINGS="${W_FAIL} -pedantic -Wall -Wundef -Wshadow ${NO_UNUSED} ${F_DIAGNOSTICS_SHOW_OPTION} ${F_LOOP_PARALLELIZE_ALL} ${BASE_WARNINGS_FULL}"
+      BASE_WARNINGS="${W_FAIL} -pedantic -Wall -Wundef -Wshadow -Wno-variadic-macros ${NO_UNUSED} ${F_DIAGNOSTICS_SHOW_OPTION} ${F_LOOP_PARALLELIZE_ALL} ${BASE_WARNINGS_FULL}"
       AS_IF([test "$ac_cv_safe_to_use_Wextra_" = "yes"],
             [BASE_WARNINGS="${BASE_WARNINGS} -Wextra"],
             [BASE_WARNINGS="${BASE_WARNINGS} -W"])


### PR DESCRIPTION
[C Client] compile 이슈 (with ZooKeeper 3.5.X library) https://github.com/jam2in/arcus-works/issues/294

variadic-macro compile warning 을 발생시킨 컴파일 옵션은 pedantic 입니다. 
pedantic 은 ISO C 표준이 아닌 기능을 사용하였을 때 warning 을 발생시킵니다.
variadic-macro 는 표준에서 extension 된 기능 중 하나로 pedantic 이 검사하는 목록을 아래 링크에서 확인할 수 있습니다.
https://gcc.gnu.org/onlinedocs/gcc-8.4.0/gcc/C-Extensions.html#C-Extensions

variadic-macro warning 은 ignore 하도록 -Wno-variadic-macros 을 추가하였습니다.