### PR TITLE
INTERNAL: Call memcached_set_error() when version operation is failed on connect.

### DIFF
--- a/libmemcached/connect.cc
+++ b/libmemcached/connect.cc
@@ -662,6 +662,10 @@ memcached_return_t memcached_connect(memcached_server_write_instance_st server)
   {
     memcached_mark_server_as_clean(server);
     rc= memcached_version_instance(server);
+    if (memcached_failed(rc))
+    {
+      return memcached_set_error(*server, rc, MEMCACHED_AT);
+    }
     return rc;
   }
 


### PR DESCRIPTION
- 에러 코드 `MEMCACHED_VERSION_FAILURE`를 추가했습니다.
- memcached_connect() 함수 내에서 memcached_version_instance() 함수가 실패했을 때 memcached_set_error() 함수를 호출하면서 MEMCACHED_VERSION_FAILURE를 사용합니다.
- 에러 코드를 추가한 의도는 connection이 수립 되기 전에 발생한 에러와 connection이 수립 되었으나 version을 가져오는데 실패한 경우의 에러를 분리하기 위함입니다.
- 이러한 분리를 통해 memcached_connect() 함수에서 connection 실패 시에 발생하는 에러 코드와 memcached_version_instance() 실패 시에 발생하는 에러 코드가 중복되어도 어느 쪽에서 문제가 생긴 것인지 알 수 있습니다.