### PR TITLE
INTERNAL: Do not use UNKNOWN version

### DIFF
--- a/config/autorun.sh
+++ b/config/autorun.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
 if [[ -d .git || -f .git || ! -f m4/version.m4 ]]
 then
-  perl config/version.pl || die "Failed to run config/version.pl"
+  perl config/version.pl
 fi
 
 autoreconf --install --force --verbose -Wall

--- a/config/version.pl
+++ b/config/version.pl
@@ -27,9 +27,13 @@ my $libmemcached_version = "0.53";
 my $arcus_describe = `git describe`;
 chomp $arcus_describe;
 
-unless ($arcus_describe =~ m/^\d+\.\d+\.\d+/) {
-    $arcus_describe = 'unknown';
-}
+#unless ($arcus_describe =~ m/^\d+\.\d+\.\d+/) {
+#    $arcus_describe = 'unknown';
+#}
+my $unknown_version_message = "Can't find recent tag from current commit.
+If you forked the repository, the tag might not be included.
+You need to fetch tags from upstream repository.";
+$arcus_describe =~ m/^\d+\.\d+\.\d+/ or die $unknown_version_message;
 
 $arcus_describe =~ s/-/_/g;
 


### PR DESCRIPTION
- jam2in/arcus-works#368

`git describe` 명령을 통해 버전 정보를 가져올 수 없는 경우,
`unknown` 버전을 사용하는 대신 스크립트 실행을 중단합니다.