### PR TITLE
FIX: Revert version.pl about unknown version

### DIFF
--- a/config/version.pl
+++ b/config/version.pl
@@ -27,13 +27,9 @@ my $libmemcached_version = "0.53";
 my $arcus_describe = `git describe`;
 chomp $arcus_describe;
 
-#unless ($arcus_describe =~ m/^\d+\.\d+\.\d+/) {
-#    $arcus_describe = 'unknown';
-#}
-my $unknown_version_message = "Can't find recent tag from current commit.
-If you forked the repository, the tag might not be included.
-You need to fetch tags from upstream repository.";
-$arcus_describe =~ m/^\d+\.\d+\.\d+/ or die $unknown_version_message;
+unless ($arcus_describe =~ m/^\d+\.\d+\.\d+/) {
+    $arcus_describe = '1.13.2-unknown';
+}
 
 $arcus_describe =~ s/-/_/g;
 


### PR DESCRIPTION
- jam2in/arcus-works#368
- #256 
- naver/arcus-memcached#689 

`git describe`에 실패하는 경우(tag 정보를 가져올 수 없는 경우) 실패하는 대신
`<latest release>-unknown` 버전을 사용하도록 변경합니다.

이 PR이 적용된 이후에는 매 릴리즈 마다 version.pl 파일을 함께 변경해 주어야 합니다.