### PR TITLE
INTERNAL: Remove #pragma once #233

### DIFF
--- a/clients/client_options.h
+++ b/clients/client_options.h
@@ -9,7 +9,8 @@
  *
  */
 
-#pragma once
+#ifndef __CLIENTS_CLIENT_OPTIONS_H__
+#define __CLIENTS_CLIENT_OPTIONS_H__
 
 typedef struct memcached_help_text_st memcached_help_text_st;
 
@@ -41,3 +42,5 @@ enum memcached_options {
   OPT_QUIET,
   OPT_FILE= 'f'
 };
+
+#endif /* __CLIENTS_CLIENT_OPTIONS_H__ */

--- a/clients/execute.h
+++ b/clients/execute.h
@@ -9,7 +9,8 @@
  *
  */
 
-#pragma once 
+#ifndef __CLIENTS_EXECUTE_H__
+#define __CLIENTS_EXECUTE_H__
 
 #include <stdio.h>
 
@@ -28,3 +29,5 @@ unsigned int execute_mget(memcached_st *memc, const char * const *keys, size_t *
 #ifdef __cplusplus
 } // extern "C"
 #endif
+
+#endif /* __CLIENTS_EXECUTE_H__ */

--- a/clients/generator.h
+++ b/clients/generator.h
@@ -13,7 +13,8 @@
   Code to generate data to be pushed into memcached
 */
 
-#pragma once
+#ifndef __CLIENTS_GENERATOR_H__
+#define __CLIENTS_GENERATOR_H__
 
 typedef struct pairs_st pairs_st;
 
@@ -34,3 +35,5 @@ void pairs_free(pairs_st *pairs);
 #ifdef __cplusplus
 } // extern "C"
 #endif
+
+#endif /* __CLIENTS_GENERATOR_H__ */

--- a/clients/utilities.h
+++ b/clients/utilities.h
@@ -9,7 +9,8 @@
  *
  */
 
-#pragma once
+#ifndef __CLIENTS_UTILITIES_H__
+#define __CLIENTS_UTILITIES_H__
 
 #include <getopt.h>
 #include <libmemcached/memcached.h>
@@ -63,3 +64,5 @@ void close_stdio(void);
 #ifdef __cplusplus
 } // extern "C"
 #endif
+
+#endif /* __CLIENTS_UTILITIES_H__ */

--- a/example/byteorder.h
+++ b/example/byteorder.h
@@ -34,7 +34,8 @@
  *
  */
 
-#pragma once
+#ifndef __EXAMPLE_BYTEORDER_H__
+#define __EXAMPLE_BYTEORDER_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,3 +48,5 @@ uint64_t example_htonll(uint64_t);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __EXAMPLE_BYTEORDER_H__ */

--- a/libhashkit/algorithm.h
+++ b/libhashkit/algorithm.h
@@ -11,7 +11,8 @@
  * @brief HashKit Header
  */
 
-#pragma once
+#ifndef __LIBHASHKIT_ALGORITHM_H__
+#define __LIBHASHKIT_ALGORITHM_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -83,3 +84,5 @@ void libhashkit_md5_signature(const unsigned char *key, size_t length, unsigned 
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBHASHKIT_ALGORITHM_H__ */

--- a/libhashkit/behavior.h
+++ b/libhashkit/behavior.h
@@ -11,7 +11,8 @@
  * @brief HashKit Header
  */
 
-#pragma once
+#ifndef __LIBHASHKIT_BEHAVIOR_H__
+#define __LIBHASHKIT_BEHAVIOR_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -21,3 +22,5 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBHASHKIT_BEHAVIOR_H__ */

--- a/libhashkit/common.h
+++ b/libhashkit/common.h
@@ -6,7 +6,8 @@
  * the COPYING file in the parent directory for full text.
  */
 
-#pragma once
+#ifndef __LIBHASHKIT_COMMON_H__
+#define __LIBHASHKIT_COMMON_H__
 
 #include <config.h>
 
@@ -31,3 +32,5 @@ int update_continuum(hashkit_st *hashkit);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBHASHKIT_COMMON_H__ */

--- a/libhashkit/configure.h.in
+++ b/libhashkit/configure.h.in
@@ -6,7 +6,8 @@
  * the COPYING file in the parent directory for full text.
  */
 
-#pragma once
+#ifndef __LIBHASHKIT_CONFIGURE_H_IN__
+#define __LIBHASHKIT_CONFIGURE_H_IN__
 
 #ifdef __cplusplus
 extern "C" {
@@ -15,3 +16,5 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBHASHKIT_CONFIGURE_H_IN__ */

--- a/libhashkit/digest.h
+++ b/libhashkit/digest.h
@@ -6,7 +6,8 @@
  * the COPYING file in the parent directory for full text.
  */
 
-#pragma once
+#ifndef __LIBHASHKIT_DIGEST_H__
+#define __LIBHASHKIT_DIGEST_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,3 +26,5 @@ uint32_t libhashkit_digest(const char *key, size_t key_length, hashkit_hash_algo
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBHASHKIT_DIGEST_H__ */

--- a/libhashkit/has.h
+++ b/libhashkit/has.h
@@ -34,7 +34,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBHASHKIT_HAS_H__
+#define __LIBHASHKIT_HAS_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,3 +47,5 @@ bool libhashkit_has_algorithm(const hashkit_hash_algorithm_t);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBHASHKIT_HAS_H__ */

--- a/libhashkit/hashkit.h
+++ b/libhashkit/hashkit.h
@@ -36,8 +36,9 @@
  */
 
 
-#pragma once
 
+#ifndef __LIBHASHKIT_HASHKIT_H__
+#define __LIBHASHKIT_HASHKIT_H__
 
 #if !defined(__cplusplus)
 # include <stdbool.h>
@@ -94,3 +95,5 @@ void hashkit_free(hashkit_st *hash);
 #ifdef __cplusplus
 } // extern "C"
 #endif
+
+#endif /* __LIBHASHKIT_HASHKIT_H__ */

--- a/libhashkit/hashkit.hpp
+++ b/libhashkit/hashkit.hpp
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBHASHKIT_HASHKIT_HPP__
+#define __LIBHASHKIT_HASHKIT_HPP__
 
 #include <libhashkit/hashkit.h>
 #include <string>
@@ -95,3 +96,5 @@ private:
 
   hashkit_st self;
 };
+
+#endif /* __LIBHASHKIT_HASHKIT_HPP__ */

--- a/libhashkit/str_algorithm.h
+++ b/libhashkit/str_algorithm.h
@@ -34,7 +34,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBHASHKIT_STR_ALGORITHM_H__
+#define __LIBHASHKIT_STR_ALGORITHM_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,3 +47,5 @@ const char *libhashkit_string_hash(hashkit_hash_algorithm_t type);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBHASHKIT_STR_ALGORITHM_H__ */

--- a/libhashkit/types.h
+++ b/libhashkit/types.h
@@ -36,7 +36,8 @@
  */
 
 
