### PR TITLE
INTERNAL: Fix typo from occured to occurred

### DIFF
--- a/docs/man/memcached_behavior_get.3
+++ b/docs/man/memcached_behavior_get.3
@@ -270,13 +270,13 @@ Specify time, in seconds, to mark a connection as idle. This is only available a
 .B MEMCACHED_BEHAVIOR_SOCKET_SEND_SIZE
 .UNINDENT
 .sp
-Find the current size of SO_SNDBUF. A value of 0 means either an error occured or no hosts were available. It is safe to assume system default if this occurs. If an error occurs you can checked the last cached errno statement to find the specific error.
+Find the current size of SO_SNDBUF. A value of 0 means either an error occurred or no hosts were available. It is safe to assume system default if this occurs. If an error occurs you can checked the last cached errno statement to find the specific error.
 .INDENT 0.0
 .TP
 .B MEMCACHED_BEHAVIOR_SOCKET_RECV_SIZE
 .UNINDENT
 .sp
-Find the current size of SO_RCVBUF. A value of 0 means either an error occured or no hosts were available. It is safe to assume system default if this occurs. If an error occurs you can checked the last cached errno statement to find the specific error.
+Find the current size of SO_RCVBUF. A value of 0 means either an error occurred or no hosts were available. It is safe to assume system default if this occurs. If an error occurs you can checked the last cached errno statement to find the specific error.
 .INDENT 0.0
 .TP
 .B MEMCACHED_BEHAVIOR_SERVER_FAILURE_LIMIT

--- a/docs/man/memcached_behavior_set.3
+++ b/docs/man/memcached_behavior_set.3
@@ -270,13 +270,13 @@ Specify time, in seconds, to mark a connection as idle. This is only available a
 .B MEMCACHED_BEHAVIOR_SOCKET_SEND_SIZE
 .UNINDENT
 .sp
-Find the current size of SO_SNDBUF. A value of 0 means either an error occured or no hosts were available. It is safe to assume system default if this occurs. If an error occurs you can checked the last cached errno statement to find the specific error.
+Find the current size of SO_SNDBUF. A value of 0 means either an error occurred or no hosts were available. It is safe to assume system default if this occurs. If an error occurs you can checked the last cached errno statement to find the specific error.
 .INDENT 0.0
 .TP
 .B MEMCACHED_BEHAVIOR_SOCKET_RECV_SIZE
 .UNINDENT
 .sp
-Find the current size of SO_RCVBUF. A value of 0 means either an error occured or no hosts were available. It is safe to assume system default if this occurs. If an error occurs you can checked the last cached errno statement to find the specific error.
+Find the current size of SO_RCVBUF. A value of 0 means either an error occurred or no hosts were available. It is safe to assume system default if this occurs. If an error occurs you can checked the last cached errno statement to find the specific error.
 .INDENT 0.0
 .TP
 .B MEMCACHED_BEHAVIOR_SERVER_FAILURE_LIMIT

--- a/libmemcached/collection.cc
+++ b/libmemcached/collection.cc
@@ -2122,7 +2122,7 @@ static memcached_return_t do_coll_mget(memcached_st *ptr,
   }
 
   /* Send the request (buffered) */
-  bool failures_occured_in_sending= false;
+  bool failures_occurred_in_sending= false;
   size_t hosts_connected= 0;
   bool hosts_failed[MAX_SERVERS_FOR_MULTI_KEY_OPERATION]= { false };
   for (size_t i=0; i<number_of_keys; i++)
