### PR TITLE
INTERNAL: Check mc->connect_timeout instead of mc->poll_timeout in connect_poll()

### DIFF
--- a/libmemcached/connect.cc
+++ b/libmemcached/connect.cc
@@ -50,7 +50,7 @@ static memcached_return_t connect_poll(memcached_server_st *server)
 
   size_t loop_max= 5;
 
-  if (server->root->poll_timeout == 0)
+  if (server->root->connect_timeout == 0)
   {
     return memcached_set_error(*server, MEMCACHED_TIMEOUT, MEMCACHED_AT);
   }

--- a/tests/mem_functions.cc
+++ b/tests/mem_functions.cc
@@ -2857,6 +2857,7 @@ static test_return_t user_supplied_bug10(memcached_st *memc)
   memcached_behavior_set(mclone, MEMCACHED_BEHAVIOR_NO_BLOCK, set);
   memcached_behavior_set(mclone, MEMCACHED_BEHAVIOR_TCP_NODELAY, set);
   memcached_behavior_set(mclone, MEMCACHED_BEHAVIOR_POLL_TIMEOUT, uint64_t(0));
+  memcached_behavior_set(mclone, MEMCACHED_BEHAVIOR_CONNECT_TIMEOUT, uint64_t(0));
 
   char *value= (char*)malloc(value_length * sizeof(char));
 


### PR DESCRIPTION
- connect 모듈에서 poll() system call을 수행할 때 mc->connect_timeout을 timeout 매개변수로 넣어주는데, poll() 수행 전 timeout 매개변수 검사에는 mc->poll_timeout을 사용하고 있었습니다. timeout 매개변수 검사에도 mc->connect_timeout을 사용하도록 변경했습니다.
- 단위 테스트 중 timeout failure를 발생시키는 테스트 코드에서 mc->poll_timeout을 0으로 설정해 timeout을 유도하는 부분을 mc->connect_timeout 값도 0으로 설정하도록 변경했습니다.