-#pragma once
+#ifndef __LIBHASHKIT_TYPES_H__
+#define __LIBHASHKIT_TYPES_H__
 
 typedef enum {
   HASHKIT_SUCCESS,
@@ -94,3 +95,5 @@ typedef uint32_t (*hashkit_hash_fn)(const char *key, size_t key_length, void *co
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBHASHKIT_TYPES_H__ */

--- a/libhashkit/visibility.h
+++ b/libhashkit/visibility.h
@@ -13,7 +13,8 @@
  * @brief Visibility control macros
  */
 
-#pragma once
+#ifndef __LIBHASHKIT_VISIBILITY_H__
+#define __LIBHASHKIT_VISIBILITY_H__
 
 /**
  *
@@ -46,3 +47,5 @@
 #  define HASHKIT_LOCAL
 # endif /* defined(_MSC_VER) */
 #endif /* defined(BUILDING_HASHKIT) */
+
+#endif /* __LIBHASHKIT_VISIBILITY_H__ */

--- a/libmemcached/allocators.h
+++ b/libmemcached/allocators.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_ALLOCATORS_H__
+#define __LIBMEMCACHED_ALLOCATORS_H__
 
 struct memcached_allocator_t {
   memcached_calloc_fn calloc;
@@ -85,3 +86,5 @@ struct memcached_allocator_t memcached_allocators_return_default(void);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_ALLOCATORS_H__ */

--- a/libmemcached/analyze.h
+++ b/libmemcached/analyze.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_ANALYZE_H__
+#define __LIBMEMCACHED_ANALYZE_H__
 
 struct memcached_analysis_st {
   memcached_st *root;
@@ -64,3 +65,5 @@ void memcached_analyze_free(memcached_analysis_st *);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_ANALYZE_H__ */

--- a/libmemcached/array.h
+++ b/libmemcached/array.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_ARRAY_H__
+#define __LIBMEMCACHED_ARRAY_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -73,3 +74,5 @@ bool memcached_array_is_null(memcached_array_st *array);
 #define memcached_print_array(X) (int)memcached_array_size((X)), memcached_array_string((X))
 #define memcached_param_array(X) memcached_array_string(X), memcached_array_size(X)
 #endif
+
+#endif /* __LIBMEMCACHED_ARRAY_H__ */

--- a/libmemcached/assert.hpp
+++ b/libmemcached/assert.hpp
@@ -51,7 +51,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_ASSERT_HPP__
+#define __LIBMEMCACHED_ASSERT_HPP__
 
 #include <cstdlib>
 #include <cstdio>
@@ -79,3 +80,5 @@ if (not (__expr)) \
   fprintf(stderr, "\nAssertion \"%s\" failed for function \"%s\" likely for %s, at %s:%d\n", #__expr, __func__, (#__mesg),  __FILE__, __LINE__);\
   return ret; \
 }
+
+#endif /* __LIBMEMCACHED_ASSERT_HPP__ */

--- a/libmemcached/auto.h
+++ b/libmemcached/auto.h
@@ -51,7 +51,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_AUTO_H__
+#define __LIBMEMCACHED_AUTO_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -129,3 +130,5 @@ LIBMEMCACHED_API
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_AUTO_H__ */

--- a/libmemcached/backtrace.hpp
+++ b/libmemcached/backtrace.hpp
@@ -35,7 +35,10 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_BACKTRACE_HPP__
+#define __LIBMEMCACHED_BACKTRACE_HPP__
 
 LIBMEMCACHED_LOCAL
 void custom_backtrace(void);
+
+#endif /* __LIBMEMCACHED_BACKTRACE_HPP__ */

--- a/libmemcached/basic_string.h
+++ b/libmemcached/basic_string.h
@@ -34,7 +34,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_BASIC_STRING_H__
+#define __LIBMEMCACHED_BASIC_STRING_H__
 
 // No assumptions of NULL should be made
 
@@ -53,3 +54,4 @@ struct memcached_string_t {
 #define memcached_string_printf(X) (int)((X).size), (X).c_str
 #endif
 
+#endif /* __LIBMEMCACHED_BASIC_STRING_H__ */

--- a/libmemcached/behavior.h
+++ b/libmemcached/behavior.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_BEHAVIOR_H__
+#define __LIBMEMCACHED_BEHAVIOR_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -84,3 +85,5 @@ LIBMEMCACHED_API
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_BEHAVIOR_H__ */

--- a/libmemcached/byteorder.h
+++ b/libmemcached/byteorder.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_BYTEORDER_H__
+#define __LIBMEMCACHED_BYTEORDER_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,3 +51,5 @@ uint64_t memcached_htonll(uint64_t);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_BYTEORDER_H__ */

--- a/libmemcached/callback.h
+++ b/libmemcached/callback.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_CALLBACK_H__
+#define __LIBMEMCACHED_CALLBACK_H__
 
 struct memcached_callback_st {
   memcached_execute_fn *callback;
@@ -59,3 +60,5 @@ void *memcached_callback_get(memcached_st *ptr,
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_CALLBACK_H__ */

--- a/libmemcached/common.h
+++ b/libmemcached/common.h
@@ -56,7 +56,8 @@
   Common include file for libmemached
 */
 
-#pragma once
+#ifndef __LIBMEMCACHED_COMMON_H__
+#define __LIBMEMCACHED_COMMON_H__
 
 #include <config.h>
 
@@ -213,3 +214,5 @@ static inline memcached_return_t memcached_validate_key_length(size_t key_length
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_COMMON_H__ */

--- a/libmemcached/configure.h.in
+++ b/libmemcached/configure.h.in
@@ -51,7 +51,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_CONFIGURE_H_IN__
+#define __LIBMEMCACHED_CONFIGURE_H_IN__
 
 #ifdef __cplusplus
 extern "C" {
@@ -67,3 +68,5 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_CONFIGURE_H_IN__ */

--- a/libmemcached/constants.h
+++ b/libmemcached/constants.h
@@ -52,7 +52,8 @@
  */
 
 
-#pragma once
+#ifndef __LIBMEMCACHED_CONSTANTS_H__
+#define __LIBMEMCACHED_CONSTANTS_H__
 
 #ifdef LIBMEMCACHED_WITH_ZK_INTEGRATION
 #define ENABLE_REPLICATION 1
@@ -202,3 +203,5 @@ enum {
 #ifndef __cplusplus
 typedef enum memcached_connection_t memcached_connection_t;
 #endif
+
+#endif /* __LIBMEMCACHED_CONSTANTS_H__ */

--- a/libmemcached/continuum.hpp
+++ b/libmemcached/continuum.hpp
@@ -36,7 +36,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_CONTINUUM_HPP__
+#define __LIBMEMCACHED_CONTINUUM_HPP__
 
 /* string value */
 struct memcached_continuum_item_st
@@ -50,3 +51,5 @@ struct memcached_ketama_info_st {
   uint32_t continuum_points_counter;
   memcached_continuum_item_st *continuum;
 };
+
+#endif /* __LIBMEMCACHED_CONTINUUM_HPP__ */

--- a/libmemcached/csl/common.h
+++ b/libmemcached/csl/common.h
@@ -35,7 +35,9 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_CSL_COMMON_H__
+#define __LIBMEMCACHED_CSL_COMMON_H__
 
 #include <libmemcached/common.h>
 
+#endif /* __LIBMEMCACHED_CSL_COMMON_H__ */

--- a/libmemcached/csl/context.h
+++ b/libmemcached/csl/context.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_CSL_CONTEXT_H__
+#define __LIBMEMCACHED_CSL_CONTEXT_H__
 
 #include <libmemcached/csl/common.h>
 #include <libmemcached/csl/parser.h>
@@ -123,3 +124,5 @@ private:
   bool _end;
   char _hostname[NI_MAXHOST];
 }; 
+
+#endif /* __LIBMEMCACHED_CSL_CONTEXT_H__ */

--- a/libmemcached/csl/server.h
+++ b/libmemcached/csl/server.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_CSL_SERVER_H__
+#define __LIBMEMCACHED_CSL_SERVER_H__
 
 #include <cstdlib>
 #include <arpa/inet.h>
@@ -47,3 +48,5 @@ struct server_t
   const char *c_str;
   size_t size;
 };
+
+#endif /* __LIBMEMCACHED_CSL_SERVER_H__ */

--- a/libmemcached/csl/symbol.h
+++ b/libmemcached/csl/symbol.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_CSL_SYMBOL_H__
+#define __LIBMEMCACHED_CSL_SYMBOL_H__
 
 #include <libmemcached/basic_string.h>
 #include <libmemcached/constants.h>
@@ -55,3 +56,5 @@ union YYSTYPE
 };
 
 typedef union YYSTYPE YYSTYPE;
+
+#endif /* __LIBMEMCACHED_CSL_SYMBOL_H__ */

--- a/libmemcached/delete.h
+++ b/libmemcached/delete.h
@@ -36,7 +36,8 @@
  */
 
 
-#pragma once
+#ifndef __LIBMEMCACHED_DELETE_H__
+#define __LIBMEMCACHED_DELETE_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -55,3 +56,5 @@ memcached_return_t memcached_delete_by_key(memcached_st *ptr,
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_DELETE_H__ */

--- a/libmemcached/do.hpp
+++ b/libmemcached/do.hpp
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_DO_HPP__
+#define __LIBMEMCACHED_DO_HPP__
 
 LIBMEMCACHED_LOCAL
 memcached_return_t memcached_do(memcached_server_write_instance_st ptr,
@@ -47,3 +48,5 @@ LIBMEMCACHED_LOCAL
 memcached_return_t memcached_vdo(memcached_server_write_instance_st ptr,
                                  const struct libmemcached_io_vector_st *vector, size_t count,
                                  bool with_flush);
+
+#endif /* __LIBMEMCACHED_DO_HPP__ */

--- a/libmemcached/dump.h
+++ b/libmemcached/dump.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_DUMP_H__
+#define __LIBMEMCACHED_DUMP_H__
 
 
 #ifdef __cplusplus
@@ -49,3 +50,5 @@ memcached_return_t memcached_dump(memcached_st *ptr, memcached_dump_fn *function
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_DUMP_H__ */

--- a/libmemcached/error.h
+++ b/libmemcached/error.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_ERROR_H__
+#define __LIBMEMCACHED_ERROR_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -67,3 +68,5 @@ LIBMEMCACHED_API
 #ifdef __cplusplus
 } // extern "C"
 #endif
+
+#endif /* __LIBMEMCACHED_ERROR_H__ */

--- a/libmemcached/error.hpp
+++ b/libmemcached/error.hpp
@@ -37,7 +37,8 @@
 
 #include <libmemcached/error.h>
 
-#pragma once
+#ifndef __LIBMEMCACHED_ERROR_HPP__
+#define __LIBMEMCACHED_ERROR_HPP__
 
 #ifdef __cplusplus
 
@@ -102,3 +103,5 @@ LIBMEMCACHED_LOCAL
 memcached_error_t *memcached_error_copy(const memcached_server_st&);
 
 #endif
+
+#endif /* __LIBMEMCACHED_ERROR_HPP__ */

--- a/libmemcached/exception.hpp
+++ b/libmemcached/exception.hpp
@@ -10,7 +10,8 @@
  * @brief Exception declarations
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_EXCEPTION_HPP__
+#define __LIBMEMCACHED_EXCEPTION_HPP__
 
 #include <stdexcept>
 #include <string>
@@ -58,3 +59,5 @@ namespace memcache
   };
 
 } /* namespace libmemcached */
+
+#endif /* __LIBMEMCACHED_EXCEPTION_HPP__ */

--- a/libmemcached/exist.h
+++ b/libmemcached/exist.h
@@ -34,10 +34,13 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_EXIST_H__
+#define __LIBMEMCACHED_EXIST_H__
 
 memcached_return_t memcached_exist(memcached_st *memc, const char *key, size_t key_length);
 
 memcached_return_t memcached_exist_by_key(memcached_st *memc,
                                           const char *group_key, size_t group_key_length,
                                           const char *key, size_t key_length);
+
+#endif /* __LIBMEMCACHED_EXIST_H__ */

--- a/libmemcached/fetch.h
+++ b/libmemcached/fetch.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_FETCH_H__
+#define __LIBMEMCACHED_FETCH_H__
 
 
 #ifdef __cplusplus
@@ -51,3 +52,5 @@ memcached_return_t memcached_fetch_execute(memcached_st *ptr,
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_FETCH_H__ */

--- a/libmemcached/flush.h
+++ b/libmemcached/flush.h
@@ -51,7 +51,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_FLUSH_H__
+#define __LIBMEMCACHED_FLUSH_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -68,3 +69,5 @@ memcached_return_t memcached_flush_by_prefix(memcached_st *ptr,
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_FLUSH_H__ */

--- a/libmemcached/flush_buffers.h
+++ b/libmemcached/flush_buffers.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_FLUSH_BUFFERS_H__
+#define __LIBMEMCACHED_FLUSH_BUFFERS_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,3 +48,5 @@ memcached_return_t memcached_flush_buffers(memcached_st *mem);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_FLUSH_BUFFERS_H__ */

--- a/libmemcached/get.h
+++ b/libmemcached/get.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_GET_H__
+#define __LIBMEMCACHED_GET_H__
 
 
 #ifdef __cplusplus
@@ -108,3 +109,5 @@ memcached_return_t memcached_mget_execute_by_key(memcached_st *ptr,
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_GET_H__ */

--- a/libmemcached/hash.h
+++ b/libmemcached/hash.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_HASH_H__
+#define __LIBMEMCACHED_HASH_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,3 +67,5 @@ LIBMEMCACHED_API
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_HASH_H__ */

--- a/libmemcached/initialize_query.h
+++ b/libmemcached/initialize_query.h
@@ -50,7 +50,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_INITIALIZE_QUERY_H__
+#define __LIBMEMCACHED_INITIALIZE_QUERY_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -71,3 +72,5 @@ memcached_return_t before_query(memcached_st *self,
 #ifdef __cplusplus
 } // extern "C"
 #endif
+
+#endif /* __LIBMEMCACHED_INITIALIZE_QUERY_H__ */

--- a/libmemcached/internal.h
+++ b/libmemcached/internal.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_INTERNAL_H__
+#define __LIBMEMCACHED_INTERNAL_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -44,3 +45,5 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_INTERNAL_H__ */

--- a/libmemcached/io.h
+++ b/libmemcached/io.h
@@ -36,7 +36,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_IO_H__
+#define __LIBMEMCACHED_IO_H__
 
 #define MAX_UDP_DATAGRAM_LENGTH 1400
 #define UDP_DATAGRAM_HEADER_LENGTH 8
@@ -80,3 +81,5 @@ ssize_t memcached_io_writev(memcached_server_write_instance_st ptr,
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_IO_H__ */

--- a/libmemcached/io.hpp
+++ b/libmemcached/io.hpp
@@ -36,7 +36,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_IO_HPP__
+#define __LIBMEMCACHED_IO_HPP__
 
 LIBMEMCACHED_LOCAL
 memcached_return_t memcached_io_wait_for_write(memcached_server_write_instance_st ptr);
@@ -73,3 +74,5 @@ memcached_server_write_instance_st memcached_io_get_readable_server(memcached_st
 
 LIBMEMCACHED_LOCAL
 memcached_return_t memcached_io_slurp(memcached_server_write_instance_st ptr);
+
+#endif /* __LIBMEMCACHED_IO_HPP__ */

--- a/libmemcached/is.h
+++ b/libmemcached/is.h
@@ -51,7 +51,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_IS_H__
+#define __LIBMEMCACHED_IS_H__
 
 /* These are private */ 
 #define memcached_is_allocated(__object) ((__object)->options.is_allocated)
@@ -63,3 +64,5 @@
 #define memcached_set_initialized(__object, __value) ((__object)->options.is_initialized(= (__value))
 #define memcached_set_allocated(__object, __value) ((__object)->options.is_allocated= (__value))
 #define memcached_is_descending(__object) ((__object)->options.is_descending)
+
+#endif /* __LIBMEMCACHED_IS_H__ */

--- a/libmemcached/libmemcached_probes.h
+++ b/libmemcached/libmemcached_probes.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_LIBMEMCACHED_PROBES_H__
+#define __LIBMEMCACHED_LIBMEMCACHED_PROBES_H__
 
 
 /*
@@ -112,3 +113,5 @@
 #define	LIBMEMCACHED_MEMCACHED_SET_START_ENABLED() (0)
 
 #endif
+
+#endif /* __LIBMEMCACHED_LIBMEMCACHED_PROBES_H__ */

--- a/libmemcached/memcached.h
+++ b/libmemcached/memcached.h
@@ -51,7 +51,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_MEMCACHED_H__
+#define __LIBMEMCACHED_MEMCACHED_H__
 
 #include <inttypes.h>
 #include <stdlib.h>
@@ -309,3 +310,5 @@ void memcached_ketama_release(memcached_st *ptr);
 #ifdef __cplusplus
 } // extern "C"
 #endif
+
+#endif /* __LIBMEMCACHED_MEMCACHED_H__ */

--- a/libmemcached/memcached.hpp
+++ b/libmemcached/memcached.hpp
@@ -12,7 +12,8 @@
  * @brief Libmemcached C++ interface
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_MEMCACHED_HPP__
+#define __LIBMEMCACHED_MEMCACHED_HPP__
 
 #include <libmemcached/memcached.h>
 #include <libmemcached/exception.hpp>
@@ -823,3 +824,5 @@ private:
 };
 
 }
+
+#endif /* __LIBMEMCACHED_MEMCACHED_HPP__ */

--- a/libmemcached/memcached_util.h
+++ b/libmemcached/memcached_util.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_MEMCACHED_UTIL_H__
+#define __LIBMEMCACHED_MEMCACHED_UTIL_H__
 
 
 #include <libmemcached/util/pid.h>
@@ -43,3 +44,5 @@
 #include <libmemcached/util/ping.h>
 #include <libmemcached/util/pool.h>
 #include <libmemcached/util/version.h>
+
+#endif /* __LIBMEMCACHED_MEMCACHED_UTIL_H__ */

--- a/libmemcached/memory.h
+++ b/libmemcached/memory.h
@@ -34,7 +34,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_MEMORY_H__
+#define __LIBMEMCACHED_MEMORY_H__
 
 static inline void libmemcached_free(const memcached_st *self, void *mem)
 {
@@ -77,3 +78,5 @@ static inline void *libmemcached_calloc(const memcached_st *self, size_t nelem, 
 
   return calloc(nelem, size);
 }
+
+#endif /* __LIBMEMCACHED_MEMORY_H__ */

--- a/libmemcached/namespace.h
+++ b/libmemcached/namespace.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_NAMESPACE_H__
+#define __LIBMEMCACHED_NAMESPACE_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,3 +51,5 @@ LIBMEMCACHED_API
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_NAMESPACE_H__ */

--- a/libmemcached/options.h
+++ b/libmemcached/options.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_OPTIONS_H__
+#define __LIBMEMCACHED_OPTIONS_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,3 +48,5 @@ LIBMEMCACHED_API
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_OPTIONS_H__ */

--- a/libmemcached/options.hpp
+++ b/libmemcached/options.hpp
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_OPTIONS_HPP__
+#define __LIBMEMCACHED_OPTIONS_HPP__
 
 LIBMEMCACHED_LOCAL
   void memcached_set_configuration_file(memcached_st *self, const char *filename, size_t filename_length);
@@ -54,3 +55,5 @@ LIBMEMCACHED_LOCAL
 
 LIBMEMCACHED_LOCAL
   memcached_return_t memcached_parse_configure_file(memcached_st&, memcached_array_st& filename);
+
+#endif /* __LIBMEMCACHED_OPTIONS_HPP__ */

--- a/libmemcached/parse.h
+++ b/libmemcached/parse.h
@@ -9,7 +9,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_PARSE_H__
+#define __LIBMEMCACHED_PARSE_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -21,3 +22,5 @@ memcached_server_list_st memcached_servers_parse(const char *server_strings);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_PARSE_H__ */

--- a/libmemcached/platform.h
+++ b/libmemcached/platform.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_PLATFORM_H__
+#define __LIBMEMCACHED_PLATFORM_H__
 
 
 #ifdef WIN32
@@ -54,3 +55,5 @@ typedef int memcached_socket_t;
 #include <netinet/tcp.h>
 
 #endif /* WIN32 */
+
+#endif /* __LIBMEMCACHED_PLATFORM_H__ */

--- a/libmemcached/protocol/ascii_handler.h
+++ b/libmemcached/protocol/ascii_handler.h
@@ -34,7 +34,10 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_PROTOCOL_ASCII_HANDLER_H__
+#define __LIBMEMCACHED_PROTOCOL_ASCII_HANDLER_H__
 
 LIBMEMCACHED_LOCAL
 memcached_protocol_event_t memcached_ascii_protocol_process_data(memcached_protocol_client_st *client, ssize_t *length, void **endptr);
+
+#endif /* __LIBMEMCACHED_PROTOCOL_ASCII_HANDLER_H__ */

--- a/libmemcached/protocol/binary_handler.h
+++ b/libmemcached/protocol/binary_handler.h
@@ -34,7 +34,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_PROTOCOL_BINARY_HANDLER_H__
+#define __LIBMEMCACHED_PROTOCOL_BINARY_HANDLER_H__
 
 LIBMEMCACHED_LOCAL
 bool memcached_binary_protocol_pedantic_check_request(const protocol_binary_request_header *request);
@@ -45,3 +46,5 @@ bool memcached_binary_protocol_pedantic_check_response(const protocol_binary_req
 
 LIBMEMCACHED_LOCAL
 memcached_protocol_event_t memcached_binary_protocol_process_data(memcached_protocol_client_st *client, ssize_t *length, void **endptr);
+
+#endif /* __LIBMEMCACHED_PROTOCOL_BINARY_HANDLER_H__ */

--- a/libmemcached/protocol/cache.h
+++ b/libmemcached/protocol/cache.h
@@ -35,7 +35,8 @@
  */
 
 /* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
-#pragma once
+#ifndef __LIBMEMCACHED_PROTOCOL_CACHE_H__
+#define __LIBMEMCACHED_PROTOCOL_CACHE_H__
 
 #include <pthread.h>
 
@@ -146,3 +147,5 @@ void* cache_alloc(cache_t* handle);
  */
 void cache_free(cache_t* handle, void* ptr);
 #endif //  HAVE_UMEM_H
+
+#endif /* __LIBMEMCACHED_PROTOCOL_CACHE_H__ */

--- a/libmemcached/protocol/common.h
+++ b/libmemcached/protocol/common.h
@@ -34,7 +34,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_PROTOCOL_COMMON_H__
+#define __LIBMEMCACHED_PROTOCOL_COMMON_H__
 
 #include "config.h"
 #if !defined(__cplusplus)
@@ -161,3 +162,5 @@ struct memcached_protocol_client_st {
 
 #include "ascii_handler.h"
 #include "binary_handler.h"
+
+#endif /* __LIBMEMCACHED_PROTOCOL_COMMON_H__ */

--- a/libmemcached/protocol_handler.h
+++ b/libmemcached/protocol_handler.h
@@ -11,7 +11,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_PROTOCOL_HANDLER_H__
+#define __LIBMEMCACHED_PROTOCOL_HANDLER_H__
 
 #include <sys/types.h>
 #if !defined(__cplusplus)
@@ -213,3 +214,5 @@ memcached_binary_protocol_raw_response_handler memcached_binary_protocol_get_raw
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_PROTOCOL_HANDLER_H__ */

--- a/libmemcached/quit.h
+++ b/libmemcached/quit.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_QUIT_H__
+#define __LIBMEMCACHED_QUIT_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,3 +54,5 @@ void send_quit(memcached_st *ptr);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_QUIT_H__ */

--- a/libmemcached/response.h
+++ b/libmemcached/response.h
@@ -51,7 +51,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_RESPONSE_H__
+#define __LIBMEMCACHED_RESPONSE_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -81,3 +82,5 @@ memcached_return_t memcached_coll_smget_response(memcached_server_write_instance
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_RESPONSE_H__ */

--- a/libmemcached/result.h
+++ b/libmemcached/result.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_RESULT_H__
+#define __LIBMEMCACHED_RESULT_H__
 
 struct memcached_result_st {
   uint32_t item_flags;
@@ -98,3 +99,5 @@ void memcached_result_set_expiration(memcached_result_st *self, time_t expiratio
 #ifdef __cplusplus
 } // extern "C"
 #endif
+
+#endif /* __LIBMEMCACHED_RESULT_H__ */

--- a/libmemcached/return.h
+++ b/libmemcached/return.h
@@ -50,7 +50,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_RETURN_H__
+#define __LIBMEMCACHED_RETURN_H__
 
 enum memcached_return_t {
   MEMCACHED_SUCCESS,
@@ -183,3 +184,5 @@ static inline bool memcached_fatal(memcached_return_t rc)
 }
 
 #define memcached_continue(__memcached_return_t) ((__memcached_return_t) == MEMCACHED_IN_PROGRESS)
+
+#endif /* __LIBMEMCACHED_RETURN_H__ */

--- a/libmemcached/rgroup.h
+++ b/libmemcached/rgroup.h
@@ -51,7 +51,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_RGROUP_H__
+#define __LIBMEMCACHED_RGROUP_H__
 
 #ifdef ENABLE_REPLICATION
 #define RGROUP_NAME_LENGTH 128
@@ -151,3 +152,5 @@ LIBMEMCACHED_API
 #endif
 
 #endif
+
+#endif /* __LIBMEMCACHED_RGROUP_H__ */

--- a/libmemcached/sasl.h
+++ b/libmemcached/sasl.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_SASL_H__
+#define __LIBMEMCACHED_SASL_H__
 
 #if defined(LIBMEMCACHED_WITH_SASL_SUPPORT) && LIBMEMCACHED_WITH_SASL_SUPPORT
 #include <sasl/sasl.h>
@@ -81,3 +82,5 @@ struct memcached_sasl_st {
  */
   bool is_allocated;
 };
+
+#endif /* __LIBMEMCACHED_SASL_H__ */

--- a/libmemcached/server.h
+++ b/libmemcached/server.h
@@ -36,7 +36,8 @@
  */
 
 
-#pragma once
+#ifndef __LIBMEMCACHED_SERVER_H__
+#define __LIBMEMCACHED_SERVER_H__
 
 #ifndef WIN32
 #include <netdb.h>
@@ -205,3 +206,5 @@ void memcached_server_set_immediate_reconnect(memcached_server_st *ptr);
 #ifdef __cplusplus
 } // extern "C"
 #endif
+
+#endif /* __LIBMEMCACHED_SERVER_H__ */

--- a/libmemcached/server.hpp
+++ b/libmemcached/server.hpp
@@ -51,7 +51,8 @@
  */
 
 
-#pragma once
+#ifndef __LIBMEMCACHED_SERVER_HPP__
+#define __LIBMEMCACHED_SERVER_HPP__
 
 #include <libmemcached/basic_string.h>
 
@@ -132,3 +133,5 @@ LIBMEMCACHED_LOCAL
                                             const in_port_t port,
                                             uint32_t weight,
                                             const memcached_connection_t type);
+
+#endif /* __LIBMEMCACHED_SERVER_HPP__ */

--- a/libmemcached/server_instance.h
+++ b/libmemcached/server_instance.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_SERVER_INSTANCE_H__
+#define __LIBMEMCACHED_SERVER_INSTANCE_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,3 +47,5 @@ typedef struct memcached_server_st * memcached_server_write_instance_st;
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_SERVER_INSTANCE_H__ */

--- a/libmemcached/server_list.h
+++ b/libmemcached/server_list.h
@@ -51,7 +51,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_SERVER_LIST_H__
+#define __LIBMEMCACHED_SERVER_LIST_H__
 
 
 #ifdef __cplusplus
@@ -109,3 +110,5 @@ LIBMEMCACHED_LOCAL
 #ifdef __cplusplus
 } // extern "C"
 #endif
+
+#endif /* __LIBMEMCACHED_SERVER_LIST_H__ */

--- a/libmemcached/stats.h
+++ b/libmemcached/stats.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_STATS_H__
+#define __LIBMEMCACHED_STATS_H__
 
 struct memcached_stat_st {
   unsigned long connection_structures;
@@ -94,3 +95,5 @@ memcached_return_t memcached_stat_execute(memcached_st *memc, const char *args, 
 #ifdef __cplusplus
 } // extern "C"
 #endif
+
+#endif /* __LIBMEMCACHED_STATS_H__ */

--- a/libmemcached/storage.h
+++ b/libmemcached/storage.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_STORAGE_H__
+#define __LIBMEMCACHED_STORAGE_H__
 
 #include "libmemcached/memcached.h"
 
@@ -131,3 +132,5 @@ memcached_return_t memcached_cas_by_key(memcached_st *ptr,
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_STORAGE_H__ */

--- a/libmemcached/strerror.h
+++ b/libmemcached/strerror.h
@@ -36,7 +36,8 @@
  */
 
 
-#pragma once
+#ifndef __LIBMEMCACHED_STRERROR_H__
+#define __LIBMEMCACHED_STRERROR_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,3 +49,5 @@ const char *memcached_strerror(memcached_st *ptr, memcached_return_t rc);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_STRERROR_H__ */

--- a/libmemcached/string.h
+++ b/libmemcached/string.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_STRING_H__
+#define __LIBMEMCACHED_STRING_H__
 
 #include <libmemcached/basic_string.h>
 
@@ -107,3 +108,5 @@ void memcached_string_set_length(memcached_string_st *self, size_t length);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_STRING_H__ */

--- a/libmemcached/string.hpp
+++ b/libmemcached/string.hpp
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_STRING_HPP__
+#define __LIBMEMCACHED_STRING_HPP__
 
 #include "util/string.hpp"
 
@@ -44,4 +45,4 @@
 #define memcached_string_make_from_cstr util_string_make_from_cstr
 #define memcached_array_length util_array_length
 
-
+#endif /* __LIBMEMCACHED_STRING_HPP__ */

--- a/libmemcached/types.h
+++ b/libmemcached/types.h
@@ -52,7 +52,8 @@
  */
 
 
-#pragma once
+#ifndef __LIBMEMCACHED_TYPES_H__
+#define __LIBMEMCACHED_TYPES_H__
 
 typedef struct memcached_st memcached_st;
 typedef struct memcached_stat_st memcached_stat_st;
@@ -150,3 +151,5 @@ typedef memcached_server_fn memcached_server_function;
 typedef memcached_trigger_key_fn memcached_trigger_key;
 typedef memcached_trigger_delete_key_fn memcached_trigger_delete_key;
 typedef memcached_dump_fn memcached_dump_func;
+
+#endif /* __LIBMEMCACHED_TYPES_H__ */

--- a/libmemcached/util.h
+++ b/libmemcached/util.h
@@ -35,6 +35,9 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_UTIL_H__
+#define __LIBMEMCACHED_UTIL_H__
 
 #include <libmemcached/memcached_util.h>
+
+#endif /* __LIBMEMCACHED_UTIL_H__ */

--- a/libmemcached/util/flush.h
+++ b/libmemcached/util/flush.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_UTIL_FLUSH_H__
+#define __LIBMEMCACHED_UTIL_FLUSH_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,3 +49,4 @@ bool libmemcached_util_flush(const char *hostname, in_port_t port, memcached_ret
 }
 #endif
 
+#endif /* __LIBMEMCACHED_UTIL_FLUSH_H__ */

--- a/libmemcached/util/pid.h
+++ b/libmemcached/util/pid.h
@@ -34,7 +34,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_UTIL_PID_H__
+#define __LIBMEMCACHED_UTIL_PID_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,3 +51,4 @@ pid_t libmemcached_util_getpid2(const char *hostname, in_port_t port, const char
 }
 #endif
 
+#endif /* __LIBMEMCACHED_UTIL_PID_H__ */

--- a/libmemcached/util/ping.h
+++ b/libmemcached/util/ping.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_UTIL_PING_H__
+#define __LIBMEMCACHED_UTIL_PING_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,3 +51,5 @@ bool libmemcached_util_ping2(const char *hostname, in_port_t port, const char *u
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_UTIL_PING_H__ */

--- a/libmemcached/util/pool.h
+++ b/libmemcached/util/pool.h
@@ -51,7 +51,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_UTIL_POOL_H__
+#define __LIBMEMCACHED_UTIL_POOL_H__
 
 
 #include <libmemcached/memcached.h>
@@ -148,3 +149,5 @@ uint16_t get_memcached_pool_size(memcached_pool_st* pool);
 #ifdef __cplusplus
 } // extern "C"
 #endif
+
+#endif /* __LIBMEMCACHED_UTIL_POOL_H__ */

--- a/libmemcached/util/version.h
+++ b/libmemcached/util/version.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_UTIL_VERSION_H__
+#define __LIBMEMCACHED_UTIL_VERSION_H__
 
 
 #ifdef __cplusplus
@@ -51,3 +52,5 @@ LIBMEMCACHED_API
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_UTIL_VERSION_H__ */

--- a/libmemcached/verbosity.h
+++ b/libmemcached/verbosity.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_VERBOSITY_H__
+#define __LIBMEMCACHED_VERBOSITY_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,3 +49,5 @@ memcached_return_t memcached_verbosity(memcached_st *ptr, uint32_t verbosity);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_VERBOSITY_H__ */

--- a/libmemcached/version.h
+++ b/libmemcached/version.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_VERSION_H__
+#define __LIBMEMCACHED_VERSION_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,3 +54,5 @@ memcached_return_t memcached_version_instance(memcached_server_st *instance);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_VERSION_H__ */

--- a/libmemcached/virtual_bucket.h
+++ b/libmemcached/virtual_bucket.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_VIRTUAL_BUCKET_H__
+#define __LIBMEMCACHED_VIRTUAL_BUCKET_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -57,3 +58,5 @@ void memcached_virtual_bucket_free(memcached_st *self);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBMEMCACHED_VIRTUAL_BUCKET_H__ */

--- a/libmemcached/visibility.h
+++ b/libmemcached/visibility.h
@@ -16,7 +16,8 @@
  * @brief Visibility control macros
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_VISIBILITY_H__
+#define __LIBMEMCACHED_VISIBILITY_H__
 
 /**
  *
@@ -65,3 +66,5 @@
 #  endif /* defined(_MSC_VER) */
 # endif /* defined(BUILDING_LIBMEMCACHED) */
 #endif /* defined(BUILDING_LIBMEMCACHEDINTERNAL) */
+
+#endif /* __LIBMEMCACHED_VISIBILITY_H__ */

--- a/libmemcached/watchpoint.h
+++ b/libmemcached/watchpoint.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __LIBMEMCACHED_WATCHPOINT_H__
+#define __LIBMEMCACHED_WATCHPOINT_H__
 
 #define WATCHPOINT
 #define WATCHPOINT_ERROR(A)
@@ -49,3 +50,5 @@
 #define WATCHPOINT_ASSERT(A) (void)(A)
 #define WATCHPOINT_ASSERT_INITIALIZED(A)
 #define WATCHPOINT_SET(A)
+
+#endif /* __LIBMEMCACHED_WATCHPOINT_H__ */

--- a/libtest/binaries.h
+++ b/libtest/binaries.h
@@ -19,7 +19,8 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#pragma once
+#ifndef __LIBTEST_BINARIES_H__
+#define __LIBTEST_BINARIES_H__
 
 namespace libtest {
 
@@ -34,3 +35,4 @@ bool has_gearmand_binary();
 
 } // namespace libtest
 
+#endif /* __LIBTEST_BINARIES_H__ */

--- a/libtest/blobslap_worker.h
+++ b/libtest/blobslap_worker.h
@@ -19,10 +19,13 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#pragma once
+#ifndef __LIBTEST_BLOBSLAP_WORKER_H__
+#define __LIBTEST_BLOBSLAP_WORKER_H__
 
 namespace libtest {
 
 Server *build_blobslap_worker(in_port_t try_port);
 
 }
+
+#endif /* __LIBTEST_BLOBSLAP_WORKER_H__ */

--- a/libtest/callbacks.h
+++ b/libtest/callbacks.h
@@ -20,7 +20,8 @@
  */
 
 
-#pragma once
+#ifndef __LIBTEST_CALLBACKS_H__
+#define __LIBTEST_CALLBACKS_H__
 
 #ifdef	__cplusplus
 extern "C" {
@@ -36,3 +37,4 @@ typedef enum test_return_t (test_callback_error_fn)(const test_return_t, void *)
 }
 #endif
 
+#endif /* __LIBTEST_CALLBACKS_H__ */

--- a/libtest/cmdline.h
+++ b/libtest/cmdline.h
@@ -19,7 +19,8 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#pragma once
+#ifndef __LIBTEST_CMDLINE_H__
+#define __LIBTEST_CMDLINE_H__
 
 namespace libtest {
 
@@ -28,3 +29,5 @@ bool exec_cmdline(const std::string& executable, const char *args[]);
 const char *gearmand_binary(); 
 
 }
+
+#endif /* __LIBTEST_CMDLINE_H__ */

--- a/libtest/collection.h
+++ b/libtest/collection.h
@@ -20,7 +20,8 @@
  */
 
 
-#pragma once
+#ifndef __LIBTEST_COLLECTION_H__
+#define __LIBTEST_COLLECTION_H__
 
 /**
   A structure which describes a collection of test cases.
@@ -32,4 +33,4 @@ struct collection_st {
   struct test_st *tests;
 };
 
-
+#endif /* __LIBTEST_COLLECTION_H__ */

--- a/libtest/common.h
+++ b/libtest/common.h
@@ -23,7 +23,8 @@
   Common include file for libtest
 */
 
-#pragma once
+#ifndef __LIBTEST_COMMON_H__
+#define __LIBTEST_COMMON_H__
 
 #include <config.h>
 
@@ -66,3 +67,4 @@
 #include <libtest/stats.h>
 #include <libtest/signal.h>
 
+#endif /* __LIBTEST_COMMON_H__ */

--- a/libtest/comparison.hpp
+++ b/libtest/comparison.hpp
@@ -19,7 +19,8 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#pragma once
+#ifndef __LIBTEST_COMPARISON_HPP__
+#define __LIBTEST_COMPARISON_HPP__
 
 #include <typeinfo>
 
@@ -162,3 +163,5 @@ bool _compare_hint(const char *file, int line, const char *func, T1_comparable _
 }
 
 } // namespace libtest
+
+#endif /* __LIBTEST_COMPARISON_HPP__ */

--- a/libtest/core.h
+++ b/libtest/core.h
@@ -20,7 +20,8 @@
  */
 
 
-#pragma once
+#ifndef __LIBTEST_CORE_H__
+#define __LIBTEST_CORE_H__
 
 namespace libtest {
 
@@ -28,3 +29,5 @@ LIBTEST_API
 void create_core(void);
 
 } // namespace libtest
+
+#endif /* __LIBTEST_CORE_H__ */

--- a/libtest/error.h
+++ b/libtest/error.h
@@ -20,7 +20,8 @@
  */
 
 
-#pragma once
+#ifndef __LIBTEST_ERROR_H__
+#define __LIBTEST_ERROR_H__
 
 enum test_return_t {
   TEST_SUCCESS,
@@ -40,3 +41,5 @@ static inline bool test_failed(test_return_t rc)
 {
   return (rc != TEST_SUCCESS);
 }
+
+#endif /* __LIBTEST_ERROR_H__ */

--- a/libtest/failed.h
+++ b/libtest/failed.h
@@ -19,7 +19,8 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#pragma once
+#ifndef __LIBTEST_FAILED_H__
+#define __LIBTEST_FAILED_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,3 +35,5 @@ LIBTEST_INTERNAL_API
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __LIBTEST_FAILED_H__ */

--- a/libtest/framework.h
+++ b/libtest/framework.h
@@ -21,7 +21,8 @@
 
 
 
-#pragma once
+#ifndef __LIBTEST_FRAMEWORK_H__
+#define __LIBTEST_FRAMEWORK_H__
 
 /**
   Framework is the structure which is passed to the test implementation to be filled.
@@ -180,3 +181,5 @@ private:
   bool _socket;
   void *_creators_ptr;
 };
+
+#endif /* __LIBTEST_FRAMEWORK_H__ */

--- a/libtest/gearmand.h
+++ b/libtest/gearmand.h
@@ -20,7 +20,8 @@
  */
 
 
-#pragma once
+#ifndef __LIBTEST_GEARMAND_H__
+#define __LIBTEST_GEARMAND_H__
 
 #include <arpa/inet.h>
 
@@ -31,3 +32,5 @@ namespace libtest {
 libtest::Server *build_gearmand(const char *hostname, in_port_t try_port);
 
 }
+
+#endif /* __LIBTEST_GEARMAND_H__ */

--- a/libtest/get.h
+++ b/libtest/get.h
@@ -20,7 +20,8 @@
  */
 
 
-#pragma once
+#ifndef __LIBTEST_GET_H__
+#define __LIBTEST_GET_H__
 
 #ifdef	__cplusplus
 extern "C" {
@@ -34,4 +35,4 @@ extern "C" {
 }
 #endif
 
-
+#endif /* __LIBTEST_GET_H__ */

--- a/libtest/is_local.hpp
+++ b/libtest/is_local.hpp
@@ -19,7 +19,8 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#pragma once
+#ifndef __LIBTEST_IS_LOCAL_HPP__
+#define __LIBTEST_IS_LOCAL_HPP__
 
 namespace libtest {
 
@@ -27,3 +28,5 @@ LIBTEST_API
 bool test_is_local();
 
 } // namespace libtest
+
+#endif /* __LIBTEST_IS_LOCAL_HPP__ */

--- a/libtest/is_pid.hpp
+++ b/libtest/is_pid.hpp
@@ -19,10 +19,12 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#pragma once
+#ifndef __LIBTEST_IS_PID_HPP__
+#define __LIBTEST_IS_PID_HPP__
 
 static inline bool is_pid_valid(const pid_t pid)
 {
   return (pid > 1) ? true : false;
 }
 
+#endif /* __LIBTEST_IS_PID_HPP__ */

--- a/libtest/killpid.h
+++ b/libtest/killpid.h
@@ -20,7 +20,8 @@
  */
 
 
-#pragma once
+#ifndef __LIBTEST_KILLPID_H__
+#define __LIBTEST_KILLPID_H__
 
 
 bool kill_pid(pid_t pid_arg);
@@ -35,3 +36,5 @@ static inline bool check_pid(pid_t pid_arg)
 {
   return (pid_arg > 1);
 }
+
+#endif /* __LIBTEST_KILLPID_H__ */

--- a/libtest/libtool.hpp
+++ b/libtest/libtool.hpp
@@ -19,10 +19,13 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#pragma once
+#ifndef __LIBTEST_LIBTOOL_HPP__
+#define __LIBTEST_LIBTOOL_HPP__
 
 namespace libtest {
 
 const char *libtool(void);
 
 }
+
+#endif /* __LIBTEST_LIBTOOL_HPP__ */

--- a/libtest/memcached.h
+++ b/libtest/memcached.h
@@ -19,7 +19,8 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#pragma once
+#ifndef __LIBTEST_MEMCACHED_H__
+#define __LIBTEST_MEMCACHED_H__
 
 namespace libtest {
 
@@ -33,3 +34,4 @@ libtest::Server *build_memcached_sasl_socket(const std::string& socket_file, con
 
 }
 
+#endif /* __LIBTEST_MEMCACHED_H__ */

--- a/libtest/port.h
+++ b/libtest/port.h
@@ -24,7 +24,8 @@
   Structures for generic tests.
 */
 
-#pragma once
+#ifndef __LIBTEST_PORT_H__
+#define __LIBTEST_PORT_H__
 
 namespace libtest {
 
@@ -41,3 +42,5 @@ LIBTEST_API
 void set_max_port(in_port_t port);
 
 } // namespace libtest
+
+#endif /* __LIBTEST_PORT_H__ */

--- a/libtest/runner.h
+++ b/libtest/runner.h
@@ -20,7 +20,8 @@
  */
 
 
-#pragma once
+#ifndef __LIBTEST_RUNNER_H__
+#define __LIBTEST_RUNNER_H__
 
 
 namespace libtest {
@@ -41,3 +42,5 @@ public:
 };
 
 } // namespace Runner
+
+#endif /* __LIBTEST_RUNNER_H__ */

--- a/libtest/server.h
+++ b/libtest/server.h
@@ -19,7 +19,8 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#pragma once
+#ifndef __LIBTEST_SERVER_H__
+#define __LIBTEST_SERVER_H__
 
 #include <cassert>
 #include <cstdio>
@@ -189,4 +190,4 @@ std::ostream& operator<<(std::ostream& output, const libtest::Server &arg);
 
 } // namespace libtest
 
-
+#endif /* __LIBTEST_SERVER_H__ */

--- a/libtest/server_container.h
+++ b/libtest/server_container.h
@@ -19,7 +19,8 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#pragma once
+#ifndef __LIBTEST_SERVER_CONTAINER_H__
+#define __LIBTEST_SERVER_CONTAINER_H__
 
 #include <cassert>
 #include <cstdio>
@@ -121,3 +122,5 @@ public:
 bool server_startup(server_startup_st&, const std::string&, in_port_t try_port, int argc, const char *argv[]);
 
 } // namespace libtest
+
+#endif /* __LIBTEST_SERVER_CONTAINER_H__ */

--- a/libtest/signal.h
+++ b/libtest/signal.h
@@ -21,7 +21,8 @@
 
 
 
-#pragma once 
+#ifndef __LIBTEST_SIGNAL_H__
+#define __LIBTEST_SIGNAL_H__
 
 #include <pthread.h>
 #include <semaphore.h>
@@ -64,3 +65,5 @@ public:
 };
 
 } // namespace libtest
+
+#endif /* __LIBTEST_SIGNAL_H__ */

--- a/libtest/socket.hpp
+++ b/libtest/socket.hpp
@@ -19,7 +19,8 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#pragma once
+#ifndef __LIBTEST_SOCKET_HPP__
+#define __LIBTEST_SOCKET_HPP__
 
 namespace libtest {
 
@@ -29,3 +30,4 @@ void set_default_socket(const char *socket);
 
 } // namespace libtest
 
+#endif /* __LIBTEST_SOCKET_HPP__ */

--- a/libtest/stats.h
+++ b/libtest/stats.h
@@ -20,7 +20,8 @@
  */
 
 
-#pragma once
+#ifndef __LIBTEST_STATS_H__
+#define __LIBTEST_STATS_H__
 
 struct Stats {
   int32_t collection_success;
@@ -45,3 +46,4 @@ struct Stats {
   { }
 };
 
+#endif /* __LIBTEST_STATS_H__ */

--- a/libtest/stream.h
+++ b/libtest/stream.h
@@ -19,7 +19,8 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#pragma once
+#ifndef __LIBTEST_STREAM_H__
+#define __LIBTEST_STREAM_H__
 
 #include <iostream>
 #include <cassert>
@@ -174,3 +175,5 @@ public:
 #define Logn() stream::clog(NULL, __LINE__, __func__) << " "
 
 } // namespace libtest
+
+#endif /* __LIBTEST_STREAM_H__ */

--- a/libtest/strerror.h
+++ b/libtest/strerror.h
@@ -19,7 +19,8 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#pragma once
+#ifndef __LIBTEST_STRERROR_H__
+#define __LIBTEST_STRERROR_H__
 
 namespace libtest {
 
@@ -30,3 +31,5 @@ LIBTEST_API
 const char *test_strerror(test_return_t code);
 
 } // namespace libtest
+
+#endif /* __LIBTEST_STRERROR_H__ */

--- a/libtest/string.hpp
+++ b/libtest/string.hpp
@@ -20,7 +20,8 @@
  */
 
 
-#pragma once
+#ifndef __LIBTEST_STRING_HPP__
+#define __LIBTEST_STRING_HPP__
 
 #include "util/string.hpp"
 
@@ -28,3 +29,5 @@
 #define test_literal_param_size util_literal_param_size
 #define test_string_make_from_cstr util_string_make_from_cstr
 #define test_array_length util_array_length
+
+#endif /* __LIBTEST_STRING_HPP__ */

--- a/libtest/test.h
+++ b/libtest/test.h
@@ -20,7 +20,8 @@
  */
 
 
-#pragma once
+#ifndef __LIBTEST_TEST_H__
+#define __LIBTEST_TEST_H__
 
 #ifndef __INTEL_COMPILER
 #pragma GCC diagnostic ignored "-Wold-style-cast"
@@ -216,3 +217,4 @@ do \
   } \
 } while (0)
 
+#endif /* __LIBTEST_TEST_H__ */

--- a/libtest/version.h.in
+++ b/libtest/version.h.in
@@ -20,7 +20,10 @@
  */
 
 
-#pragma once
+#ifndef __LIBTEST_VERSION_H_IN__
+#define __LIBTEST_VERSION_H_IN__
 
 #define LIBTEST_VERSION_STRING "@VERSION@"
 #define LIBTEST_VERSION_HEX @HEX_VERSION@
+
+#endif /* __LIBTEST_VERSION_H_IN__ */

--- a/libtest/visibility.h
+++ b/libtest/visibility.h
@@ -20,7 +20,8 @@
  */
 
 
-#pragma once
+#ifndef __LIBTEST_VISIBILITY_H__
+#define __LIBTEST_VISIBILITY_H__
 
 #if defined(BUILDING_LIBTEST)
 # if defined(HAVE_VISIBILITY) && HAVE_VISIBILITY
@@ -61,3 +62,5 @@
 #  endif /* defined(_MSC_VER) */
 # endif /* defined(BUILDING_LIBTEST) */
 #endif /* defined(BUILDING_LIBTESTINTERNAL) */
+
+#endif /* __LIBTEST_VISIBILITY_H__ */

--- a/libtest/wait.h
+++ b/libtest/wait.h
@@ -20,7 +20,8 @@
  */
 
 
-#pragma once
+#ifndef __LIBTEST_WAIT_H__
+#define __LIBTEST_WAIT_H__
 
 #include <unistd.h>
 #include <string>
@@ -77,3 +78,5 @@ private:
 };
 
 } // namespace libtest