@@ -2167,7 +2167,7 @@ static memcached_return_t do_coll_mget(memcached_st *ptr,
 
       if ((memcached_io_writev(instance, vector, 5, false)) == -1)
       {
-        failures_occured_in_sending= true;
+        failures_occurred_in_sending= true;
         hosts_failed[serverkey]= true;
         continue;
       }
@@ -2184,7 +2184,7 @@ static memcached_return_t do_coll_mget(memcached_st *ptr,
       if ((memcached_io_writev(instance, vector, 2, false)) == -1)
       {
         memcached_server_response_reset(instance);
-        failures_occured_in_sending= true;
+        failures_occurred_in_sending= true;
         hosts_failed[serverkey]= true;
         continue;
       }
@@ -2214,7 +2214,7 @@ static memcached_return_t do_coll_mget(memcached_st *ptr,
       /* We need to do something about non-connnected hosts in the future */
       if ((memcached_io_write(instance, "\r\n", 2, true)) == -1)
       {
-        failures_occured_in_sending= true;
+        failures_occurred_in_sending= true;
       }
       else
       {
@@ -2223,7 +2223,7 @@ static memcached_return_t do_coll_mget(memcached_st *ptr,
     }
   }
 
-  if (failures_occured_in_sending && success_happened)
+  if (failures_occurred_in_sending && success_happened)
   {
     return MEMCACHED_SOME_ERRORS;
   }
@@ -2736,7 +2736,7 @@ static memcached_return_t do_bop_smget(memcached_st *ptr,
   }
 
   /* Send the request (buffered) */
-  bool failures_occured_in_sending= false;
+  bool failures_occurred_in_sending= false;
   size_t hosts_connected= 0;
   bool hosts_failed[MAX_SERVERS_FOR_MULTI_KEY_OPERATION]= { false };
   for (size_t i=0; i<number_of_keys; i++)
@@ -2781,7 +2781,7 @@ static memcached_return_t do_bop_smget(memcached_st *ptr,
 
       if ((memcached_io_writev(instance, vector, 5, false)) == -1)
       {
-        failures_occured_in_sending= true;
+        failures_occurred_in_sending= true;
         hosts_failed[serverkey]= true;
         continue;
       }
@@ -2798,7 +2798,7 @@ static memcached_return_t do_bop_smget(memcached_st *ptr,
       if ((memcached_io_writev(instance, vector, 2, false)) == -1)
       {
         memcached_server_response_reset(instance);
-        failures_occured_in_sending= true;
+        failures_occurred_in_sending= true;
         hosts_failed[serverkey]= true;
         continue;
       }
@@ -2828,7 +2828,7 @@ static memcached_return_t do_bop_smget(memcached_st *ptr,
       /* We need to do something about non-connnected hosts in the future */
       if ((memcached_io_write(instance, "\r\n", 2, true)) == -1)
       {
-        failures_occured_in_sending= true;
+        failures_occurred_in_sending= true;
       }
       else
       {
@@ -2837,7 +2837,7 @@ static memcached_return_t do_bop_smget(memcached_st *ptr,
     }
   }
 
-  if (failures_occured_in_sending && success_happened)
+  if (failures_occurred_in_sending && success_happened)
   {
     return MEMCACHED_SOME_ERRORS;
   }

--- a/libmemcached/connect.cc
+++ b/libmemcached/connect.cc
@@ -402,7 +402,7 @@ static memcached_return_t unix_socket_connect(memcached_server_st *server)
 
 static memcached_return_t network_connect(memcached_server_st *server)
 {
-  bool timeout_error_occured= false;
+  bool timeout_error_occurred= false;
 
   WATCHPOINT_ASSERT(server->fd == INVALID_SOCKET);
   WATCHPOINT_ASSERT(server->cursor_active == 0);
@@ -480,7 +480,7 @@ static memcached_return_t network_connect(memcached_server_st *server)
     switch (get_socket_errno())
     {
     case ETIMEDOUT:
-      timeout_error_occured= true;
+      timeout_error_occurred= true;
       break;
 
     case EWOULDBLOCK:
@@ -499,7 +499,7 @@ static memcached_return_t network_connect(memcached_server_st *server)
         // A timeout here is treated as an error, we will not retry
         if (rc == MEMCACHED_TIMEOUT)
         {
-          timeout_error_occured= true;
+          timeout_error_occurred= true;
         }
       }
       break;
@@ -526,7 +526,7 @@ static memcached_return_t network_connect(memcached_server_st *server)
 
   WATCHPOINT_ASSERT(server->fd == INVALID_SOCKET);
 
-  if (timeout_error_occured)
+  if (timeout_error_occurred)
   {
     if (server->fd != INVALID_SOCKET)
     {
@@ -542,7 +542,7 @@ static memcached_return_t network_connect(memcached_server_st *server)
     return memcached_server_error_return(server);
   }
 
-  if (timeout_error_occured and server->state < MEMCACHED_SERVER_STATE_IN_PROGRESS)
+  if (timeout_error_occurred and server->state < MEMCACHED_SERVER_STATE_IN_PROGRESS)
   {
     return memcached_set_error(*server, MEMCACHED_TIMEOUT, MEMCACHED_AT);
   }

--- a/libmemcached/csl/context.cc
+++ b/libmemcached/csl/context.cc
@@ -46,11 +46,11 @@ void Context::abort(const char *error_arg, yytokentype last_token, const char *l
 
   if (error_arg)
   {
-    memcached_set_parser_error(*memc, MEMCACHED_AT, "Error occured while parsing: %s", error_arg);
+    memcached_set_parser_error(*memc, MEMCACHED_AT, "Error occurred while parsing: %s", error_arg);
     return;
   }
 
-  memcached_set_parser_error(*memc, MEMCACHED_AT, "Error occured while parsing: %s", memcached_strerror(NULL, MEMCACHED_PARSE_ERROR));
+  memcached_set_parser_error(*memc, MEMCACHED_AT, "Error occurred while parsing: %s", memcached_strerror(NULL, MEMCACHED_PARSE_ERROR));
 }
 
 void Context::error(const char *error_arg, yytokentype last_token, const char *last_token_str)
@@ -58,7 +58,7 @@ void Context::error(const char *error_arg, yytokentype last_token, const char *l
   rc= MEMCACHED_PARSE_ERROR;
   if (not error_arg)
   {
-    memcached_set_parser_error(*memc, MEMCACHED_AT, "Unknown error occured during parsing (%s)", last_token_str ? last_token_str : " ");
+    memcached_set_parser_error(*memc, MEMCACHED_AT, "Unknown error occurred during parsing (%s)", last_token_str ? last_token_str : " ");
     return;
   }
 
@@ -74,7 +74,7 @@ void Context::error(const char *error_arg, yytokentype last_token, const char *l
   { }
   else if (error_arg)
   {
-    memcached_set_parser_error(*memc, MEMCACHED_AT, "Error occured during parsing (%s)", error_arg);
+    memcached_set_parser_error(*memc, MEMCACHED_AT, "Error occurred during parsing (%s)", error_arg);
     return;
   }
 
@@ -84,11 +84,11 @@ void Context::error(const char *error_arg, yytokentype last_token, const char *l
   }
   else if (last_token == UNKNOWN)
   {
-    memcached_set_parser_error(*memc, MEMCACHED_AT, "Error occured durring parsing, an unknown token was found.");
+    memcached_set_parser_error(*memc, MEMCACHED_AT, "Error occurred durring parsing, an unknown token was found.");
   }
   else
   {
-    memcached_set_parser_error(*memc, MEMCACHED_AT, "Error occured while parsing (%s)", last_token_str ? last_token_str : " ");
+    memcached_set_parser_error(*memc, MEMCACHED_AT, "Error occurred while parsing (%s)", last_token_str ? last_token_str : " ");
   }
 }
 

--- a/libmemcached/get.cc
+++ b/libmemcached/get.cc
@@ -653,7 +653,7 @@ memcached_return_t memcached_mget_by_key(memcached_st *ptr,
   arcus_server_check_for_update(ptr);
 
   memcached_return_t rc;
-  bool failures_occured_in_sending= false;
+  bool failures_occurred_in_sending= false;
   unsigned int master_server_key= (unsigned int)-1; /* 0 is a valid server id! */
 
   if (memcached_failed(rc= before_get_query(ptr, group_key, group_key_length,
@@ -790,7 +790,7 @@ memcached_return_t memcached_mget_by_key(memcached_st *ptr,
 
       if (write_result == -1)
       {
-        failures_occured_in_sending= true;
+        failures_occurred_in_sending= true;
         hosts_failed[server_key]= true;
         continue;
       }
@@ -809,7 +809,7 @@ memcached_return_t memcached_mget_by_key(memcached_st *ptr,
       if (write_result == -1)
       {
         memcached_server_response_reset(instance);
-        failures_occured_in_sending= true;
+        failures_occurred_in_sending= true;
         hosts_failed[server_key]= true;
         continue;
       }
@@ -843,7 +843,7 @@ memcached_return_t memcached_mget_by_key(memcached_st *ptr,
       /* We need to do something about non-connnected hosts in the future */
       if ((memcached_io_write(instance, "\r\n", 2, true)) == -1)
       {
-        failures_occured_in_sending= true;
+        failures_occurred_in_sending= true;
       }
       else
       {
@@ -854,7 +854,7 @@ memcached_return_t memcached_mget_by_key(memcached_st *ptr,
 
   LIBMEMCACHED_MEMCACHED_MGET_END();
 
-  if (failures_occured_in_sending && success_happened)
+  if (failures_occurred_in_sending && success_happened)
   {
     return MEMCACHED_SOME_ERRORS;
   }

--- a/libmemcached/io.cc
+++ b/libmemcached/io.cc
@@ -259,7 +259,7 @@ static memcached_return_t io_wait(memcached_server_write_instance_st ptr,
 
       return MEMCACHED_SUCCESS;
 
-    case 0: // Timeout occured, we let the while() loop do its thing.
+    case 0: // Timeout occurred, we let the while() loop do its thing.
       return memcached_set_error(*ptr, MEMCACHED_TIMEOUT, MEMCACHED_AT);
 
     default:

--- a/libmemcached/protocol/binary_handler.c
+++ b/libmemcached/protocol/binary_handler.c
@@ -959,7 +959,7 @@ static memcached_binary_protocol_command_handler comcode_v0_v1_remap[256]= {
  * if it's present.
  * @param client the client connection to operate on
  * @param header the command to execute
- * @return true if success or false if a fatal error occured so that the
+ * @return true if success or false if a fatal error occurred so that the
  *         connection should be shut down.
  */
 static protocol_binary_response_status execute_command(memcached_protocol_client_st *client, protocol_binary_request_header *header)

--- a/libmemcached/protocol/protocol_handler.c
+++ b/libmemcached/protocol/protocol_handler.c
@@ -96,7 +96,7 @@ static ssize_t default_send(const void *cookie,
  * Try to drain the output buffers without blocking
  *
  * @param client the client to drain
- * @return false if an error occured (connection should be shut down)
+ * @return false if an error occurred (connection should be shut down)
  *         true otherwise (please note that there may be more data to
  *              left in the buffer to send)
  */

--- a/libmemcached/strerror.cc
+++ b/libmemcached/strerror.cc
@@ -187,10 +187,10 @@ const char *memcached_strerror(memcached_st *, memcached_return_t rc)
     return "CONTINUE AUTHENTICATION";
 
   case MEMCACHED_PARSE_ERROR:
-    return "ERROR OCCURED WHILE PARSING";
+    return "ERROR OCCURRED WHILE PARSING";
 
   case MEMCACHED_PARSE_USER_ERROR:
-    return "USER INITIATED ERROR OCCURED WHILE PARSING";
+    return "USER INITIATED ERROR OCCURRED WHILE PARSING";
 
   case MEMCACHED_DEPRECATED:
     return "DEPRECATED";

--- a/libtest/killpid.cc
+++ b/libtest/killpid.cc
@@ -77,7 +77,7 @@ bool kill_pid(pid_t pid_arg)
       }
     }
 
-    Error << "Error occured while waitpid(" << strerror(errno) << ") on pid " << int(pid_arg);
+    Error << "Error occurred while waitpid(" << strerror(errno) << ") on pid " << int(pid_arg);
 
     return false;
   }

--- a/libtest/server_container.cc
+++ b/libtest/server_container.cc
@@ -246,7 +246,7 @@ bool server_startup(server_startup_st& construct, const std::string& server_type
 
   if (server == NULL)
   {
-    Error << "Failure occured while creating server: " <<  server_type;
+    Error << "Failure occurred while creating server: " <<  server_type;
     return false;
   }
 
@@ -349,7 +349,7 @@ bool server_startup_st::start_socket_server(const std::string& server_type, cons
 
   if (server == NULL)
   {
-    Error << "Failure occured while creating server: " <<  server_type;
+    Error << "Failure occurred while creating server: " <<  server_type;
     return false;
   }
 

--- a/tests/parser.cc
+++ b/tests/parser.cc
@@ -477,7 +477,7 @@ test_return_t random_statement_build_test(memcached_st*)
           char buffer[2048];
           memcached_return_t rc= libmemcached_check_configuration(random_options.c_str(), random_options.size(), buffer, sizeof(buffer));
           test_true_got(rc != MEMCACHED_SUCCESS, "memcached_create_with_options() failed whiled libmemcached_check_configuration() was successful");
-          std::cerr << "Error occured on " << random_options.c_str() << " : " << buffer << std::endl;
+          std::cerr << "Error occurred on " << random_options.c_str() << " : " << buffer << std::endl;
           return TEST_FAILURE;
         }
 #endif

--- a/tests/string.cc
+++ b/tests/string.cc
@@ -175,7 +175,7 @@ test_return_t string_alloc_append_multiple(void*)
   memcached_st *memc= memcached_create(NULL);
 
   memcached_string_st *error_string= memcached_string_create(memc, NULL, 1024);
-  memcached_string_append(error_string, test_literal_param("Error occured while parsing: "));
+  memcached_string_append(error_string, test_literal_param("Error occurred while parsing: "));
   memcached_string_append(error_string, test_string_make_from_cstr("jog the strlen() method"));
   memcached_string_append(error_string, test_literal_param(" ("));
 

--- a/util/instance.cc
+++ b/util/instance.cc
@@ -220,7 +220,7 @@ bool Instance::run()
             switch(errno)
             {
             default:
-              std::cerr << "Error occured while reading data from " << _host.c_str() << std::endl;
+              std::cerr << "Error occurred while reading data from " << _host.c_str() << std::endl;
               return false;
             }
           }


### PR DESCRIPTION
`occured`로 표현된 오타가 많이 있어서 `occurred`로 고쳤습니다.