+
+#endif /* __LIBTEST_WAIT_H__ */

--- a/tests/basic.h
+++ b/tests/basic.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __TESTS_BASIC_H__
+#define __TESTS_BASIC_H__
 
 #include <libtest/visibility.h>
 
@@ -64,3 +65,5 @@ test_return_t basic_reset_heap_clone_test(memcached_st *memc);
 #ifdef	__cplusplus
 }
 #endif
+
+#endif /* __TESTS_BASIC_H__ */

--- a/tests/debug.h
+++ b/tests/debug.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __TESTS_DEBUG_H__
+#define __TESTS_DEBUG_H__
 
 test_return_t confirm_keys_exist(memcached_st *memc, const char * const *keys, const size_t number_of_keys, bool key_matches_value= false, bool require_all= false);
 
@@ -46,3 +47,5 @@ test_return_t print_keys_by_server(memcached_st *memc);
 size_t confirm_key_count(memcached_st *memc);
 
 void print_servers(memcached_st *);
+
+#endif /* __TESTS_DEBUG_H__ */

--- a/tests/deprecated.h
+++ b/tests/deprecated.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __TESTS_DEPRECATED_H__
+#define __TESTS_DEPRECATED_H__
 
 #ifdef	__cplusplus
 extern "C" {
@@ -47,3 +48,5 @@ test_return_t regression_bug_728286(memcached_st *);
 #ifdef	__cplusplus
 }
 #endif
+
+#endif /* __TESTS_DEPRECATED_H__ */

--- a/tests/error_conditions.h
+++ b/tests/error_conditions.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __TESTS_ERROR_CONDITIONS_H__
+#define __TESTS_ERROR_CONDITIONS_H__
 
 #ifdef	__cplusplus
 extern "C" {
@@ -46,3 +47,5 @@ test_return_t memcached_increment_MEMCACHED_NO_SERVERS(memcached_st *junk);
 #ifdef	__cplusplus
 }
 #endif
+
+#endif /* __TESTS_ERROR_CONDITIONS_H__ */

--- a/tests/exist.h
+++ b/tests/exist.h
@@ -34,9 +34,12 @@
  *
  */
 
-#pragma once
+#ifndef __TESTS_EXIST_H__
+#define __TESTS_EXIST_H__
 
 test_return_t memcached_exist_NOTFOUND(memcached_st *);
 test_return_t memcached_exist_SUCCESS(memcached_st *);
 test_return_t memcached_exist_by_key_NOTFOUND(memcached_st *);
 test_return_t memcached_exist_by_key_SUCCESS(memcached_st *);
+
+#endif /* __TESTS_EXIST_H__ */

--- a/tests/ketama.h
+++ b/tests/ketama.h
@@ -34,9 +34,12 @@
  *
  */
 
-#pragma once
+#ifndef __TESTS_KETAMA_H__
+#define __TESTS_KETAMA_H__
 
 test_return_t auto_eject_hosts(memcached_st *);
 test_return_t ketama_compatibility_libmemcached(memcached_st *);
 test_return_t ketama_compatibility_spymemcached(memcached_st *);
 test_return_t user_supplied_bug18(memcached_st *);
+
+#endif /* __TESTS_KETAMA_H__ */

--- a/tests/ketama_test_cases.h
+++ b/tests/ketama_test_cases.h
@@ -6,7 +6,8 @@
  * the COPYING file in the parent directory for full text.
  */
 
-#pragma once
+#ifndef __TESTS_KETAMA_TEST_CASES_H__
+#define __TESTS_KETAMA_TEST_CASES_H__
 
 static struct {
     const char *key;
@@ -116,3 +117,5 @@ static struct {
 };
 
 #include "ketama_test_cases_spy.h"
+
+#endif /* __TESTS_KETAMA_TEST_CASES_H__ */

--- a/tests/ketama_test_cases_spy.h
+++ b/tests/ketama_test_cases_spy.h
@@ -6,7 +6,8 @@
  * the COPYING file in the parent directory for full text.
  */
 
-#pragma once
+#ifndef __TESTS_KETAMA_TEST_CASES_SPY_H__
+#define __TESTS_KETAMA_TEST_CASES_SPY_H__
 
 static struct {
     const char *key;
@@ -114,3 +115,5 @@ static struct {
   { "\\MQ_XNT7L-", 1259349383UL, 1259509450UL, "10.0.1.5" },
   { "VD6D0]ba_\\", 3842502950UL, 3842588691UL, "10.0.1.7" },
 };
+
+#endif /* __TESTS_KETAMA_TEST_CASES_SPY_H__ */

--- a/tests/libmemcached_world.h
+++ b/tests/libmemcached_world.h
@@ -9,7 +9,8 @@
  *
  */
 
-#pragma once
+#ifndef __TESTS_LIBMEMCACHED_WORLD_H__
+#define __TESTS_LIBMEMCACHED_WORLD_H__
 
 #include <cassert>
 
@@ -298,3 +299,5 @@ public:
 };
 
 static LibmemcachedRunner defualt_libmemcached_runner;
+
+#endif /* __TESTS_LIBMEMCACHED_WORLD_H__ */

--- a/tests/namespace.h
+++ b/tests/namespace.h
@@ -35,7 +35,10 @@
  *
  */
 
-#pragma once
+#ifndef __TESTS_NAMESPACE_H__
+#define __TESTS_NAMESPACE_H__
 
 LIBTEST_LOCAL
 test_return_t memcached_increment_namespace(memcached_st *memc);
+
+#endif /* __TESTS_NAMESPACE_H__ */

--- a/tests/parser.h
+++ b/tests/parser.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __TESTS_PARSER_H__
+#define __TESTS_PARSER_H__
 
 #ifdef	__cplusplus
 extern "C" {
@@ -113,3 +114,5 @@ test_return_t test_namespace_keyword(memcached_st*);
 #ifdef	__cplusplus
 }
 #endif
+
+#endif /* __TESTS_PARSER_H__ */

--- a/tests/pool.h
+++ b/tests/pool.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __TESTS_POOL_H__
+#define __TESTS_POOL_H__
 
 #ifdef	__cplusplus
 extern "C" {
@@ -47,3 +48,5 @@ test_return_t memcached_pool_test(memcached_st *);
 #ifdef	__cplusplus
 }
 #endif
+
+#endif /* __TESTS_POOL_H__ */

--- a/tests/print.h
+++ b/tests/print.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __TESTS_PRINT_H__
+#define __TESTS_PRINT_H__
 
 #ifdef	__cplusplus
 extern "C" {
@@ -49,3 +50,5 @@ memcached_return_t server_print_callback(const memcached_st *ptr,
 #ifdef	__cplusplus
 }
 #endif
+
+#endif /* __TESTS_PRINT_H__ */

--- a/tests/replication.h
+++ b/tests/replication.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __TESTS_REPLICATION_H__
+#define __TESTS_REPLICATION_H__
 
 #ifdef	__cplusplus
 extern "C" {
@@ -62,3 +63,5 @@ test_return_t replication_randomize_mget_fail_test(memcached_st *memc);
 #ifdef	__cplusplus
 }
 #endif
+
+#endif /* __TESTS_REPLICATION_H__ */

--- a/tests/server_add.h
+++ b/tests/server_add.h
@@ -35,7 +35,10 @@
  *
  */
 
-#pragma once
+#ifndef __TESTS_SERVER_ADD_H__
+#define __TESTS_SERVER_ADD_H__
 
 test_return_t memcached_server_add_null_test(memcached_st*);
 test_return_t memcached_server_add_empty_test(memcached_st*);
+
+#endif /* __TESTS_SERVER_ADD_H__ */

--- a/tests/string.h
+++ b/tests/string.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __TESTS_STRING_H__
+#define __TESTS_STRING_H__
 
 #ifdef	__cplusplus
 extern "C" {
@@ -65,3 +66,5 @@ test_return_t string_alloc_append_multiple(void *);
 #ifdef	__cplusplus
 }
 #endif
+
+#endif /* __TESTS_STRING_H__ */

--- a/tests/virtual_buckets.h
+++ b/tests/virtual_buckets.h
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __TESTS_VIRTUAL_BUCKETS_H__
+#define __TESTS_VIRTUAL_BUCKETS_H__
 
 struct memcached_st;
 
@@ -49,3 +50,5 @@ test_return_t virtual_back_map(memcached_st *);
 #ifdef	__cplusplus
 }
 #endif
+
+#endif /* __TESTS_VIRTUAL_BUCKETS_H__ */

--- a/util/daemon.hpp
+++ b/util/daemon.hpp
@@ -31,7 +31,8 @@
  * SUCH DAMAGE.
  */
 
-#pragma once
+#ifndef __UTIL_DAEMON_HPP__
+#define __UTIL_DAEMON_HPP__
 
 namespace datadifferential {
 namespace util {
@@ -41,3 +42,5 @@ bool daemonize(bool is_chdir= true, bool wait_sigusr1= true);
 
 } /* namespace util */
 } /* namespace datadifferential */
+
+#endif /* __UTIL_DAEMON_HPP__ */

--- a/util/instance.hpp
+++ b/util/instance.hpp
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __UTIL_INSTANCE_HPP__
+#define __UTIL_INSTANCE_HPP__
 
 #include <arpa/inet.h>
 #include <cstdio>
@@ -115,3 +116,5 @@ private:
 
 } /* namespace util */
 } /* namespace datadifferential */
+
+#endif /* __UTIL_INSTANCE_HPP__ */

--- a/util/logfile.hpp
+++ b/util/logfile.hpp
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __UTIL_LOGFILE_HPP__
+#define __UTIL_LOGFILE_HPP__
 
 #include <string>
 #include <fstream>
@@ -64,3 +65,5 @@ private:
 
 } /* namespace util */
 } /* namespace datadifferential */
+
+#endif /* __UTIL_LOGFILE_HPP__ */

--- a/util/operation.hpp
+++ b/util/operation.hpp
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __UTIL_OPERATION_HPP__
+#define __UTIL_OPERATION_HPP__
 
 
 #include <cstring>
@@ -101,3 +102,5 @@ private:
 
 } /* namespace util */
 } /* namespace datadifferential */
+
+#endif /* __UTIL_OPERATION_HPP__ */

--- a/util/pidfile.hpp
+++ b/util/pidfile.hpp
@@ -35,7 +35,8 @@
  *
  */
 
-#pragma once
+#ifndef __UTIL_PIDFILE_HPP__
+#define __UTIL_PIDFILE_HPP__
 
 #include <string>
 
@@ -64,3 +65,5 @@ private:
 
 } /* namespace util */
 } /* namespace datadifferential */
+
+#endif /* __UTIL_PIDFILE_HPP__ */

--- a/util/signal.hpp
+++ b/util/signal.hpp
@@ -21,7 +21,8 @@
 
 
 
-#pragma once 
+#ifndef __UTIL_SIGNAL_HPP__
+#define __UTIL_SIGNAL_HPP__
 
 #include <pthread.h>
 #include <semaphore.h>
@@ -71,3 +72,5 @@ public:
 
 } /* namespace util */
 } /* namespace datadifferential */
+
+#endif /* __UTIL_SIGNAL_HPP__ */

--- a/util/string.hpp
+++ b/util/string.hpp
@@ -42,7 +42,8 @@
 #include <cstring>
 #include <cstddef>
 
-#pragma once
+#ifndef __UTIL_STRING_HPP__
+#define __UTIL_STRING_HPP__
 
 #define util_literal_param(X) (X), (static_cast<size_t>((sizeof(X) - 1)))
 #define util_literal_param_size(X) static_cast<size_t>(sizeof(X) - 1)
@@ -51,3 +52,4 @@
 
 #define util_array_length(__array) sizeof(__array)/sizeof(&__array)
 
+#endif /* __UTIL_STRING_HPP__ */


### PR DESCRIPTION
https://github.com/naver/arcus-c-client/issues/233

`#pragma once` 제거 후 `#define __HEADERNAME_H__` 형태로 변경했습니다.