### PR TITLE
Build with bison 3.8.

### DIFF
--- a/libmemcached/csl/parser.cc
+++ b/libmemcached/csl/parser.cc
@@ -88,11 +88,11 @@
 
 int conf_lex(YYSTYPE* lvalp, void* scanner);
 
-#define select_yychar(__context) yychar == UNKNOWN ? ( (__context)->previous_token == END ? UNKNOWN : (__context)->previous_token ) : yychar   
+#define select_yychar(__context) yychar == UNKNOWN ? ( (__context)->previous_token == END ? UNKNOWN : (__context)->previous_token ) : yychar
 
 #define stryytname(__yytokentype) ((__yytokentype) <  YYNTOKENS ) ? yytname[(__yytokentype)] : ""
 
-#define parser_abort(__context, __error_message) do { (__context)->abort((__error_message), yytokentype(select_yychar(__context)), stryytname(YYTRANSLATE(select_yychar(__context)))); YYABORT; } while (0) 
+#define parser_abort(__context, __error_message) do { (__context)->abort((__error_message), yytokentype(select_yychar(__context)), stryytname(YYTRANSLATE(select_yychar(__context)))); YYABORT; } while (0)
 
 // This is bison calling error.
 inline void __config_error(Context *context, yyscan_t *scanner, const char *error, int last_token, const char *last_token_str)
@@ -1262,6 +1262,8 @@ yydestruct (const char *yymsg,
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
+/* Prevent warnings from -Wmissing-prototypes.  */
+int yyparse (Context *context, yyscan_t *scanner);
 
 
 
@@ -1693,7 +1695,7 @@ yyreduce:
           {
             if ((context->rc= memcached_behavior_set(context->memc, MEMCACHED_BEHAVIOR_HASH, (yyvsp[0].hash))) != MEMCACHED_SUCCESS)
             {
-              parser_abort(context, NULL);; 
+              parser_abort(context, NULL);;
             }
           }
 #line 1700 "libmemcached/csl/parser.cc"
@@ -2282,9 +2284,9 @@ yyreturnlab:
 }
 
 #line 481 "libmemcached/csl/parser.yy"
- 
 
-void Context::start() 
+
+void Context::start()
 {
   config_parse(this, (void **)scanner);
 }

--- a/libmemcached/csl/parser.cc
+++ b/libmemcached/csl/parser.cc
@@ -1,22 +1,22 @@
-/* A Bison parser, made by GNU Bison 2.4.3.  */
+/* A Bison parser, made by GNU Bison 3.8.  */
 
-/* Skeleton implementation for Bison's Yacc-like parsers in C
-   
-      Copyright (C) 1984, 1989, 1990, 2000, 2001, 2002, 2003, 2004, 2005, 2006,
-   2009, 2010 Free Software Foundation, Inc.
-   
+/* Bison implementation for Yacc-like parsers in C
+
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+   Inc.
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -27,12 +27,16 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-   
+
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
 /* C LALR(1) parser skeleton written by Richard Stallman, by
    simplifying the original so-called "semantic" parser.  */
+
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
 
 /* All symbols defined below should begin with yy or YY, to avoid
    infringing on user name space.  This should be done even for local
@@ -41,11 +45,11 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
-/* Identify Bison output.  */
-#define YYBISON 1
+/* Identify Bison output, and Bison version.  */
+#define YYBISON 30800
 
-/* Bison version.  */
-#define YYBISON_VERSION "2.4.3"
+/* Bison version string.  */
+#define YYBISON_VERSION "3.8"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -59,22 +63,15 @@
 /* Pull parsers.  */
 #define YYPULL 1
 
-/* Using locations.  */
-#define YYLSP_NEEDED 0
 
 /* Substitute the variable and function names.  */
 #define yyparse         config_parse
 #define yylex           config_lex
 #define yyerror         config_error
-#define yylval          config_lval
-#define yychar          config_char
 #define yydebug         config_debug
 #define yynerrs         config_nerrs
 
-
-/* Copy the first part of user declarations.  */
-
-/* Line 189 of yacc.c  */
+/* First part of user prologue.  */
 #line 36 "libmemcached/csl/parser.yy"
 
 
@@ -114,151 +111,212 @@ inline void __config_error(Context *context, yyscan_t *scanner, const char *erro
 
 
 
+#line 115 "libmemcached/csl/parser.cc"
 
-/* Line 189 of yacc.c  */
-#line 120 "libmemcached/csl/parser.cc"
+# ifndef YY_CAST
+#  ifdef __cplusplus
+#   define YY_CAST(Type, Val) static_cast<Type> (Val)
+#   define YY_REINTERPRET_CAST(Type, Val) reinterpret_cast<Type> (Val)
+#  else
+#   define YY_CAST(Type, Val) ((Type) (Val))
+#   define YY_REINTERPRET_CAST(Type, Val) ((Type) (Val))
+#  endif
+# endif
+# ifndef YY_NULLPTR
+#  if defined __cplusplus
+#   if 201103L <= __cplusplus
+#    define YY_NULLPTR nullptr
+#   else
+#    define YY_NULLPTR 0
+#   endif
+#  else
+#   define YY_NULLPTR ((void*)0)
+#  endif
+# endif
 
-/* Enabling traces.  */
-#ifndef YYDEBUG
-# define YYDEBUG 1
-#endif
-
-/* Enabling verbose error messages.  */
-#ifdef YYERROR_VERBOSE
-# undef YYERROR_VERBOSE
-# define YYERROR_VERBOSE 1
-#else
-# define YYERROR_VERBOSE 1
-#endif
-
-/* Enabling the token table.  */
-#ifndef YYTOKEN_TABLE
-# define YYTOKEN_TABLE 0
-#endif
-
-
-/* Tokens.  */
-#ifndef YYTOKENTYPE
-# define YYTOKENTYPE
-   /* Put the tokens into the symbol table, so that GDB and other debuggers
-      know about them.  */
-   enum yytokentype {
-     COMMENT = 258,
-     END = 259,
-     ERROR = 260,
-     RESET = 261,
-     PARSER_DEBUG = 262,
-     INCLUDE = 263,
-     CONFIGURE_FILE = 264,
-     EMPTY_LINE = 265,
-     SERVER = 266,
-     SOCKET = 267,
-     SERVERS = 268,
-     SERVERS_OPTION = 269,
-     UNKNOWN_OPTION = 270,
-     UNKNOWN = 271,
-     BINARY_PROTOCOL = 272,
-     BUFFER_REQUESTS = 273,
-     CONNECT_TIMEOUT = 274,
-     DISTRIBUTION = 275,
-     HASH = 276,
-     HASH_WITH_NAMESPACE = 277,
-     IO_BYTES_WATERMARK = 278,
-     IO_KEY_PREFETCH = 279,
-     IO_MSG_WATERMARK = 280,
-     KETAMA_HASH = 281,
-     KETAMA_WEIGHTED = 282,
-     NOREPLY = 283,
-     NUMBER_OF_REPLICAS = 284,
-     POLL_TIMEOUT = 285,
-     RANDOMIZE_REPLICA_READ = 286,
-     RCV_TIMEOUT = 287,
-     REMOVE_FAILED_SERVERS = 288,
-     RETRY_TIMEOUT = 289,
-     SND_TIMEOUT = 290,
-     SOCKET_RECV_SIZE = 291,
-     SOCKET_SEND_SIZE = 292,
-     SORT_HOSTS = 293,
-     SUPPORT_CAS = 294,
-     USER_DATA = 295,
-     USE_UDP = 296,
-     VERIFY_KEY = 297,
-     _TCP_KEEPALIVE = 298,
-     _TCP_KEEPIDLE = 299,
-     _TCP_NODELAY = 300,
-     NAMESPACE = 301,
-     POOL_MIN = 302,
-     POOL_MAX = 303,
-     MD5 = 304,
-     CRC = 305,
-     FNV1_64 = 306,
-     FNV1A_64 = 307,
-     FNV1_32 = 308,
-     FNV1A_32 = 309,
-     HSIEH = 310,
-     MURMUR = 311,
-     JENKINS = 312,
-     CONSISTENT = 313,
-     MODULA = 314,
-     RANDOM = 315,
-     MC_TRUE = 316,
-     MC_FALSE = 317,
-     FLOAT = 318,
-     NUMBER = 319,
-     PORT = 320,
-     WEIGHT_START = 321,
-     IPADDRESS = 322,
-     HOSTNAME = 323,
-     STRING = 324,
-     QUOTED_STRING = 325,
-     FILE_PATH = 326
-   };
-#endif
+#include "parser.h"
+/* Symbol kind.  */
+enum yysymbol_kind_t
+{
+  YYSYMBOL_YYEMPTY = -2,
+  YYSYMBOL_YYEOF = 0,                      /* "end of file"  */
+  YYSYMBOL_YYerror = 1,                    /* error  */
+  YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
+  YYSYMBOL_COMMENT = 3,                    /* COMMENT  */
+  YYSYMBOL_END = 4,                        /* END  */
+  YYSYMBOL_ERROR = 5,                      /* ERROR  */
+  YYSYMBOL_RESET = 6,                      /* RESET  */
+  YYSYMBOL_PARSER_DEBUG = 7,               /* PARSER_DEBUG  */
+  YYSYMBOL_INCLUDE = 8,                    /* INCLUDE  */
+  YYSYMBOL_CONFIGURE_FILE = 9,             /* CONFIGURE_FILE  */
+  YYSYMBOL_EMPTY_LINE = 10,                /* EMPTY_LINE  */
+  YYSYMBOL_SERVER = 11,                    /* SERVER  */
+  YYSYMBOL_SOCKET = 12,                    /* SOCKET  */
+  YYSYMBOL_SERVERS = 13,                   /* SERVERS  */
+  YYSYMBOL_SERVERS_OPTION = 14,            /* SERVERS_OPTION  */
+  YYSYMBOL_UNKNOWN_OPTION = 15,            /* UNKNOWN_OPTION  */
+  YYSYMBOL_UNKNOWN = 16,                   /* UNKNOWN  */
+  YYSYMBOL_BINARY_PROTOCOL = 17,           /* BINARY_PROTOCOL  */
+  YYSYMBOL_BUFFER_REQUESTS = 18,           /* BUFFER_REQUESTS  */
+  YYSYMBOL_CONNECT_TIMEOUT = 19,           /* CONNECT_TIMEOUT  */
+  YYSYMBOL_DISTRIBUTION = 20,              /* DISTRIBUTION  */
+  YYSYMBOL_HASH = 21,                      /* HASH  */
+  YYSYMBOL_HASH_WITH_NAMESPACE = 22,       /* HASH_WITH_NAMESPACE  */
+  YYSYMBOL_IO_BYTES_WATERMARK = 23,        /* IO_BYTES_WATERMARK  */
+  YYSYMBOL_IO_KEY_PREFETCH = 24,           /* IO_KEY_PREFETCH  */
+  YYSYMBOL_IO_MSG_WATERMARK = 25,          /* IO_MSG_WATERMARK  */
+  YYSYMBOL_KETAMA_HASH = 26,               /* KETAMA_HASH  */
+  YYSYMBOL_KETAMA_WEIGHTED = 27,           /* KETAMA_WEIGHTED  */
+  YYSYMBOL_NOREPLY = 28,                   /* NOREPLY  */
+  YYSYMBOL_NUMBER_OF_REPLICAS = 29,        /* NUMBER_OF_REPLICAS  */
+  YYSYMBOL_POLL_TIMEOUT = 30,              /* POLL_TIMEOUT  */
+  YYSYMBOL_RANDOMIZE_REPLICA_READ = 31,    /* RANDOMIZE_REPLICA_READ  */
+  YYSYMBOL_RCV_TIMEOUT = 32,               /* RCV_TIMEOUT  */
+  YYSYMBOL_REMOVE_FAILED_SERVERS = 33,     /* REMOVE_FAILED_SERVERS  */
+  YYSYMBOL_RETRY_TIMEOUT = 34,             /* RETRY_TIMEOUT  */
+  YYSYMBOL_SND_TIMEOUT = 35,               /* SND_TIMEOUT  */
+  YYSYMBOL_SOCKET_RECV_SIZE = 36,          /* SOCKET_RECV_SIZE  */
+  YYSYMBOL_SOCKET_SEND_SIZE = 37,          /* SOCKET_SEND_SIZE  */
+  YYSYMBOL_SORT_HOSTS = 38,                /* SORT_HOSTS  */
+  YYSYMBOL_SUPPORT_CAS = 39,               /* SUPPORT_CAS  */
+  YYSYMBOL_USER_DATA = 40,                 /* USER_DATA  */
+  YYSYMBOL_USE_UDP = 41,                   /* USE_UDP  */
+  YYSYMBOL_VERIFY_KEY = 42,                /* VERIFY_KEY  */
+  YYSYMBOL__TCP_KEEPALIVE = 43,            /* _TCP_KEEPALIVE  */
+  YYSYMBOL__TCP_KEEPIDLE = 44,             /* _TCP_KEEPIDLE  */
+  YYSYMBOL__TCP_NODELAY = 45,              /* _TCP_NODELAY  */
+  YYSYMBOL_NAMESPACE = 46,                 /* NAMESPACE  */
+  YYSYMBOL_POOL_MIN = 47,                  /* POOL_MIN  */
+  YYSYMBOL_POOL_MAX = 48,                  /* POOL_MAX  */
+  YYSYMBOL_MD5 = 49,                       /* MD5  */
+  YYSYMBOL_CRC = 50,                       /* CRC  */
+  YYSYMBOL_FNV1_64 = 51,                   /* FNV1_64  */
+  YYSYMBOL_FNV1A_64 = 52,                  /* FNV1A_64  */
+  YYSYMBOL_FNV1_32 = 53,                   /* FNV1_32  */
+  YYSYMBOL_FNV1A_32 = 54,                  /* FNV1A_32  */
+  YYSYMBOL_HSIEH = 55,                     /* HSIEH  */
+  YYSYMBOL_MURMUR = 56,                    /* MURMUR  */
+  YYSYMBOL_JENKINS = 57,                   /* JENKINS  */
+  YYSYMBOL_CONSISTENT = 58,                /* CONSISTENT  */
+  YYSYMBOL_MODULA = 59,                    /* MODULA  */
+  YYSYMBOL_RANDOM = 60,                    /* RANDOM  */
+  YYSYMBOL_TRUE = 61,                      /* TRUE  */
+  YYSYMBOL_FALSE = 62,                     /* FALSE  */
+  YYSYMBOL_63_ = 63,                       /* ','  */
+  YYSYMBOL_64_ = 64,                       /* '='  */
+  YYSYMBOL_FLOAT = 65,                     /* FLOAT  */
+  YYSYMBOL_NUMBER = 66,                    /* NUMBER  */
+  YYSYMBOL_PORT = 67,                      /* PORT  */
+  YYSYMBOL_WEIGHT_START = 68,              /* WEIGHT_START  */
+  YYSYMBOL_IPADDRESS = 69,                 /* IPADDRESS  */
+  YYSYMBOL_HOSTNAME = 70,                  /* HOSTNAME  */
+  YYSYMBOL_STRING = 71,                    /* STRING  */
+  YYSYMBOL_QUOTED_STRING = 72,             /* QUOTED_STRING  */
+  YYSYMBOL_FILE_PATH = 73,                 /* FILE_PATH  */
+  YYSYMBOL_74_ = 74,                       /* ' '  */
+  YYSYMBOL_YYACCEPT = 75,                  /* $accept  */
+  YYSYMBOL_begin = 76,                     /* begin  */
+  YYSYMBOL_statement = 77,                 /* statement  */
+  YYSYMBOL_expression = 78,                /* expression  */
+  YYSYMBOL_behaviors = 79,                 /* behaviors  */
+  YYSYMBOL_behavior_number = 80,           /* behavior_number  */
+  YYSYMBOL_behavior_boolean = 81,          /* behavior_boolean  */
+  YYSYMBOL_optional_port = 82,             /* optional_port  */
+  YYSYMBOL_optional_weight = 83,           /* optional_weight  */
+  YYSYMBOL_hash = 84,                      /* hash  */
+  YYSYMBOL_string = 85,                    /* string  */
+  YYSYMBOL_distribution = 86               /* distribution  */
+};
+typedef enum yysymbol_kind_t yysymbol_kind_t;
 
 
 
-#if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
-
-# define yystype YYSTYPE /* obsolescent; will be withdrawn */
-# define YYSTYPE_IS_DECLARED 1
-#endif
-
-
-/* Copy the second part of user declarations.  */
-
-
-/* Line 264 of yacc.c  */
-#line 232 "libmemcached/csl/parser.cc"
 
 #ifdef short
 # undef short
 #endif
 
-#ifdef YYTYPE_UINT8
-typedef YYTYPE_UINT8 yytype_uint8;
-#else
-typedef unsigned char yytype_uint8;
+/* On compilers that do not define __PTRDIFF_MAX__ etc., make sure
+   <limits.h> and (if available) <stdint.h> are included
+   so that the code can choose integer types of a good width.  */
+
+#ifndef __PTRDIFF_MAX__
+# include <limits.h> /* INFRINGES ON USER NAME SPACE */
+# if defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#  include <stdint.h> /* INFRINGES ON USER NAME SPACE */
+#  define YY_STDINT_H
+# endif
 #endif
 
-#ifdef YYTYPE_INT8
-typedef YYTYPE_INT8 yytype_int8;
-#elif (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+/* Narrow types that promote to a signed type and that can represent a
+   signed or unsigned integer of at least N bits.  In tables they can
+   save space and decrease cache pressure.  Promoting to a signed type
+   helps avoid bugs in integer arithmetic.  */
+
+#ifdef __INT_LEAST8_MAX__
+typedef __INT_LEAST8_TYPE__ yytype_int8;
+#elif defined YY_STDINT_H
+typedef int_least8_t yytype_int8;
+#else
 typedef signed char yytype_int8;
-#else
-typedef short int yytype_int8;
 #endif
 
-#ifdef YYTYPE_UINT16
-typedef YYTYPE_UINT16 yytype_uint16;
+#ifdef __INT_LEAST16_MAX__
+typedef __INT_LEAST16_TYPE__ yytype_int16;
+#elif defined YY_STDINT_H
+typedef int_least16_t yytype_int16;
 #else
-typedef unsigned short int yytype_uint16;
+typedef short yytype_int16;
 #endif
 
-#ifdef YYTYPE_INT16
-typedef YYTYPE_INT16 yytype_int16;
+/* Work around bug in HP-UX 11.23, which defines these macros
+   incorrectly for preprocessor constants.  This workaround can likely
+   be removed in 2023, as HPE has promised support for HP-UX 11.23
+   (aka HP-UX 11i v2) only through the end of 2022; see Table 2 of
+   <https://h20195.www2.hpe.com/V2/getpdf.aspx/4AA4-7673ENW.pdf>.  */
+#ifdef __hpux
+# undef UINT_LEAST8_MAX
+# undef UINT_LEAST16_MAX
+# define UINT_LEAST8_MAX 255
+# define UINT_LEAST16_MAX 65535
+#endif
+
+#if defined __UINT_LEAST8_MAX__ && __UINT_LEAST8_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST8_TYPE__ yytype_uint8;
+#elif (!defined __UINT_LEAST8_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST8_MAX <= INT_MAX)
+typedef uint_least8_t yytype_uint8;
+#elif !defined __UINT_LEAST8_MAX__ && UCHAR_MAX <= INT_MAX
+typedef unsigned char yytype_uint8;
 #else
-typedef short int yytype_int16;
+typedef short yytype_uint8;
+#endif
+
+#if defined __UINT_LEAST16_MAX__ && __UINT_LEAST16_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST16_TYPE__ yytype_uint16;
+#elif (!defined __UINT_LEAST16_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST16_MAX <= INT_MAX)
+typedef uint_least16_t yytype_uint16;
+#elif !defined __UINT_LEAST16_MAX__ && USHRT_MAX <= INT_MAX
+typedef unsigned short yytype_uint16;
+#else
+typedef int yytype_uint16;
+#endif
+
+#ifndef YYPTRDIFF_T
+# if defined __PTRDIFF_TYPE__ && defined __PTRDIFF_MAX__
+#  define YYPTRDIFF_T __PTRDIFF_TYPE__
+#  define YYPTRDIFF_MAXIMUM __PTRDIFF_MAX__
+# elif defined PTRDIFF_MAX
+#  ifndef ptrdiff_t
+#   include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  endif
+#  define YYPTRDIFF_T ptrdiff_t
+#  define YYPTRDIFF_MAXIMUM PTRDIFF_MAX
+# else
+#  define YYPTRDIFF_T long
+#  define YYPTRDIFF_MAXIMUM LONG_MAX
+# endif
 #endif
 
 #ifndef YYSIZE_T
@@ -266,55 +324,106 @@ typedef short int yytype_int16;
 #  define YYSIZE_T __SIZE_TYPE__
 # elif defined size_t
 #  define YYSIZE_T size_t
-# elif ! defined YYSIZE_T && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+# elif defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
-#  define YYSIZE_T unsigned int
+#  define YYSIZE_T unsigned
 # endif
 #endif
 
-#define YYSIZE_MAXIMUM ((YYSIZE_T) -1)
+#define YYSIZE_MAXIMUM                                  \
+  YY_CAST (YYPTRDIFF_T,                                 \
+           (YYPTRDIFF_MAXIMUM < YY_CAST (YYSIZE_T, -1)  \
+            ? YYPTRDIFF_MAXIMUM                         \
+            : YY_CAST (YYSIZE_T, -1)))
+
+#define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
+
+
+/* Stored state numbers (used for stacks). */
+typedef yytype_int8 yy_state_t;
+
+/* State numbers in computations.  */
+typedef int yy_state_fast_t;
 
 #ifndef YY_
 # if defined YYENABLE_NLS && YYENABLE_NLS
 #  if ENABLE_NLS
 #   include <libintl.h> /* INFRINGES ON USER NAME SPACE */
-#   define YY_(msgid) dgettext ("bison-runtime", msgid)
+#   define YY_(Msgid) dgettext ("bison-runtime", Msgid)
 #  endif
 # endif
 # ifndef YY_
-#  define YY_(msgid) msgid
+#  define YY_(Msgid) Msgid
+# endif
+#endif
+
+
+#ifndef YY_ATTRIBUTE_PURE
+# if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_PURE __attribute__ ((__pure__))
+# else
+#  define YY_ATTRIBUTE_PURE
+# endif
+#endif
+
+#ifndef YY_ATTRIBUTE_UNUSED
+# if defined __GNUC__ && 2 < __GNUC__ + (7 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_UNUSED __attribute__ ((__unused__))
+# else
+#  define YY_ATTRIBUTE_UNUSED
 # endif
 #endif
 
 /* Suppress unused-variable warnings by "using" E.  */
 #if ! defined lint || defined __GNUC__
-# define YYUSE(e) ((void) (e))
+# define YY_USE(E) ((void) (E))
 #else
-# define YYUSE(e) /* empty */
+# define YY_USE(E) /* empty */
 #endif
 
-/* Identity function, used to suppress warnings about constant conditions.  */
-#ifndef lint
-# define YYID(n) (n)
+/* Suppress an incorrect diagnostic about yylval being uninitialized.  */
+#if defined __GNUC__ && ! defined __ICC && 406 <= __GNUC__ * 100 + __GNUC_MINOR__
+# if __GNUC__ * 100 + __GNUC_MINOR__ < 407
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")
+# else
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
+    _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+# endif
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
+    _Pragma ("GCC diagnostic pop")
 #else
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-static int
-YYID (int yyi)
-#else
-static int
-YYID (yyi)
-    int yyi;
+# define YY_INITIAL_VALUE(Value) Value
 #endif
-{
-  return yyi;
-}
+#ifndef YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END
+#endif
+#ifndef YY_INITIAL_VALUE
+# define YY_INITIAL_VALUE(Value) /* Nothing. */
 #endif
 
-#if ! defined yyoverflow || YYERROR_VERBOSE
+#if defined __cplusplus && defined __GNUC__ && ! defined __ICC && 6 <= __GNUC__
+# define YY_IGNORE_USELESS_CAST_BEGIN                          \
+    _Pragma ("GCC diagnostic push")                            \
+    _Pragma ("GCC diagnostic ignored \"-Wuseless-cast\"")
+# define YY_IGNORE_USELESS_CAST_END            \
+    _Pragma ("GCC diagnostic pop")
+#endif
+#ifndef YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_END
+#endif
+
+
+#define YY_ASSERT(E) ((void) (0 && (E)))
+
+#if 1
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */
 
@@ -331,11 +440,11 @@ YYID (yyi)
 #    define alloca _alloca
 #   else
 #    define YYSTACK_ALLOC alloca
-#    if ! defined _ALLOCA_H && ! defined _STDLIB_H && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#    if ! defined _ALLOCA_H && ! defined EXIT_SUCCESS
 #     include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
-#     ifndef _STDLIB_H
-#      define _STDLIB_H 1
+      /* Use EXIT_SUCCESS as a witness for stdlib.h.  */
+#     ifndef EXIT_SUCCESS
+#      define EXIT_SUCCESS 0
 #     endif
 #    endif
 #   endif
@@ -343,8 +452,8 @@ YYID (yyi)
 # endif
 
 # ifdef YYSTACK_ALLOC
-   /* Pacify GCC's `empty if-body' warning.  */
-#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (YYID (0))
+   /* Pacify GCC's 'empty if-body' warning.  */
+#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (0)
 #  ifndef YYSTACK_ALLOC_MAXIMUM
     /* The OS might guarantee only one guard page at the bottom of the stack,
        and a page size can be as small as 4096 bytes.  So we cannot safely
@@ -358,87 +467,88 @@ YYID (yyi)
 #  ifndef YYSTACK_ALLOC_MAXIMUM
 #   define YYSTACK_ALLOC_MAXIMUM YYSIZE_MAXIMUM
 #  endif
-#  if (defined __cplusplus && ! defined _STDLIB_H \
+#  if (defined __cplusplus && ! defined EXIT_SUCCESS \
        && ! ((defined YYMALLOC || defined malloc) \
-	     && (defined YYFREE || defined free)))
+             && (defined YYFREE || defined free)))
 #   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
-#   ifndef _STDLIB_H
-#    define _STDLIB_H 1
+#   ifndef EXIT_SUCCESS
+#    define EXIT_SUCCESS 0
 #   endif
 #  endif
 #  ifndef YYMALLOC
 #   define YYMALLOC malloc
-#   if ! defined malloc && ! defined _STDLIB_H && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#   if ! defined malloc && ! defined EXIT_SUCCESS
 void *malloc (YYSIZE_T); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 #  ifndef YYFREE
 #   define YYFREE free
-#   if ! defined free && ! defined _STDLIB_H && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#   if ! defined free && ! defined EXIT_SUCCESS
 void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 # endif
-#endif /* ! defined yyoverflow || YYERROR_VERBOSE */
-
+#endif /* 1 */
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
-	 || (defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
+         || (defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
 
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
 {
-  yytype_int16 yyss_alloc;
+  yy_state_t yyss_alloc;
   YYSTYPE yyvs_alloc;
 };
 
 /* The size of the maximum gap between one aligned stack and the next.  */
-# define YYSTACK_GAP_MAXIMUM (sizeof (union yyalloc) - 1)
+# define YYSTACK_GAP_MAXIMUM (YYSIZEOF (union yyalloc) - 1)
 
 /* The size of an array large to enough to hold all stacks, each with
    N elements.  */
 # define YYSTACK_BYTES(N) \
-     ((N) * (sizeof (yytype_int16) + sizeof (YYSTYPE)) \
+     ((N) * (YYSIZEOF (yy_state_t) + YYSIZEOF (YYSTYPE)) \
       + YYSTACK_GAP_MAXIMUM)
 
-/* Copy COUNT objects from FROM to TO.  The source and destination do
-   not overlap.  */
-# ifndef YYCOPY
-#  if defined __GNUC__ && 1 < __GNUC__
-#   define YYCOPY(To, From, Count) \
-      __builtin_memcpy (To, From, (Count) * sizeof (*(From)))
-#  else
-#   define YYCOPY(To, From, Count)		\
-      do					\
-	{					\
-	  YYSIZE_T yyi;				\
-	  for (yyi = 0; yyi < (Count); yyi++)	\
-	    (To)[yyi] = (From)[yyi];		\
-	}					\
-      while (YYID (0))
-#  endif
-# endif
+# define YYCOPY_NEEDED 1
 
 /* Relocate STACK from its old location to the new one.  The
    local variables YYSIZE and YYSTACKSIZE give the old and new number of
    elements in the stack, and YYPTR gives the new location of the
    stack.  Advance YYPTR to a properly aligned location for the next
    stack.  */
-# define YYSTACK_RELOCATE(Stack_alloc, Stack)				\
-    do									\
-      {									\
-	YYSIZE_T yynewbytes;						\
-	YYCOPY (&yyptr->Stack_alloc, Stack, yysize);			\
-	Stack = &yyptr->Stack_alloc;					\
-	yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
-	yyptr += yynewbytes / sizeof (*yyptr);				\
-      }									\
-    while (YYID (0))
+# define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
+    do                                                                  \
+      {                                                                 \
+        YYPTRDIFF_T yynewbytes;                                         \
+        YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
+        Stack = &yyptr->Stack_alloc;                                    \
+        yynewbytes = yystacksize * YYSIZEOF (*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / YYSIZEOF (*yyptr);                        \
+      }                                                                 \
+    while (0)
 
 #endif
+
+#if defined YYCOPY_NEEDED && YYCOPY_NEEDED
+/* Copy COUNT objects from SRC to DST.  The source and destination do
+   not overlap.  */
+# ifndef YYCOPY
+#  if defined __GNUC__ && 1 < __GNUC__
+#   define YYCOPY(Dst, Src, Count) \
+      __builtin_memcpy (Dst, Src, YY_CAST (YYSIZE_T, (Count)) * sizeof (*(Src)))
+#  else
+#   define YYCOPY(Dst, Src, Count)              \
+      do                                        \
+        {                                       \
+          YYPTRDIFF_T yyi;                      \
+          for (yyi = 0; yyi < (Count); yyi++)   \
+            (Dst)[yyi] = (Src)[yyi];            \
+        }                                       \
+      while (0)
+#  endif
+# endif
+#endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  71
@@ -451,18 +561,23 @@ union yyalloc
 #define YYNNTS  12
 /* YYNRULES -- Number of rules.  */
 #define YYNRULES  67
-/* YYNRULES -- Number of states.  */
+/* YYNSTATES -- Number of states.  */
 #define YYNSTATES  85
 
-/* YYTRANSLATE(YYLEX) -- Bison symbol number corresponding to YYLEX.  */
-#define YYUNDEFTOK  2
+/* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   326
 
-#define YYTRANSLATE(YYX)						\
-  ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
 
-/* YYTRANSLATE[YYLEX] -- Bison symbol number corresponding to YYLEX.  */
-static const yytype_uint8 yytranslate[] =
+/* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex, with out-of-bounds checking.  */
+#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_kind_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
+
+/* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex.  */
+static const yytype_int8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -500,42 +615,8 @@ static const yytype_uint8 yytranslate[] =
 };
 
 #if YYDEBUG
-/* YYPRHS[YYN] -- Index of the first RHS symbol of rule number YYN in
-   YYRHS.  */
-static const yytype_uint8 yyprhs[] =
-{
-       0,     0,     3,     5,     9,    11,    13,    15,    17,    19,
-      21,    23,    27,    32,    37,    41,    44,    47,    50,    52,
-      55,    58,    63,    66,    69,    71,    73,    75,    77,    79,
-      81,    83,    85,    87,    89,    91,    93,    95,    97,    99,
-     101,   103,   105,   107,   109,   111,   113,   115,   117,   119,
-     121,   122,   124,   125,   127,   129,   131,   133,   135,   137,
-     139,   141,   143,   145,   147,   149,   151,   153
-};
-
-/* YYRHS -- A `-1'-separated list of the rules' RHS.  */
-static const yytype_int8 yyrhs[] =
-{
-      76,     0,    -1,    77,    -1,    76,    74,    77,    -1,    78,
-      -1,     3,    -1,    10,    -1,     4,    -1,     5,    -1,     6,
-      -1,     7,    -1,     8,    74,    85,    -1,    11,    70,    82,
-      83,    -1,    11,    69,    82,    83,    -1,    12,    85,    83,
-      -1,     9,    85,    -1,    47,    66,    -1,    48,    66,    -1,
-      79,    -1,    46,    85,    -1,    20,    86,    -1,    20,    86,
-      63,    84,    -1,    21,    84,    -1,    80,    66,    -1,    81,
-      -1,    40,    -1,    33,    -1,    19,    -1,    25,    -1,    23,
-      -1,    24,    -1,    29,    -1,    30,    -1,    32,    -1,    34,
-      -1,    35,    -1,    36,    -1,    37,    -1,    17,    -1,    18,
-      -1,    22,    -1,    28,    -1,    31,    -1,    38,    -1,    39,
-      -1,    45,    -1,    43,    -1,    44,    -1,    41,    -1,    42,
-      -1,    -1,    67,    -1,    -1,    68,    -1,    49,    -1,    50,
-      -1,    51,    -1,    52,    -1,    53,    -1,    54,    -1,    55,
-      -1,    56,    -1,    57,    -1,    71,    -1,    72,    -1,    58,
-      -1,    59,    -1,    60,    -1
-};
-
-/* YYRLINE[YYN] -- source line where rule number YYN was defined.  */
-static const yytype_uint16 yyrline[] =
+/* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
+static const yytype_int16 yyrline[] =
 {
        0,   172,   172,   173,   177,   179,   181,   183,   188,   193,
      197,   201,   212,   220,   228,   235,   239,   243,   247,   251,
@@ -547,98 +628,58 @@ static const yytype_uint16 yyrline[] =
 };
 #endif
 
-#if YYDEBUG || YYERROR_VERBOSE || YYTOKEN_TABLE
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_kind_t, yystos[State])
+
+#if 1
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "$end", "error", "$undefined", "COMMENT", "END", "ERROR", "RESET",
-  "PARSER_DEBUG", "INCLUDE", "CONFIGURE_FILE", "EMPTY_LINE", "SERVER",
-  "SOCKET", "SERVERS", "SERVERS_OPTION", "UNKNOWN_OPTION", "UNKNOWN",
-  "BINARY_PROTOCOL", "BUFFER_REQUESTS", "CONNECT_TIMEOUT", "DISTRIBUTION",
-  "HASH", "HASH_WITH_NAMESPACE", "IO_BYTES_WATERMARK", "IO_KEY_PREFETCH",
-  "IO_MSG_WATERMARK", "KETAMA_HASH", "KETAMA_WEIGHTED", "NOREPLY",
-  "NUMBER_OF_REPLICAS", "POLL_TIMEOUT", "RANDOMIZE_REPLICA_READ",
-  "RCV_TIMEOUT", "REMOVE_FAILED_SERVERS", "RETRY_TIMEOUT", "SND_TIMEOUT",
+  "\"end of file\"", "error", "\"invalid token\"", "COMMENT", "END",
+  "ERROR", "RESET", "PARSER_DEBUG", "INCLUDE", "CONFIGURE_FILE",
+  "EMPTY_LINE", "SERVER", "SOCKET", "SERVERS", "SERVERS_OPTION",
+  "UNKNOWN_OPTION", "UNKNOWN", "BINARY_PROTOCOL", "BUFFER_REQUESTS",
+  "CONNECT_TIMEOUT", "DISTRIBUTION", "HASH", "HASH_WITH_NAMESPACE",
+  "IO_BYTES_WATERMARK", "IO_KEY_PREFETCH", "IO_MSG_WATERMARK",
+  "KETAMA_HASH", "KETAMA_WEIGHTED", "NOREPLY", "NUMBER_OF_REPLICAS",
+  "POLL_TIMEOUT", "RANDOMIZE_REPLICA_READ", "RCV_TIMEOUT",
+  "REMOVE_FAILED_SERVERS", "RETRY_TIMEOUT", "SND_TIMEOUT",
   "SOCKET_RECV_SIZE", "SOCKET_SEND_SIZE", "SORT_HOSTS", "SUPPORT_CAS",
   "USER_DATA", "USE_UDP", "VERIFY_KEY", "_TCP_KEEPALIVE", "_TCP_KEEPIDLE",
   "_TCP_NODELAY", "NAMESPACE", "POOL_MIN", "POOL_MAX", "MD5", "CRC",
   "FNV1_64", "FNV1A_64", "FNV1_32", "FNV1A_32", "HSIEH", "MURMUR",
-  "JENKINS", "CONSISTENT", "MODULA", "RANDOM", "MC_TRUE", "MC_FALSE", "','",
+  "JENKINS", "CONSISTENT", "MODULA", "RANDOM", "TRUE", "FALSE", "','",
   "'='", "FLOAT", "NUMBER", "PORT", "WEIGHT_START", "IPADDRESS",
   "HOSTNAME", "STRING", "QUOTED_STRING", "FILE_PATH", "' '", "$accept",
   "begin", "statement", "expression", "behaviors", "behavior_number",
   "behavior_boolean", "optional_port", "optional_weight", "hash", "string",
-  "distribution", 0
+  "distribution", YY_NULLPTR
 };
+
+static const char *
+yysymbol_name (yysymbol_kind_t yysymbol)
+{
+  return yytname[yysymbol];
+}
 #endif
 
-# ifdef YYPRINT
-/* YYTOKNUM[YYLEX-NUM] -- Internal token number corresponding to
-   token YYLEX-NUM.  */
-static const yytype_uint16 yytoknum[] =
-{
-       0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
-     265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
-     275,   276,   277,   278,   279,   280,   281,   282,   283,   284,
-     285,   286,   287,   288,   289,   290,   291,   292,   293,   294,
-     295,   296,   297,   298,   299,   300,   301,   302,   303,   304,
-     305,   306,   307,   308,   309,   310,   311,   312,   313,   314,
-     315,   316,   317,    44,    61,   318,   319,   320,   321,   322,
-     323,   324,   325,   326,    32
-};
-# endif
+#define YYPACT_NINF (-61)
 
-/* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
-static const yytype_uint8 yyr1[] =
-{
-       0,    75,    76,    76,    77,    77,    77,    77,    77,    77,
-      77,    77,    78,    78,    78,    78,    78,    78,    78,    79,
-      79,    79,    79,    79,    79,    79,    80,    80,    80,    80,
-      80,    80,    80,    80,    80,    80,    80,    80,    81,    81,
-      81,    81,    81,    81,    81,    81,    81,    81,    81,    81,
-      82,    82,    83,    83,    84,    84,    84,    84,    84,    84,
-      84,    84,    84,    85,    85,    86,    86,    86
-};
+#define yypact_value_is_default(Yyn) \
+  ((Yyn) == YYPACT_NINF)
 
-/* YYR2[YYN] -- Number of symbols composing right hand side of rule YYN.  */
-static const yytype_uint8 yyr2[] =
-{
-       0,     2,     1,     3,     1,     1,     1,     1,     1,     1,
-       1,     3,     4,     4,     3,     2,     2,     2,     1,     2,
-       2,     4,     2,     2,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       0,     1,     0,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     1,     1
-};
+#define YYTABLE_NINF (-1)
 
-/* YYDEFACT[STATE-NAME] -- Default rule to reduce with in state
-   STATE-NUM when YYTABLE doesn't specify something else to do.  Zero
-   means the default is an error.  */
-static const yytype_uint8 yydefact[] =
-{
-       0,     5,     7,     8,     9,    10,     0,     0,     6,     0,
-       0,    38,    39,    27,     0,     0,    40,    29,    30,    28,
-      41,    31,    32,    42,    33,    26,    34,    35,    36,    37,
-      43,    44,    25,    48,    49,    46,    47,    45,     0,     0,
-       0,     0,     2,     4,    18,     0,    24,     0,    63,    64,
-      15,    50,    50,    52,    65,    66,    67,    20,    54,    55,
-      56,    57,    58,    59,    60,    61,    62,    22,    19,    16,
-      17,     1,     0,    23,    11,    51,    52,    52,    53,    14,
-       0,     3,    13,    12,    21
-};
-
-/* YYDEFGOTO[NTERM-NUM].  */
-static const yytype_int8 yydefgoto[] =
-{
-      -1,    41,    42,    43,    44,    45,    46,    76,    79,    67,
-      50,    57
-};
+#define yytable_value_is_error(Yyn) \
+  0
 
 /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
    STATE-NUM.  */
-#define YYPACT_NINF -61
 static const yytype_int8 yypact[] =
 {
       -2,   -61,   -61,   -61,   -61,   -61,   -60,   -24,   -61,   -20,
@@ -652,6 +693,22 @@ static const yytype_int8 yypact[] =
       13,   -61,   -61,   -61,   -61
 };
 
+/* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+   Performed when YYTABLE does not specify something else to do.  Zero
+   means the default is an error.  */
+static const yytype_int8 yydefact[] =
+{
+       0,     5,     7,     8,     9,    10,     0,     0,     6,     0,
+       0,    38,    39,    27,     0,     0,    40,    29,    30,    28,
+      41,    31,    32,    42,    33,    26,    34,    35,    36,    37,
+      43,    44,    25,    48,    49,    46,    47,    45,     0,     0,
+       0,     0,     2,     4,    18,     0,    24,     0,    63,    64,
+      15,    50,    50,    52,    65,    66,    67,    20,    54,    55,
+      56,    57,    58,    59,    60,    61,    62,    22,    19,    16,
+      17,     1,     0,    23,    11,    51,    52,    52,    53,    14,
+       0,     3,    13,    12,    21
+};
+
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
@@ -659,12 +716,17 @@ static const yytype_int8 yypgoto[] =
       14,   -61
 };
 
-/* YYTABLE[YYPACT[STATE-NUM]].  What to do in state STATE-NUM.  If
-   positive, shift that token.  If negative, reduce the rule which
-   number is the opposite.  If zero, do what YYDEFACT says.
-   If YYTABLE_NINF, syntax error.  */
-#define YYTABLE_NINF -1
-static const yytype_uint8 yytable[] =
+/* YYDEFGOTO[NTERM-NUM].  */
+static const yytype_int8 yydefgoto[] =
+{
+       0,    41,    42,    43,    44,    45,    46,    76,    79,    67,
+      50,    57
+};
+
+/* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+   positive, shift that token.  If negative, reduce the rule whose
+   number is the opposite.  If YYTABLE_NINF, syntax error.  */
+static const yytype_int8 yytable[] =
 {
       71,     1,     2,     3,     4,     5,     6,     7,     8,     9,
       10,    54,    55,    56,    47,    11,    12,    13,    14,    15,
@@ -688,9 +750,9 @@ static const yytype_int8 yycheck[] =
       57,    80,    -1,    -1,    74
 };
 
-/* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-   symbol of state STATE-NUM.  */
-static const yytype_uint8 yystos[] =
+/* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
+   state STATE-NUM.  */
+static const yytype_int8 yystos[] =
 {
        0,     3,     4,     5,     6,     7,     8,     9,    10,    11,
       12,    17,    18,    19,    20,    21,    22,    23,    24,    25,
@@ -703,104 +765,65 @@ static const yytype_uint8 yystos[] =
       63,    77,    83,    83,    84
 };
 
-#define yyerrok		(yyerrstatus = 0)
-#define yyclearin	(yychar = YYEMPTY)
-#define YYEMPTY		(-2)
-#define YYEOF		0
+/* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr1[] =
+{
+       0,    75,    76,    76,    77,    77,    77,    77,    77,    77,
+      77,    77,    78,    78,    78,    78,    78,    78,    78,    79,
+      79,    79,    79,    79,    79,    79,    80,    80,    80,    80,
+      80,    80,    80,    80,    80,    80,    80,    80,    81,    81,
+      81,    81,    81,    81,    81,    81,    81,    81,    81,    81,
+      82,    82,    83,    83,    84,    84,    84,    84,    84,    84,
+      84,    84,    84,    85,    85,    86,    86,    86
+};
 
-#define YYACCEPT	goto yyacceptlab
-#define YYABORT		goto yyabortlab
-#define YYERROR		goto yyerrorlab
+/* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr2[] =
+{
+       0,     2,     1,     3,     1,     1,     1,     1,     1,     1,
+       1,     3,     4,     4,     3,     2,     2,     2,     1,     2,
+       2,     4,     2,     2,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       0,     1,     0,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     1
+};
 
 
-/* Like YYERROR except do call yyerror.  This remains here temporarily
-   to ease the transition to the new meaning of YYERROR, for GCC.
-   Once GCC version 2 has supplanted version 1, this can go.  However,
-   YYFAIL appears to be in use.  Nevertheless, it is formally deprecated
-   in Bison 2.4.2's NEWS entry, where a plan to phase it out is
-   discussed.  */
+enum { YYENOMEM = -2 };
 
-#define YYFAIL		goto yyerrlab
-#if defined YYFAIL
-  /* This is here to suppress warnings from the GCC cpp's
-     -Wunused-macros.  Normally we don't worry about that warning, but
-     some users do, and we want to make it easy for users to remove
-     YYFAIL uses, which will produce warnings from Bison 2.5.  */
-#endif
+#define yyerrok         (yyerrstatus = 0)
+#define yyclearin       (yychar = YYEMPTY)
+
+#define YYACCEPT        goto yyacceptlab
+#define YYABORT         goto yyabortlab
+#define YYERROR         goto yyerrorlab
+#define YYNOMEM         goto yyexhaustedlab
+
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
-#define YYBACKUP(Token, Value)					\
-do								\
-  if (yychar == YYEMPTY && yylen == 1)				\
-    {								\
-      yychar = (Token);						\
-      yylval = (Value);						\
-      yytoken = YYTRANSLATE (yychar);				\
-      YYPOPSTACK (1);						\
-      goto yybackup;						\
-    }								\
-  else								\
-    {								\
-      yyerror (context, scanner, YY_("syntax error: cannot back up")); \
-      YYERROR;							\
-    }								\
-while (YYID (0))
+#define YYBACKUP(Token, Value)                                    \
+  do                                                              \
+    if (yychar == YYEMPTY)                                        \
+      {                                                           \
+        yychar = (Token);                                         \
+        yylval = (Value);                                         \
+        YYPOPSTACK (yylen);                                       \
+        yystate = *yyssp;                                         \
+        goto yybackup;                                            \
+      }                                                           \
+    else                                                          \
+      {                                                           \
+        yyerror (context, scanner, YY_("syntax error: cannot back up")); \
+        YYERROR;                                                  \
+      }                                                           \
+  while (0)
 
+/* Backward compatibility with an undocumented macro.
+   Use YYerror or YYUNDEF. */
+#define YYERRCODE YYUNDEF
 
-#define YYTERROR	1
-#define YYERRCODE	256
-
-
-/* YYLLOC_DEFAULT -- Set CURRENT to span from RHS[1] to RHS[N].
-   If N is 0, then set CURRENT to the empty location which ends
-   the previous symbol: RHS[0] (always defined).  */
-
-#define YYRHSLOC(Rhs, K) ((Rhs)[K])
-#ifndef YYLLOC_DEFAULT
-# define YYLLOC_DEFAULT(Current, Rhs, N)				\
-    do									\
-      if (YYID (N))                                                    \
-	{								\
-	  (Current).first_line   = YYRHSLOC (Rhs, 1).first_line;	\
-	  (Current).first_column = YYRHSLOC (Rhs, 1).first_column;	\
-	  (Current).last_line    = YYRHSLOC (Rhs, N).last_line;		\
-	  (Current).last_column  = YYRHSLOC (Rhs, N).last_column;	\
-	}								\
-      else								\
-	{								\
-	  (Current).first_line   = (Current).last_line   =		\
-	    YYRHSLOC (Rhs, 0).last_line;				\
-	  (Current).first_column = (Current).last_column =		\
-	    YYRHSLOC (Rhs, 0).last_column;				\
-	}								\
-    while (YYID (0))
-#endif
-
-
-/* YY_LOCATION_PRINT -- Print the location on the stream.
-   This macro was not mandated originally: define only if we know
-   we won't break user code: when these are the locations we know.  */
-
-#ifndef YY_LOCATION_PRINT
-# if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
-#  define YY_LOCATION_PRINT(File, Loc)			\
-     fprintf (File, "%d.%d-%d.%d",			\
-	      (Loc).first_line, (Loc).first_column,	\
-	      (Loc).last_line,  (Loc).last_column)
-# else
-#  define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-# endif
-#endif
-
-
-/* YYLEX -- calling `yylex' with the right arguments.  */
-
-#ifdef YYLEX_PARAM
-# define YYLEX yylex (&yylval, YYLEX_PARAM)
-#else
-# define YYLEX yylex (&yylval, scanner)
-#endif
 
 /* Enable debugging if requested.  */
 #if YYDEBUG
@@ -810,86 +833,60 @@ while (YYID (0))
 #  define YYFPRINTF fprintf
 # endif
 
-# define YYDPRINTF(Args)			\
-do {						\
-  if (yydebug)					\
-    YYFPRINTF Args;				\
-} while (YYID (0))
-
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)			  \
-do {									  \
-  if (yydebug)								  \
-    {									  \
-      YYFPRINTF (stderr, "%s ", Title);					  \
-      yy_symbol_print (stderr,						  \
-		  Type, Value, context, scanner); \
-      YYFPRINTF (stderr, "\n");						  \
-    }									  \
-} while (YYID (0))
+# define YYDPRINTF(Args)                        \
+do {                                            \
+  if (yydebug)                                  \
+    YYFPRINTF Args;                             \
+} while (0)
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
 
-/*ARGSUSED*/
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
+do {                                                                      \
+  if (yydebug)                                                            \
+    {                                                                     \
+      YYFPRINTF (stderr, "%s ", Title);                                   \
+      yy_symbol_print (stderr,                                            \
+                  Kind, Value, context, scanner); \
+      YYFPRINTF (stderr, "\n");                                           \
+    }                                                                     \
+} while (0)
+
+
+/*-----------------------------------.
+| Print this symbol's value on YYO.  |
+`-----------------------------------*/
+
 static void
-yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, Context *context, yyscan_t *scanner)
-#else
-static void
-yy_symbol_value_print (yyoutput, yytype, yyvaluep, context, scanner)
-    FILE *yyoutput;
-    int yytype;
-    YYSTYPE const * const yyvaluep;
-    Context *context;
-    yyscan_t *scanner;
-#endif
+yy_symbol_value_print (FILE *yyo,
+                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, Context *context, yyscan_t *scanner)
 {
+  FILE *yyoutput = yyo;
+  YY_USE (yyoutput);
+  YY_USE (context);
+  YY_USE (scanner);
   if (!yyvaluep)
     return;
-  YYUSE (context);
-  YYUSE (scanner);
-# ifdef YYPRINT
-  if (yytype < YYNTOKENS)
-    YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
-# else
-  YYUSE (yyoutput);
-# endif
-  switch (yytype)
-    {
-      default:
-	break;
-    }
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  YY_USE (yykind);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+/*---------------------------.
+| Print this symbol on YYO.  |
+`---------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, Context *context, yyscan_t *scanner)
-#else
-static void
-yy_symbol_print (yyoutput, yytype, yyvaluep, context, scanner)
-    FILE *yyoutput;
-    int yytype;
-    YYSTYPE const * const yyvaluep;
-    Context *context;
-    yyscan_t *scanner;
-#endif
+yy_symbol_print (FILE *yyo,
+                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, Context *context, yyscan_t *scanner)
 {
-  if (yytype < YYNTOKENS)
-    YYFPRINTF (yyoutput, "token %s (", yytname[yytype]);
-  else
-    YYFPRINTF (yyoutput, "nterm %s (", yytname[yytype]);
+  YYFPRINTF (yyo, "%s %s (",
+             yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name (yykind));
 
-  yy_symbol_value_print (yyoutput, yytype, yyvaluep, context, scanner);
-  YYFPRINTF (yyoutput, ")");
+  yy_symbol_value_print (yyo, yykind, yyvaluep, context, scanner);
+  YYFPRINTF (yyo, ")");
 }
 
 /*------------------------------------------------------------------.
@@ -897,16 +894,8 @@ yy_symbol_print (yyoutput, yytype, yyvaluep, context, scanner)
 | TOP (included).                                                   |
 `------------------------------------------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yy_stack_print (yytype_int16 *yybottom, yytype_int16 *yytop)
-#else
-static void
-yy_stack_print (yybottom, yytop)
-    yytype_int16 *yybottom;
-    yytype_int16 *yytop;
-#endif
+yy_stack_print (yy_state_t *yybottom, yy_state_t *yytop)
 {
   YYFPRINTF (stderr, "Stack now");
   for (; yybottom <= yytop; yybottom++)
@@ -917,65 +906,56 @@ yy_stack_print (yybottom, yytop)
   YYFPRINTF (stderr, "\n");
 }
 
-# define YY_STACK_PRINT(Bottom, Top)				\
-do {								\
-  if (yydebug)							\
-    yy_stack_print ((Bottom), (Top));				\
-} while (YYID (0))
+# define YY_STACK_PRINT(Bottom, Top)                            \
+do {                                                            \
+  if (yydebug)                                                  \
+    yy_stack_print ((Bottom), (Top));                           \
+} while (0)
 
 
 /*------------------------------------------------.
 | Report that the YYRULE is going to be reduced.  |
 `------------------------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yy_reduce_print (YYSTYPE *yyvsp, int yyrule, Context *context, yyscan_t *scanner)
-#else
-static void
-yy_reduce_print (yyvsp, yyrule, context, scanner)
-    YYSTYPE *yyvsp;
-    int yyrule;
-    Context *context;
-    yyscan_t *scanner;
-#endif
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp,
+                 int yyrule, Context *context, yyscan_t *scanner)
 {
+  int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
-  unsigned long int yylno = yyrline[yyrule];
-  YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
-	     yyrule - 1, yylno);
+  YYFPRINTF (stderr, "Reducing stack by rule %d (line %d):\n",
+             yyrule - 1, yylno);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
-      yy_symbol_print (stderr, yyrhs[yyprhs[yyrule] + yyi],
-		       &(yyvsp[(yyi + 1) - (yynrhs)])
-		       		       , context, scanner);
+      yy_symbol_print (stderr,
+                       YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
+                       &yyvsp[(yyi + 1) - (yynrhs)], context, scanner);
       YYFPRINTF (stderr, "\n");
     }
 }
 
-# define YY_REDUCE_PRINT(Rule)		\
-do {					\
-  if (yydebug)				\
-    yy_reduce_print (yyvsp, Rule, context, scanner); \
-} while (YYID (0))
+# define YY_REDUCE_PRINT(Rule)          \
+do {                                    \
+  if (yydebug)                          \
+    yy_reduce_print (yyssp, yyvsp, Rule, context, scanner); \
+} while (0)
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
    multiple parsers can coexist.  */
 int yydebug;
 #else /* !YYDEBUG */
-# define YYDPRINTF(Args)
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)
+# define YYDPRINTF(Args) ((void) 0)
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)
 # define YY_STACK_PRINT(Bottom, Top)
 # define YY_REDUCE_PRINT(Rule)
 #endif /* !YYDEBUG */
 
 
 /* YYINITDEPTH -- initial size of the parser's stacks.  */
-#ifndef	YYINITDEPTH
+#ifndef YYINITDEPTH
 # define YYINITDEPTH 200
 #endif
 
@@ -990,49 +970,81 @@ int yydebug;
 # define YYMAXDEPTH 10000
 #endif
 
-
 
-#if YYERROR_VERBOSE
-
-# ifndef yystrlen
-#  if defined __GLIBC__ && defined _STRING_H
-#   define yystrlen strlen
-#  else
-/* Return the length of YYSTR.  */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-static YYSIZE_T
-yystrlen (const char *yystr)
-#else
-static YYSIZE_T
-yystrlen (yystr)
-    const char *yystr;
-#endif
+/* Context of a parse error.  */
+typedef struct
 {
-  YYSIZE_T yylen;
+  yy_state_t *yyssp;
+  yysymbol_kind_t yytoken;
+} yypcontext_t;
+
+/* Put in YYARG at most YYARGN of the expected tokens given the
+   current YYCTX, and return the number of tokens stored in YYARG.  If
+   YYARG is null, return the number of expected tokens (guaranteed to
+   be less than YYNTOKENS).  Return YYENOMEM on memory exhaustion.
+   Return 0 if there are more than YYARGN expected tokens, yet fill
+   YYARG up to YYARGN. */
+static int
+yypcontext_expected_tokens (const yypcontext_t *yyctx,
+                            yysymbol_kind_t yyarg[], int yyargn)
+{
+  /* Actual size of YYARG. */
+  int yycount = 0;
+  int yyn = yypact[+*yyctx->yyssp];
+  if (!yypact_value_is_default (yyn))
+    {
+      /* Start YYX at -YYN if negative to avoid negative indexes in
+         YYCHECK.  In other words, skip the first -YYN actions for
+         this state because they are default actions.  */
+      int yyxbegin = yyn < 0 ? -yyn : 0;
+      /* Stay within bounds of both yycheck and yytname.  */
+      int yychecklim = YYLAST - yyn + 1;
+      int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
+      int yyx;
+      for (yyx = yyxbegin; yyx < yyxend; ++yyx)
+        if (yycheck[yyx + yyn] == yyx && yyx != YYSYMBOL_YYerror
+            && !yytable_value_is_error (yytable[yyx + yyn]))
+          {
+            if (!yyarg)
+              ++yycount;
+            else if (yycount == yyargn)
+              return 0;
+            else
+              yyarg[yycount++] = YY_CAST (yysymbol_kind_t, yyx);
+          }
+    }
+  if (yyarg && yycount == 0 && 0 < yyargn)
+    yyarg[0] = YYSYMBOL_YYEMPTY;
+  return yycount;
+}
+
+
+
+
+#ifndef yystrlen
+# if defined __GLIBC__ && defined _STRING_H
+#  define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
+# else
+/* Return the length of YYSTR.  */
+static YYPTRDIFF_T
+yystrlen (const char *yystr)
+{
+  YYPTRDIFF_T yylen;
   for (yylen = 0; yystr[yylen]; yylen++)
     continue;
   return yylen;
 }
-#  endif
 # endif
+#endif
 
-# ifndef yystpcpy
-#  if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
-#   define yystpcpy stpcpy
-#  else
+#ifndef yystpcpy
+# if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
+#  define yystpcpy stpcpy
+# else
 /* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
    YYDEST.  */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static char *
 yystpcpy (char *yydest, const char *yysrc)
-#else
-static char *
-yystpcpy (yydest, yysrc)
-    char *yydest;
-    const char *yysrc;
-#endif
 {
   char *yyd = yydest;
   const char *yys = yysrc;
@@ -1042,10 +1054,10 @@ yystpcpy (yydest, yysrc)
 
   return yyd - 1;
 }
-#  endif
 # endif
+#endif
 
-# ifndef yytnamerr
+#ifndef yytnamerr
 /* Copy to YYRES the contents of YYSTR after stripping away unnecessary
    quotes and backslashes, so that it's suitable for yyerror.  The
    heuristic is that double-quoting is unnecessary unless the string
@@ -1053,283 +1065,261 @@ yystpcpy (yydest, yysrc)
    backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
    null, do not copy; instead, return the length of what the result
    would have been.  */
-static YYSIZE_T
+static YYPTRDIFF_T
 yytnamerr (char *yyres, const char *yystr)
 {
   if (*yystr == '"')
     {
-      YYSIZE_T yyn = 0;
+      YYPTRDIFF_T yyn = 0;
       char const *yyp = yystr;
-
       for (;;)
-	switch (*++yyp)
-	  {
-	  case '\'':
-	  case ',':
-	    goto do_not_strip_quotes;
+        switch (*++yyp)
+          {
+          case '\'':
+          case ',':
+            goto do_not_strip_quotes;
 
-	  case '\\':
-	    if (*++yyp != '\\')
-	      goto do_not_strip_quotes;
-	    /* Fall through.  */
-	  default:
-	    if (yyres)
-	      yyres[yyn] = *yyp;
-	    yyn++;
-	    break;
+          case '\\':
+            if (*++yyp != '\\')
+              goto do_not_strip_quotes;
+            else
+              goto append;
 
-	  case '"':
-	    if (yyres)
-	      yyres[yyn] = '\0';
-	    return yyn;
-	  }
+          append:
+          default:
+            if (yyres)
+              yyres[yyn] = *yyp;
+            yyn++;
+            break;
+
+          case '"':
+            if (yyres)
+              yyres[yyn] = '\0';
+            return yyn;
+          }
     do_not_strip_quotes: ;
     }
 
-  if (! yyres)
-    return yystrlen (yystr);
-
-  return yystpcpy (yyres, yystr) - yyres;
-}
-# endif
-
-/* Copy into YYRESULT an error message about the unexpected token
-   YYCHAR while in state YYSTATE.  Return the number of bytes copied,
-   including the terminating null byte.  If YYRESULT is null, do not
-   copy anything; just return the number of bytes that would be
-   copied.  As a special case, return 0 if an ordinary "syntax error"
-   message will do.  Return YYSIZE_MAXIMUM if overflow occurs during
-   size calculation.  */
-static YYSIZE_T
-yysyntax_error (char *yyresult, int yystate, int yychar)
-{
-  int yyn = yypact[yystate];
-
-  if (! (YYPACT_NINF < yyn && yyn <= YYLAST))
-    return 0;
+  if (yyres)
+    return yystpcpy (yyres, yystr) - yyres;
   else
-    {
-      int yytype = YYTRANSLATE (yychar);
-      YYSIZE_T yysize0 = yytnamerr (0, yytname[yytype]);
-      YYSIZE_T yysize = yysize0;
-      YYSIZE_T yysize1;
-      int yysize_overflow = 0;
-      enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
-      char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-      int yyx;
-
-# if 0
-      /* This is so xgettext sees the translatable formats that are
-	 constructed on the fly.  */
-      YY_("syntax error, unexpected %s");
-      YY_("syntax error, unexpected %s, expecting %s");
-      YY_("syntax error, unexpected %s, expecting %s or %s");
-      YY_("syntax error, unexpected %s, expecting %s or %s or %s");
-      YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s");
-# endif
-      char *yyfmt;
-      char const *yyf;
-      static char const yyunexpected[] = "syntax error, unexpected %s";
-      static char const yyexpecting[] = ", expecting %s";
-      static char const yyor[] = " or %s";
-      char yyformat[sizeof yyunexpected
-		    + sizeof yyexpecting - 1
-		    + ((YYERROR_VERBOSE_ARGS_MAXIMUM - 2)
-		       * (sizeof yyor - 1))];
-      char const *yyprefix = yyexpecting;
-
-      /* Start YYX at -YYN if negative to avoid negative indexes in
-	 YYCHECK.  */
-      int yyxbegin = yyn < 0 ? -yyn : 0;
-
-      /* Stay within bounds of both yycheck and yytname.  */
-      int yychecklim = YYLAST - yyn + 1;
-      int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-      int yycount = 1;
-
-      yyarg[0] = yytname[yytype];
-      yyfmt = yystpcpy (yyformat, yyunexpected);
-
-      for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-	if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR)
-	  {
-	    if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-	      {
-		yycount = 1;
-		yysize = yysize0;
-		yyformat[sizeof yyunexpected - 1] = '\0';
-		break;
-	      }
-	    yyarg[yycount++] = yytname[yyx];
-	    yysize1 = yysize + yytnamerr (0, yytname[yyx]);
-	    yysize_overflow |= (yysize1 < yysize);
-	    yysize = yysize1;
-	    yyfmt = yystpcpy (yyfmt, yyprefix);
-	    yyprefix = yyor;
-	  }
-
-      yyf = YY_(yyformat);
-      yysize1 = yysize + yystrlen (yyf);
-      yysize_overflow |= (yysize1 < yysize);
-      yysize = yysize1;
-
-      if (yysize_overflow)
-	return YYSIZE_MAXIMUM;
-
-      if (yyresult)
-	{
-	  /* Avoid sprintf, as that infringes on the user's name space.
-	     Don't have undefined behavior even if the translation
-	     produced a string with the wrong number of "%s"s.  */
-	  char *yyp = yyresult;
-	  int yyi = 0;
-	  while ((*yyp = *yyf) != '\0')
-	    {
-	      if (*yyp == '%' && yyf[1] == 's' && yyi < yycount)
-		{
-		  yyp += yytnamerr (yyp, yyarg[yyi++]);
-		  yyf += 2;
-		}
-	      else
-		{
-		  yyp++;
-		  yyf++;
-		}
-	    }
-	}
-      return yysize;
-    }
+    return yystrlen (yystr);
 }
-#endif /* YYERROR_VERBOSE */
-
+#endif
+
+
+static int
+yy_syntax_error_arguments (const yypcontext_t *yyctx,
+                           yysymbol_kind_t yyarg[], int yyargn)
+{
+  /* Actual size of YYARG. */
+  int yycount = 0;
+  /* There are many possibilities here to consider:
+     - If this state is a consistent state with a default action, then
+       the only way this function was invoked is if the default action
+       is an error action.  In that case, don't check for expected
+       tokens because there are none.
+     - The only way there can be no lookahead present (in yychar) is if
+       this state is a consistent state with a default action.  Thus,
+       detecting the absence of a lookahead is sufficient to determine
+       that there is no unexpected or expected token to report.  In that
+       case, just report a simple "syntax error".
+     - Don't assume there isn't a lookahead just because this state is a
+       consistent state with a default action.  There might have been a
+       previous inconsistent state, consistent state with a non-default
+       action, or user semantic action that manipulated yychar.
+     - Of course, the expected token list depends on states to have
+       correct lookahead information, and it depends on the parser not
+       to perform extra reductions after fetching a lookahead from the
+       scanner and before detecting a syntax error.  Thus, state merging
+       (from LALR or IELR) and default reductions corrupt the expected
+       token list.  However, the list is correct for canonical LR with
+       one exception: it will still contain any token that will not be
+       accepted due to an error action in a later state.
+  */
+  if (yyctx->yytoken != YYSYMBOL_YYEMPTY)
+    {
+      int yyn;
+      if (yyarg)
+        yyarg[yycount] = yyctx->yytoken;
+      ++yycount;
+      yyn = yypcontext_expected_tokens (yyctx,
+                                        yyarg ? yyarg + 1 : yyarg, yyargn - 1);
+      if (yyn == YYENOMEM)
+        return YYENOMEM;
+      else
+        yycount += yyn;
+    }
+  return yycount;
+}
+
+/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
+   about the unexpected token YYTOKEN for the state stack whose top is
+   YYSSP.
+
+   Return 0 if *YYMSG was successfully written.  Return -1 if *YYMSG is
+   not large enough to hold the message.  In that case, also set
+   *YYMSG_ALLOC to the required number of bytes.  Return YYENOMEM if the
+   required number of bytes is too large to store.  */
+static int
+yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
+                const yypcontext_t *yyctx)
+{
+  enum { YYARGS_MAX = 5 };
+  /* Internationalized format string. */
+  const char *yyformat = YY_NULLPTR;
+  /* Arguments of yyformat: reported tokens (one for the "unexpected",
+     one per "expected"). */
+  yysymbol_kind_t yyarg[YYARGS_MAX];
+  /* Cumulated lengths of YYARG.  */
+  YYPTRDIFF_T yysize = 0;
+
+  /* Actual size of YYARG. */
+  int yycount = yy_syntax_error_arguments (yyctx, yyarg, YYARGS_MAX);
+  if (yycount == YYENOMEM)
+    return YYENOMEM;
+
+  switch (yycount)
+    {
+#define YYCASE_(N, S)                       \
+      case N:                               \
+        yyformat = S;                       \
+        break
+    default: /* Avoid compiler warnings. */
+      YYCASE_(0, YY_("syntax error"));
+      YYCASE_(1, YY_("syntax error, unexpected %s"));
+      YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
+      YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
+      YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
+      YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
+#undef YYCASE_
+    }
+
+  /* Compute error message size.  Don't count the "%s"s, but reserve
+     room for the terminator.  */
+  yysize = yystrlen (yyformat) - 2 * yycount + 1;
+  {
+    int yyi;
+    for (yyi = 0; yyi < yycount; ++yyi)
+      {
+        YYPTRDIFF_T yysize1
+          = yysize + yytnamerr (YY_NULLPTR, yytname[yyarg[yyi]]);
+        if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
+          yysize = yysize1;
+        else
+          return YYENOMEM;
+      }
+  }
+
+  if (*yymsg_alloc < yysize)
+    {
+      *yymsg_alloc = 2 * yysize;
+      if (! (yysize <= *yymsg_alloc
+             && *yymsg_alloc <= YYSTACK_ALLOC_MAXIMUM))
+        *yymsg_alloc = YYSTACK_ALLOC_MAXIMUM;
+      return -1;
+    }
+
+  /* Avoid sprintf, as that infringes on the user's name space.
+     Don't have undefined behavior even if the translation
+     produced a string with the wrong number of "%s"s.  */
+  {
+    char *yyp = *yymsg;
+    int yyi = 0;
+    while ((*yyp = *yyformat) != '\0')
+      if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
+        {
+          yyp += yytnamerr (yyp, yytname[yyarg[yyi++]]);
+          yyformat += 2;
+        }
+      else
+        {
+          ++yyp;
+          ++yyformat;
+        }
+  }
+  return 0;
+}
+
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
-/*ARGSUSED*/
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, Context *context, yyscan_t *scanner)
-#else
-static void
-yydestruct (yymsg, yytype, yyvaluep, context, scanner)
-    const char *yymsg;
-    int yytype;
-    YYSTYPE *yyvaluep;
-    Context *context;
-    yyscan_t *scanner;
-#endif
+yydestruct (const char *yymsg,
+            yysymbol_kind_t yykind, YYSTYPE *yyvaluep, Context *context, yyscan_t *scanner)
 {
-  YYUSE (yyvaluep);
-  YYUSE (context);
-  YYUSE (scanner);
-
+  YY_USE (yyvaluep);
+  YY_USE (context);
+  YY_USE (scanner);
   if (!yymsg)
     yymsg = "Deleting";
-  YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
+  YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
 
-  switch (yytype)
-    {
-
-      default:
-	break;
-    }
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  YY_USE (yykind);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
-/* Prevent warnings from -Wmissing-prototypes.  */
-#ifdef YYPARSE_PARAM
-#if defined __STDC__ || defined __cplusplus
-int yyparse (void *YYPARSE_PARAM);
-#else
-int yyparse ();
-#endif
-#else /* ! YYPARSE_PARAM */
-#if defined __STDC__ || defined __cplusplus
-int yyparse (Context *context, yyscan_t *scanner);
-#else
-int yyparse ();
-#endif
-#endif /* ! YYPARSE_PARAM */
 
 
 
 
 
-/*-------------------------.
-| yyparse or yypush_parse.  |
-`-------------------------*/
+/*----------.
+| yyparse.  |
+`----------*/
 
-#ifdef YYPARSE_PARAM
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-int
-yyparse (void *YYPARSE_PARAM)
-#else
-int
-yyparse (YYPARSE_PARAM)
-    void *YYPARSE_PARAM;
-#endif
-#else /* ! YYPARSE_PARAM */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 int
 yyparse (Context *context, yyscan_t *scanner)
-#else
-int
-yyparse (context, scanner)
-    Context *context;
-    yyscan_t *scanner;
-#endif
-#endif
 {
-/* The lookahead symbol.  */
+/* Lookahead token kind.  */
 int yychar;
 
+
 /* The semantic value of the lookahead symbol.  */
-YYSTYPE yylval;
+/* Default value used for initialization, for pacifying older GCCs
+   or non-GCC compilers.  */
+YY_INITIAL_VALUE (static YYSTYPE yyval_default;)
+YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
 
     /* Number of syntax errors so far.  */
-    int yynerrs;
+    int yynerrs = 0;
 
-    int yystate;
+    yy_state_fast_t yystate = 0;
     /* Number of tokens to shift before error messages enabled.  */
-    int yyerrstatus;
+    int yyerrstatus = 0;
 
-    /* The stacks and their tools:
-       `yyss': related to states.
-       `yyvs': related to semantic values.
-
-       Refer to the stacks thru separate pointers, to allow yyoverflow
+    /* Refer to the stacks through separate pointers, to allow yyoverflow
        to reallocate them elsewhere.  */
 
-    /* The state stack.  */
-    yytype_int16 yyssa[YYINITDEPTH];
-    yytype_int16 *yyss;
-    yytype_int16 *yyssp;
+    /* Their size.  */
+    YYPTRDIFF_T yystacksize = YYINITDEPTH;
 
-    /* The semantic value stack.  */
+    /* The state stack: array, bottom, top.  */
+    yy_state_t yyssa[YYINITDEPTH];
+    yy_state_t *yyss = yyssa;
+    yy_state_t *yyssp = yyss;
+
+    /* The semantic value stack: array, bottom, top.  */
     YYSTYPE yyvsa[YYINITDEPTH];
-    YYSTYPE *yyvs;
-    YYSTYPE *yyvsp;
-
-    YYSIZE_T yystacksize;
+    YYSTYPE *yyvs = yyvsa;
+    YYSTYPE *yyvsp = yyvs;
 
   int yyn;
+  /* The return value of yyparse.  */
   int yyresult;
-  /* Lookahead token as an internal (translated) token number.  */
-  int yytoken;
+  /* Lookahead symbol kind.  */
+  yysymbol_kind_t yytoken = YYSYMBOL_YYEMPTY;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;
 
-#if YYERROR_VERBOSE
   /* Buffer for error messages, and its allocated size.  */
   char yymsgbuf[128];
   char *yymsg = yymsgbuf;
-  YYSIZE_T yymsg_alloc = sizeof yymsgbuf;
-#endif
+  YYPTRDIFF_T yymsg_alloc = sizeof yymsgbuf;
 
 #define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N))
 
@@ -1337,132 +1327,139 @@ YYSTYPE yylval;
      Keep to zero when no symbol should be popped.  */
   int yylen = 0;
 
-  yytoken = 0;
-  yyss = yyssa;
-  yyvs = yyvsa;
-  yystacksize = YYINITDEPTH;
-
   YYDPRINTF ((stderr, "Starting parse\n"));
 
-  yystate = 0;
-  yyerrstatus = 0;
-  yynerrs = 0;
   yychar = YYEMPTY; /* Cause a token to be read.  */
-
-  /* Initialize stack pointers.
-     Waste one element of value and location stack
-     so that they stay on the same level as the state stack.
-     The wasted elements are never initialized.  */
-  yyssp = yyss;
-  yyvsp = yyvs;
 
   goto yysetstate;
 
+
 /*------------------------------------------------------------.
-| yynewstate -- Push a new state, which is found in yystate.  |
+| yynewstate -- push a new state, which is found in yystate.  |
 `------------------------------------------------------------*/
- yynewstate:
+yynewstate:
   /* In all cases, when you get here, the value and location stacks
      have just been pushed.  So pushing a state here evens the stacks.  */
   yyssp++;
 
- yysetstate:
-  *yyssp = yystate;
+
+/*--------------------------------------------------------------------.
+| yysetstate -- set current state (the top of the stack) to yystate.  |
+`--------------------------------------------------------------------*/
+yysetstate:
+  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+  YY_ASSERT (0 <= yystate && yystate < YYNSTATES);
+  YY_IGNORE_USELESS_CAST_BEGIN
+  *yyssp = YY_CAST (yy_state_t, yystate);
+  YY_IGNORE_USELESS_CAST_END
+  YY_STACK_PRINT (yyss, yyssp);
 
   if (yyss + yystacksize - 1 <= yyssp)
+#if !defined yyoverflow && !defined YYSTACK_RELOCATE
+    YYNOMEM;
+#else
     {
       /* Get the current used size of the three stacks, in elements.  */
-      YYSIZE_T yysize = yyssp - yyss + 1;
+      YYPTRDIFF_T yysize = yyssp - yyss + 1;
 
-#ifdef yyoverflow
+# if defined yyoverflow
       {
-	/* Give user a chance to reallocate the stack.  Use copies of
-	   these so that the &'s don't force the real ones into
-	   memory.  */
-	YYSTYPE *yyvs1 = yyvs;
-	yytype_int16 *yyss1 = yyss;
+        /* Give user a chance to reallocate the stack.  Use copies of
+           these so that the &'s don't force the real ones into
+           memory.  */
+        yy_state_t *yyss1 = yyss;
+        YYSTYPE *yyvs1 = yyvs;
 
-	/* Each stack pointer address is followed by the size of the
-	   data in use in that stack, in bytes.  This used to be a
-	   conditional around just the two extra args, but that might
-	   be undefined if yyoverflow is a macro.  */
-	yyoverflow (YY_("memory exhausted"),
-		    &yyss1, yysize * sizeof (*yyssp),
-		    &yyvs1, yysize * sizeof (*yyvsp),
-		    &yystacksize);
-
-	yyss = yyss1;
-	yyvs = yyvs1;
+        /* Each stack pointer address is followed by the size of the
+           data in use in that stack, in bytes.  This used to be a
+           conditional around just the two extra args, but that might
+           be undefined if yyoverflow is a macro.  */
+        yyoverflow (YY_("memory exhausted"),
+                    &yyss1, yysize * YYSIZEOF (*yyssp),
+                    &yyvs1, yysize * YYSIZEOF (*yyvsp),
+                    &yystacksize);
+        yyss = yyss1;
+        yyvs = yyvs1;
       }
-#else /* no yyoverflow */
-# ifndef YYSTACK_RELOCATE
-      goto yyexhaustedlab;
-# else
+# else /* defined YYSTACK_RELOCATE */
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
-	goto yyexhaustedlab;
+        YYNOMEM;
       yystacksize *= 2;
       if (YYMAXDEPTH < yystacksize)
-	yystacksize = YYMAXDEPTH;
+        yystacksize = YYMAXDEPTH;
 
       {
-	yytype_int16 *yyss1 = yyss;
-	union yyalloc *yyptr =
-	  (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
-	if (! yyptr)
-	  goto yyexhaustedlab;
-	YYSTACK_RELOCATE (yyss_alloc, yyss);
-	YYSTACK_RELOCATE (yyvs_alloc, yyvs);
+        yy_state_t *yyss1 = yyss;
+        union yyalloc *yyptr =
+          YY_CAST (union yyalloc *,
+                   YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
+        if (! yyptr)
+          YYNOMEM;
+        YYSTACK_RELOCATE (yyss_alloc, yyss);
+        YYSTACK_RELOCATE (yyvs_alloc, yyvs);
 #  undef YYSTACK_RELOCATE
-	if (yyss1 != yyssa)
-	  YYSTACK_FREE (yyss1);
+        if (yyss1 != yyssa)
+          YYSTACK_FREE (yyss1);
       }
 # endif
-#endif /* no yyoverflow */
 
       yyssp = yyss + yysize - 1;
       yyvsp = yyvs + yysize - 1;
 
-      YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-		  (unsigned long int) yystacksize));
+      YY_IGNORE_USELESS_CAST_BEGIN
+      YYDPRINTF ((stderr, "Stack size increased to %ld\n",
+                  YY_CAST (long, yystacksize)));
+      YY_IGNORE_USELESS_CAST_END
 
       if (yyss + yystacksize - 1 <= yyssp)
-	YYABORT;
+        YYABORT;
     }
+#endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
 
-  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
 
   if (yystate == YYFINAL)
     YYACCEPT;
 
   goto yybackup;
 
+
 /*-----------.
 | yybackup.  |
 `-----------*/
 yybackup:
-
   /* Do appropriate processing given the current state.  Read a
      lookahead token if we need one and don't already have one.  */
 
   /* First try to decide what to do without reference to lookahead token.  */
   yyn = yypact[yystate];
-  if (yyn == YYPACT_NINF)
+  if (yypact_value_is_default (yyn))
     goto yydefault;
 
   /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid lookahead symbol.  */
+  /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
   if (yychar == YYEMPTY)
     {
-      YYDPRINTF ((stderr, "Reading a token: "));
-      yychar = YYLEX;
+      YYDPRINTF ((stderr, "Reading a token\n"));
+      yychar = yylex (&yylval, scanner);
     }
 
   if (yychar <= YYEOF)
     {
-      yychar = yytoken = YYEOF;
+      yychar = YYEOF;
+      yytoken = YYSYMBOL_YYEOF;
       YYDPRINTF ((stderr, "Now at end of input.\n"));
+    }
+  else if (yychar == YYerror)
+    {
+      /* The scanner already issued an error message, process directly
+         to error recovery.  But do not keep the error token as
+         lookahead, it is too special and may lead us to an endless
+         loop in error recovery. */
+      yychar = YYUNDEF;
+      yytoken = YYSYMBOL_YYerror;
+      goto yyerrlab1;
     }
   else
     {
@@ -1478,8 +1475,8 @@ yybackup:
   yyn = yytable[yyn];
   if (yyn <= 0)
     {
-      if (yyn == 0 || yyn == YYTABLE_NINF)
-	goto yyerrlab;
+      if (yytable_value_is_error (yyn))
+        goto yyerrlab;
       yyn = -yyn;
       goto yyreduce;
     }
@@ -1491,13 +1488,13 @@ yybackup:
 
   /* Shift the lookahead token.  */
   YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
+  yystate = yyn;
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  *++yyvsp = yylval;
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 
   /* Discard the shifted token.  */
   yychar = YYEMPTY;
-
-  yystate = yyn;
-  *++yyvsp = yylval;
-
   goto yynewstate;
 
 
@@ -1512,14 +1509,14 @@ yydefault:
 
 
 /*-----------------------------.
-| yyreduce -- Do a reduction.  |
+| yyreduce -- do a reduction.  |
 `-----------------------------*/
 yyreduce:
   /* yyn is the number of a rule to reduce with.  */
   yylen = yyr2[yyn];
 
   /* If YYLEN is nonzero, implement the default value of the action:
-     `$$ = $1'.
+     '$$ = $1'.
 
      Otherwise, the following line sets YYVAL to garbage.
      This behavior is undocumented and Bison
@@ -1532,689 +1529,631 @@ yyreduce:
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-        case 4:
-
-/* Line 1464 of yacc.c  */
+  case 4: /* statement: expression  */
 #line 178 "libmemcached/csl/parser.yy"
-    { ;}
+          { }
+#line 1536 "libmemcached/csl/parser.cc"
     break;
 
-  case 5:
-
-/* Line 1464 of yacc.c  */
+  case 5: /* statement: COMMENT  */
 #line 180 "libmemcached/csl/parser.yy"
-    { ;}
+          { }
+#line 1542 "libmemcached/csl/parser.cc"
     break;
 
-  case 6:
-
-/* Line 1464 of yacc.c  */
+  case 6: /* statement: EMPTY_LINE  */
 #line 182 "libmemcached/csl/parser.yy"
-    { ;}
+          { }
+#line 1548 "libmemcached/csl/parser.cc"
     break;
 
-  case 7:
-
-/* Line 1464 of yacc.c  */
+  case 7: /* statement: END  */
 #line 184 "libmemcached/csl/parser.yy"
-    {
+          {
             context->set_end();
             YYACCEPT;
-          ;}
+          }
+#line 1557 "libmemcached/csl/parser.cc"
     break;
 
-  case 8:
-
-/* Line 1464 of yacc.c  */
+  case 8: /* statement: ERROR  */
 #line 189 "libmemcached/csl/parser.yy"
-    {
+          {
             context->rc= MEMCACHED_PARSE_USER_ERROR;
             parser_abort(context, NULL);
-          ;}
+          }
+#line 1566 "libmemcached/csl/parser.cc"
     break;
 
-  case 9:
-
-/* Line 1464 of yacc.c  */
+  case 9: /* statement: RESET  */
 #line 194 "libmemcached/csl/parser.yy"
-    {
+          {
             memcached_reset(context->memc);
-          ;}
+          }
+#line 1574 "libmemcached/csl/parser.cc"
     break;
 
-  case 10:
-
-/* Line 1464 of yacc.c  */
+  case 10: /* statement: PARSER_DEBUG  */
 #line 198 "libmemcached/csl/parser.yy"
-    {
+          {
             yydebug= 1;
-          ;}
+          }
+#line 1582 "libmemcached/csl/parser.cc"
     break;
 
-  case 11:
-
-/* Line 1464 of yacc.c  */
+  case 11: /* statement: INCLUDE ' ' string  */
 #line 202 "libmemcached/csl/parser.yy"
-    {
-            if ((context->rc= memcached_parse_configure_file(*context->memc, (yyvsp[(3) - (3)].string).c_str, (yyvsp[(3) - (3)].string).size)) != MEMCACHED_SUCCESS)
+          {
+            if ((context->rc= memcached_parse_configure_file(*context->memc, (yyvsp[0].string).c_str, (yyvsp[0].string).size)) != MEMCACHED_SUCCESS)
             {
               parser_abort(context, NULL);
             }
-          ;}
+          }
+#line 1593 "libmemcached/csl/parser.cc"
     break;
 
-  case 12:
-
-/* Line 1464 of yacc.c  */
+  case 12: /* expression: SERVER HOSTNAME optional_port optional_weight  */
 #line 213 "libmemcached/csl/parser.yy"
-    {
-            if (memcached_failed(context->rc= memcached_server_add_with_weight(context->memc, (yyvsp[(2) - (4)].server).c_str, (yyvsp[(3) - (4)].number), (yyvsp[(4) - (4)].number))))
+          {
+            if (memcached_failed(context->rc= memcached_server_add_with_weight(context->memc, (yyvsp[-2].server).c_str, (yyvsp[-1].number), (yyvsp[0].number))))
             {
               parser_abort(context, NULL);
             }
             context->unset_server();
-          ;}
+          }
+#line 1605 "libmemcached/csl/parser.cc"
     break;
 
-  case 13:
-
-/* Line 1464 of yacc.c  */
+  case 13: /* expression: SERVER IPADDRESS optional_port optional_weight  */
 #line 221 "libmemcached/csl/parser.yy"
-    {
-            if (memcached_failed(context->rc= memcached_server_add_with_weight(context->memc, (yyvsp[(2) - (4)].server).c_str, (yyvsp[(3) - (4)].number), (yyvsp[(4) - (4)].number))))
+          {
+            if (memcached_failed(context->rc= memcached_server_add_with_weight(context->memc, (yyvsp[-2].server).c_str, (yyvsp[-1].number), (yyvsp[0].number))))
             {
               parser_abort(context, NULL);
             }
             context->unset_server();
-          ;}
+          }
+#line 1617 "libmemcached/csl/parser.cc"
     break;
 
-  case 14:
-
-/* Line 1464 of yacc.c  */
+  case 14: /* expression: SOCKET string optional_weight  */
 #line 229 "libmemcached/csl/parser.yy"
-    {
-            if (memcached_failed(context->rc= memcached_server_add_unix_socket_with_weight(context->memc, (yyvsp[(2) - (3)].string).c_str, (yyvsp[(3) - (3)].number))))
+          {
+            if (memcached_failed(context->rc= memcached_server_add_unix_socket_with_weight(context->memc, (yyvsp[-1].string).c_str, (yyvsp[0].number))))
             {
               parser_abort(context, NULL);
             }
-          ;}
+          }
+#line 1628 "libmemcached/csl/parser.cc"
     break;
 
-  case 15:
-
-/* Line 1464 of yacc.c  */
+  case 15: /* expression: CONFIGURE_FILE string  */
 #line 236 "libmemcached/csl/parser.yy"
-    {
-            memcached_set_configuration_file(context->memc, (yyvsp[(2) - (2)].string).c_str, (yyvsp[(2) - (2)].string).size);
-          ;}
+          {
+            memcached_set_configuration_file(context->memc, (yyvsp[0].string).c_str, (yyvsp[0].string).size);
+          }
+#line 1636 "libmemcached/csl/parser.cc"
     break;
 
-  case 16:
-
-/* Line 1464 of yacc.c  */
+  case 16: /* expression: POOL_MIN NUMBER  */
 #line 240 "libmemcached/csl/parser.yy"
-    {
-            context->memc->configure.initial_pool_size= (yyvsp[(2) - (2)].number);
-          ;}
+          {
+            context->memc->configure.initial_pool_size= (yyvsp[0].number);
+          }
+#line 1644 "libmemcached/csl/parser.cc"
     break;
 
-  case 17:
-
-/* Line 1464 of yacc.c  */
+  case 17: /* expression: POOL_MAX NUMBER  */
 #line 244 "libmemcached/csl/parser.yy"
-    {
-            context->memc->configure.max_pool_size= (yyvsp[(2) - (2)].number);
-          ;}
+          {
+            context->memc->configure.max_pool_size= (yyvsp[0].number);
+          }
+#line 1652 "libmemcached/csl/parser.cc"
     break;
 
-  case 19:
-
-/* Line 1464 of yacc.c  */
+  case 19: /* behaviors: NAMESPACE string  */
 #line 252 "libmemcached/csl/parser.yy"
-    {
-            if ((context->rc= memcached_set_namespace(context->memc, (yyvsp[(2) - (2)].string).c_str, (yyvsp[(2) - (2)].string).size)) != MEMCACHED_SUCCESS)
+          {
+            if ((context->rc= memcached_set_namespace(context->memc, (yyvsp[0].string).c_str, (yyvsp[0].string).size)) != MEMCACHED_SUCCESS)
             {
               parser_abort(context, NULL);;
             }
-          ;}
+          }
+#line 1663 "libmemcached/csl/parser.cc"
     break;
 
-  case 20:
-
-/* Line 1464 of yacc.c  */
+  case 20: /* behaviors: DISTRIBUTION distribution  */
 #line 259 "libmemcached/csl/parser.yy"
-    {
-            if ((context->rc= memcached_behavior_set(context->memc, MEMCACHED_BEHAVIOR_DISTRIBUTION, (yyvsp[(2) - (2)].distribution))) != MEMCACHED_SUCCESS)
+          {
+            if ((context->rc= memcached_behavior_set(context->memc, MEMCACHED_BEHAVIOR_DISTRIBUTION, (yyvsp[0].distribution))) != MEMCACHED_SUCCESS)
             {
               parser_abort(context, NULL);;
             }
-          ;}
+          }
+#line 1674 "libmemcached/csl/parser.cc"
     break;
 
-  case 21:
-
-/* Line 1464 of yacc.c  */
+  case 21: /* behaviors: DISTRIBUTION distribution ',' hash  */
 #line 266 "libmemcached/csl/parser.yy"
-    {
-            if ((context->rc= memcached_behavior_set(context->memc, MEMCACHED_BEHAVIOR_DISTRIBUTION, (yyvsp[(2) - (4)].distribution))) != MEMCACHED_SUCCESS)
+          {
+            if ((context->rc= memcached_behavior_set(context->memc, MEMCACHED_BEHAVIOR_DISTRIBUTION, (yyvsp[-2].distribution))) != MEMCACHED_SUCCESS)
             {
               parser_abort(context, NULL);;
             }
-            if ((context->rc= memcached_behavior_set_distribution_hash(context->memc, (yyvsp[(4) - (4)].hash))) != MEMCACHED_SUCCESS)
+            if ((context->rc= memcached_behavior_set_distribution_hash(context->memc, (yyvsp[0].hash))) != MEMCACHED_SUCCESS)
             {
               parser_abort(context, NULL);;
             }
-          ;}
+          }
+#line 1689 "libmemcached/csl/parser.cc"
     break;
 
-  case 22:
-
-/* Line 1464 of yacc.c  */
+  case 22: /* behaviors: HASH hash  */
 #line 277 "libmemcached/csl/parser.yy"
-    {
-            if ((context->rc= memcached_behavior_set(context->memc, MEMCACHED_BEHAVIOR_HASH, (yyvsp[(2) - (2)].hash))) != MEMCACHED_SUCCESS)
+          {
+            if ((context->rc= memcached_behavior_set(context->memc, MEMCACHED_BEHAVIOR_HASH, (yyvsp[0].hash))) != MEMCACHED_SUCCESS)
             {
               parser_abort(context, NULL);; 
             }
-          ;}
+          }
+#line 1700 "libmemcached/csl/parser.cc"
     break;
 
-  case 23:
-
-/* Line 1464 of yacc.c  */
+  case 23: /* behaviors: behavior_number NUMBER  */
 #line 284 "libmemcached/csl/parser.yy"
-    {
-            if ((context->rc= memcached_behavior_set(context->memc, (yyvsp[(1) - (2)].behavior), (yyvsp[(2) - (2)].number))) != MEMCACHED_SUCCESS)
+          {
+            if ((context->rc= memcached_behavior_set(context->memc, (yyvsp[-1].behavior), (yyvsp[0].number))) != MEMCACHED_SUCCESS)
             {
               parser_abort(context, NULL);;
             }
-          ;}
+          }
+#line 1711 "libmemcached/csl/parser.cc"
     break;
 
-  case 24:
-
-/* Line 1464 of yacc.c  */
+  case 24: /* behaviors: behavior_boolean  */
 #line 291 "libmemcached/csl/parser.yy"
-    {
-            if ((context->rc= memcached_behavior_set(context->memc, (yyvsp[(1) - (1)].behavior), true)) != MEMCACHED_SUCCESS)
+          {
+            if ((context->rc= memcached_behavior_set(context->memc, (yyvsp[0].behavior), true)) != MEMCACHED_SUCCESS)
             {
               parser_abort(context, NULL);;
             }
-          ;}
+          }
+#line 1722 "libmemcached/csl/parser.cc"
     break;
 
-  case 25:
-
-/* Line 1464 of yacc.c  */
+  case 25: /* behaviors: USER_DATA  */
 #line 298 "libmemcached/csl/parser.yy"
-    {
-          ;}
+          {
+          }
+#line 1729 "libmemcached/csl/parser.cc"
     break;
 
-  case 26:
-
-/* Line 1464 of yacc.c  */
+  case 26: /* behavior_number: REMOVE_FAILED_SERVERS  */
 #line 304 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_REMOVE_FAILED_SERVERS;
-          ;}
+          }
+#line 1737 "libmemcached/csl/parser.cc"
     break;
 
-  case 27:
-
-/* Line 1464 of yacc.c  */
+  case 27: /* behavior_number: CONNECT_TIMEOUT  */
 #line 308 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_CONNECT_TIMEOUT;
-          ;}
+          }
+#line 1745 "libmemcached/csl/parser.cc"
     break;
 
-  case 28:
-
-/* Line 1464 of yacc.c  */
+  case 28: /* behavior_number: IO_MSG_WATERMARK  */
 #line 312 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_IO_MSG_WATERMARK;
-          ;}
+          }
+#line 1753 "libmemcached/csl/parser.cc"
     break;
 
-  case 29:
-
-/* Line 1464 of yacc.c  */
+  case 29: /* behavior_number: IO_BYTES_WATERMARK  */
 #line 316 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_IO_BYTES_WATERMARK;
-          ;}
+          }
+#line 1761 "libmemcached/csl/parser.cc"
     break;
 
-  case 30:
-
-/* Line 1464 of yacc.c  */
+  case 30: /* behavior_number: IO_KEY_PREFETCH  */
 #line 320 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_IO_KEY_PREFETCH;
-          ;}
+          }
+#line 1769 "libmemcached/csl/parser.cc"
     break;
 
-  case 31:
-
-/* Line 1464 of yacc.c  */
+  case 31: /* behavior_number: NUMBER_OF_REPLICAS  */
 #line 324 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_NUMBER_OF_REPLICAS;
-          ;}
+          }
+#line 1777 "libmemcached/csl/parser.cc"
     break;
 
-  case 32:
-
-/* Line 1464 of yacc.c  */
+  case 32: /* behavior_number: POLL_TIMEOUT  */
 #line 328 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_POLL_TIMEOUT;
-          ;}
+          }
+#line 1785 "libmemcached/csl/parser.cc"
     break;
 
-  case 33:
-
-/* Line 1464 of yacc.c  */
+  case 33: /* behavior_number: RCV_TIMEOUT  */
 #line 332 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_RCV_TIMEOUT;
-          ;}
+          }
+#line 1793 "libmemcached/csl/parser.cc"
     break;
 
-  case 34:
-
-/* Line 1464 of yacc.c  */
+  case 34: /* behavior_number: RETRY_TIMEOUT  */
 #line 336 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_RETRY_TIMEOUT;
-          ;}
+          }
+#line 1801 "libmemcached/csl/parser.cc"
     break;
 
-  case 35:
-
-/* Line 1464 of yacc.c  */
+  case 35: /* behavior_number: SND_TIMEOUT  */
 #line 340 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_SND_TIMEOUT;
-          ;}
+          }
+#line 1809 "libmemcached/csl/parser.cc"
     break;
 
-  case 36:
-
-/* Line 1464 of yacc.c  */
+  case 36: /* behavior_number: SOCKET_RECV_SIZE  */
 #line 344 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_SOCKET_RECV_SIZE;
-          ;}
+          }
+#line 1817 "libmemcached/csl/parser.cc"
     break;
 
-  case 37:
-
-/* Line 1464 of yacc.c  */
+  case 37: /* behavior_number: SOCKET_SEND_SIZE  */
 #line 348 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_SOCKET_SEND_SIZE;
-          ;}
+          }
+#line 1825 "libmemcached/csl/parser.cc"
     break;
 
-  case 38:
-
-/* Line 1464 of yacc.c  */
+  case 38: /* behavior_boolean: BINARY_PROTOCOL  */
 #line 355 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_BINARY_PROTOCOL;
-          ;}
+          }
+#line 1833 "libmemcached/csl/parser.cc"
     break;
 
-  case 39:
-
-/* Line 1464 of yacc.c  */
+  case 39: /* behavior_boolean: BUFFER_REQUESTS  */
 #line 359 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_BUFFER_REQUESTS;
-          ;}
+          }
+#line 1841 "libmemcached/csl/parser.cc"
     break;
 
-  case 40:
-
-/* Line 1464 of yacc.c  */
+  case 40: /* behavior_boolean: HASH_WITH_NAMESPACE  */
 #line 363 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_HASH_WITH_PREFIX_KEY;
-          ;}
+          }
+#line 1849 "libmemcached/csl/parser.cc"
     break;
 
-  case 41:
-
-/* Line 1464 of yacc.c  */
+  case 41: /* behavior_boolean: NOREPLY  */
 #line 367 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_NOREPLY;
-          ;}
+          }
+#line 1857 "libmemcached/csl/parser.cc"
     break;
 
-  case 42:
-
-/* Line 1464 of yacc.c  */
+  case 42: /* behavior_boolean: RANDOMIZE_REPLICA_READ  */
 #line 371 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_RANDOMIZE_REPLICA_READ;
-          ;}
+          }
+#line 1865 "libmemcached/csl/parser.cc"
     break;
 
-  case 43:
-
-/* Line 1464 of yacc.c  */
+  case 43: /* behavior_boolean: SORT_HOSTS  */
 #line 375 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_SORT_HOSTS;
-          ;}
+          }
+#line 1873 "libmemcached/csl/parser.cc"
     break;
 
-  case 44:
-
-/* Line 1464 of yacc.c  */
+  case 44: /* behavior_boolean: SUPPORT_CAS  */
 #line 379 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_SUPPORT_CAS;
-          ;}
+          }
+#line 1881 "libmemcached/csl/parser.cc"
     break;
 
-  case 45:
-
-/* Line 1464 of yacc.c  */
+  case 45: /* behavior_boolean: _TCP_NODELAY  */
 #line 383 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_TCP_NODELAY;
-          ;}
+          }
+#line 1889 "libmemcached/csl/parser.cc"
     break;
 
-  case 46:
-
-/* Line 1464 of yacc.c  */
+  case 46: /* behavior_boolean: _TCP_KEEPALIVE  */
 #line 387 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_TCP_KEEPALIVE;
-          ;}
+          }
+#line 1897 "libmemcached/csl/parser.cc"
     break;
 
-  case 47:
-
-/* Line 1464 of yacc.c  */
+  case 47: /* behavior_boolean: _TCP_KEEPIDLE  */
 #line 391 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_TCP_KEEPIDLE;
-          ;}
+          }
+#line 1905 "libmemcached/csl/parser.cc"
     break;
 
-  case 48:
-
-/* Line 1464 of yacc.c  */
+  case 48: /* behavior_boolean: USE_UDP  */
 #line 395 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_USE_UDP;
-          ;}
+          }
+#line 1913 "libmemcached/csl/parser.cc"
     break;
 
-  case 49:
-
-/* Line 1464 of yacc.c  */
+  case 49: /* behavior_boolean: VERIFY_KEY  */
 #line 399 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.behavior)= MEMCACHED_BEHAVIOR_VERIFY_KEY;
-          ;}
+          }
+#line 1921 "libmemcached/csl/parser.cc"
     break;
 
-  case 50:
-
-/* Line 1464 of yacc.c  */
+  case 50: /* optional_port: %empty  */
 #line 405 "libmemcached/csl/parser.yy"
-    { (yyval.number)= MEMCACHED_DEFAULT_PORT;;}
+          { (yyval.number)= MEMCACHED_DEFAULT_PORT;}
+#line 1927 "libmemcached/csl/parser.cc"
     break;
 
-  case 51:
-
-/* Line 1464 of yacc.c  */
+  case 51: /* optional_port: PORT  */
 #line 407 "libmemcached/csl/parser.yy"
-    { ;}
+          { }
+#line 1933 "libmemcached/csl/parser.cc"
     break;
 
-  case 52:
-
-/* Line 1464 of yacc.c  */
+  case 52: /* optional_weight: %empty  */
 #line 411 "libmemcached/csl/parser.yy"
-    { (yyval.number)= 1; ;}
+          { (yyval.number)= 1; }
+#line 1939 "libmemcached/csl/parser.cc"
     break;
 
-  case 53:
-
-/* Line 1464 of yacc.c  */
+  case 53: /* optional_weight: WEIGHT_START  */
 #line 413 "libmemcached/csl/parser.yy"
-    { ;}
+          { }
+#line 1945 "libmemcached/csl/parser.cc"
     break;
 
-  case 54:
-
-/* Line 1464 of yacc.c  */
+  case 54: /* hash: MD5  */
 #line 418 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.hash)= MEMCACHED_HASH_MD5;
-          ;}
+          }
+#line 1953 "libmemcached/csl/parser.cc"
     break;
 
-  case 55:
-
-/* Line 1464 of yacc.c  */
+  case 55: /* hash: CRC  */
 #line 422 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.hash)= MEMCACHED_HASH_CRC;
-          ;}
+          }
+#line 1961 "libmemcached/csl/parser.cc"
     break;
 
-  case 56:
-
-/* Line 1464 of yacc.c  */
+  case 56: /* hash: FNV1_64  */
 #line 426 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.hash)= MEMCACHED_HASH_FNV1_64;
-          ;}
+          }
+#line 1969 "libmemcached/csl/parser.cc"
     break;
 
-  case 57:
-
-/* Line 1464 of yacc.c  */
+  case 57: /* hash: FNV1A_64  */
 #line 430 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.hash)= MEMCACHED_HASH_FNV1A_64;
-          ;}
+          }
+#line 1977 "libmemcached/csl/parser.cc"
     break;
 
-  case 58:
-
-/* Line 1464 of yacc.c  */
+  case 58: /* hash: FNV1_32  */
 #line 434 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.hash)= MEMCACHED_HASH_FNV1_32;
-          ;}
+          }
+#line 1985 "libmemcached/csl/parser.cc"
     break;
 
-  case 59:
-
-/* Line 1464 of yacc.c  */
+  case 59: /* hash: FNV1A_32  */
 #line 438 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.hash)= MEMCACHED_HASH_FNV1A_32;
-          ;}
+          }
+#line 1993 "libmemcached/csl/parser.cc"
     break;
 
-  case 60:
-
-/* Line 1464 of yacc.c  */
+  case 60: /* hash: HSIEH  */
 #line 442 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.hash)= MEMCACHED_HASH_HSIEH;
-          ;}
+          }
+#line 2001 "libmemcached/csl/parser.cc"
     break;
 
-  case 61:
-
-/* Line 1464 of yacc.c  */
+  case 61: /* hash: MURMUR  */
 #line 446 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.hash)= MEMCACHED_HASH_MURMUR;
-          ;}
+          }
+#line 2009 "libmemcached/csl/parser.cc"
     break;
 
-  case 62:
-
-/* Line 1464 of yacc.c  */
+  case 62: /* hash: JENKINS  */
 #line 450 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.hash)= MEMCACHED_HASH_JENKINS;
-          ;}
+          }
+#line 2017 "libmemcached/csl/parser.cc"
     break;
 
-  case 63:
-
-/* Line 1464 of yacc.c  */
+  case 63: /* string: STRING  */
 #line 457 "libmemcached/csl/parser.yy"
-    {
-            (yyval.string)= (yyvsp[(1) - (1)].string);
-          ;}
+          {
+            (yyval.string)= (yyvsp[0].string);
+          }
+#line 2025 "libmemcached/csl/parser.cc"
     break;
 
-  case 64:
-
-/* Line 1464 of yacc.c  */
+  case 64: /* string: QUOTED_STRING  */
 #line 461 "libmemcached/csl/parser.yy"
-    {
-            (yyval.string)= (yyvsp[(1) - (1)].string);
-          ;}
+          {
+            (yyval.string)= (yyvsp[0].string);
+          }
+#line 2033 "libmemcached/csl/parser.cc"
     break;
 
-  case 65:
-
-/* Line 1464 of yacc.c  */
+  case 65: /* distribution: CONSISTENT  */
 #line 468 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.distribution)= MEMCACHED_DISTRIBUTION_CONSISTENT;
-          ;}
+          }
+#line 2041 "libmemcached/csl/parser.cc"
     break;
 
-  case 66:
-
-/* Line 1464 of yacc.c  */
+  case 66: /* distribution: MODULA  */
 #line 472 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.distribution)= MEMCACHED_DISTRIBUTION_MODULA;
-          ;}
+          }
+#line 2049 "libmemcached/csl/parser.cc"
     break;
 
-  case 67:
-
-/* Line 1464 of yacc.c  */
+  case 67: /* distribution: RANDOM  */
 #line 476 "libmemcached/csl/parser.yy"
-    {
+          {
             (yyval.distribution)= MEMCACHED_DISTRIBUTION_RANDOM;
-          ;}
+          }
+#line 2057 "libmemcached/csl/parser.cc"
     break;
 
 
+#line 2061 "libmemcached/csl/parser.cc"
 
-/* Line 1464 of yacc.c  */
-#line 2129 "libmemcached/csl/parser.cc"
       default: break;
     }
-  YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
+  /* User semantic actions sometimes alter yychar, and that requires
+     that yytoken be updated with the new translation.  We take the
+     approach of translating immediately before every use of yytoken.
+     One alternative is translating here after every semantic action,
+     but that translation would be missed if the semantic action invokes
+     YYABORT, YYACCEPT, or YYERROR immediately after altering yychar or
+     if it invokes YYBACKUP.  In the case of YYABORT or YYACCEPT, an
+     incorrect destructor might then be invoked immediately.  In the
+     case of YYERROR or YYBACKUP, subsequent parser actions might lead
+     to an incorrect destructor call or verbose syntax error message
+     before the lookahead is translated.  */
+  YY_SYMBOL_PRINT ("-> $$ =", YY_CAST (yysymbol_kind_t, yyr1[yyn]), &yyval, &yyloc);
 
   YYPOPSTACK (yylen);
   yylen = 0;
-  YY_STACK_PRINT (yyss, yyssp);
 
   *++yyvsp = yyval;
 
-  /* Now `shift' the result of the reduction.  Determine what state
+  /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
-
-  yyn = yyr1[yyn];
-
-  yystate = yypgoto[yyn - YYNTOKENS] + *yyssp;
-  if (0 <= yystate && yystate <= YYLAST && yycheck[yystate] == *yyssp)
-    yystate = yytable[yystate];
-  else
-    yystate = yydefgoto[yyn - YYNTOKENS];
+  {
+    const int yylhs = yyr1[yyn] - YYNTOKENS;
+    const int yyi = yypgoto[yylhs] + *yyssp;
+    yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
+               ? yytable[yyi]
+               : yydefgoto[yylhs]);
+  }
 
   goto yynewstate;
 
 
-/*------------------------------------.
-| yyerrlab -- here on detecting error |
-`------------------------------------*/
+/*--------------------------------------.
+| yyerrlab -- here on detecting error.  |
+`--------------------------------------*/
 yyerrlab:
+  /* Make sure we have latest lookahead translation.  See comments at
+     user semantic actions for why this is necessary.  */
+  yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)
     {
       ++yynerrs;
-#if ! YYERROR_VERBOSE
-      yyerror (context, scanner, YY_("syntax error"));
-#else
       {
-	YYSIZE_T yysize = yysyntax_error (0, yystate, yychar);
-	if (yymsg_alloc < yysize && yymsg_alloc < YYSTACK_ALLOC_MAXIMUM)
-	  {
-	    YYSIZE_T yyalloc = 2 * yysize;
-	    if (! (yysize <= yyalloc && yyalloc <= YYSTACK_ALLOC_MAXIMUM))
-	      yyalloc = YYSTACK_ALLOC_MAXIMUM;
-	    if (yymsg != yymsgbuf)
-	      YYSTACK_FREE (yymsg);
-	    yymsg = (char *) YYSTACK_ALLOC (yyalloc);
-	    if (yymsg)
-	      yymsg_alloc = yyalloc;
-	    else
-	      {
-		yymsg = yymsgbuf;
-		yymsg_alloc = sizeof yymsgbuf;
-	      }
-	  }
-
-	if (0 < yysize && yysize <= yymsg_alloc)
-	  {
-	    (void) yysyntax_error (yymsg, yystate, yychar);
-	    yyerror (context, scanner, yymsg);
-	  }
-	else
-	  {
-	    yyerror (context, scanner, YY_("syntax error"));
-	    if (yysize != 0)
-	      goto yyexhaustedlab;
-	  }
+        yypcontext_t yyctx
+          = {yyssp, yytoken};
+        char const *yymsgp = YY_("syntax error");
+        int yysyntax_error_status;
+        yysyntax_error_status = yysyntax_error (&yymsg_alloc, &yymsg, &yyctx);
+        if (yysyntax_error_status == 0)
+          yymsgp = yymsg;
+        else if (yysyntax_error_status == -1)
+          {
+            if (yymsg != yymsgbuf)
+              YYSTACK_FREE (yymsg);
+            yymsg = YY_CAST (char *,
+                             YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
+            if (yymsg)
+              {
+                yysyntax_error_status
+                  = yysyntax_error (&yymsg_alloc, &yymsg, &yyctx);
+                yymsgp = yymsg;
+              }
+            else
+              {
+                yymsg = yymsgbuf;
+                yymsg_alloc = sizeof yymsgbuf;
+                yysyntax_error_status = YYENOMEM;
+              }
+          }
+        yyerror (context, scanner, yymsgp);
+        if (yysyntax_error_status == YYENOMEM)
+          YYNOMEM;
       }
-#endif
     }
-
-
 
   if (yyerrstatus == 3)
     {
       /* If just tried and failed to reuse lookahead token after an
-	 error, discard it.  */
+         error, discard it.  */
 
       if (yychar <= YYEOF)
-	{
-	  /* Return failure if at end of input.  */
-	  if (yychar == YYEOF)
-	    YYABORT;
-	}
+        {
+          /* Return failure if at end of input.  */
+          if (yychar == YYEOF)
+            YYABORT;
+        }
       else
-	{
-	  yydestruct ("Error: discarding",
-		      yytoken, &yylval, context, scanner);
-	  yychar = YYEMPTY;
-	}
+        {
+          yydestruct ("Error: discarding",
+                      yytoken, &yylval, context, scanner);
+          yychar = YYEMPTY;
+        }
     }
 
   /* Else will try to reuse lookahead token after shifting the error
@@ -2226,14 +2165,13 @@ yyerrlab:
 | yyerrorlab -- error raised explicitly by YYERROR.  |
 `---------------------------------------------------*/
 yyerrorlab:
+  /* Pacify compilers when the user code never invokes YYERROR and the
+     label yyerrorlab therefore never appears in user code.  */
+  if (0)
+    YYERROR;
+  ++yynerrs;
 
-  /* Pacify compilers like GCC when the user code never invokes
-     YYERROR and the label yyerrorlab therefore never appears in user
-     code.  */
-  if (/*CONSTCOND*/ 0)
-     goto yyerrorlab;
-
-  /* Do not reclaim the symbols of the rule which action triggered
+  /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
   YYPOPSTACK (yylen);
   yylen = 0;
@@ -2246,39 +2184,42 @@ yyerrorlab:
 | yyerrlab1 -- common code for both syntax error and YYERROR.  |
 `-------------------------------------------------------------*/
 yyerrlab1:
-  yyerrstatus = 3;	/* Each real token shifted decrements this.  */
+  yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
+  /* Pop stack until we find a state that shifts the error token.  */
   for (;;)
     {
       yyn = yypact[yystate];
-      if (yyn != YYPACT_NINF)
-	{
-	  yyn += YYTERROR;
-	  if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
-	    {
-	      yyn = yytable[yyn];
-	      if (0 < yyn)
-		break;
-	    }
-	}
+      if (!yypact_value_is_default (yyn))
+        {
+          yyn += YYSYMBOL_YYerror;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYerror)
+            {
+              yyn = yytable[yyn];
+              if (0 < yyn)
+                break;
+            }
+        }
 
       /* Pop the current state because it cannot handle the error token.  */
       if (yyssp == yyss)
-	YYABORT;
+        YYABORT;
 
 
       yydestruct ("Error: popping",
-		  yystos[yystate], yyvsp, context, scanner);
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp, context, scanner);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
     }
 
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 
 
   /* Shift the error token.  */
-  YY_SYMBOL_PRINT ("Shifting", yystos[yyn], yyvsp, yylsp);
+  YY_SYMBOL_PRINT ("Shifting", YY_ACCESSING_SYMBOL (yyn), yyvsp, yylsp);
 
   yystate = yyn;
   goto yynewstate;
@@ -2289,54 +2230,57 @@ yyerrlab1:
 `-------------------------------------*/
 yyacceptlab:
   yyresult = 0;
-  goto yyreturn;
+  goto yyreturnlab;
+
 
 /*-----------------------------------.
 | yyabortlab -- YYABORT comes here.  |
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
-  goto yyreturn;
+  goto yyreturnlab;
 
-#if !defined(yyoverflow) || YYERROR_VERBOSE
-/*-------------------------------------------------.
-| yyexhaustedlab -- memory exhaustion comes here.  |
-`-------------------------------------------------*/
+
+/*-----------------------------------------------------------.
+| yyexhaustedlab -- YYNOMEM (memory exhaustion) comes here.  |
+`-----------------------------------------------------------*/
 yyexhaustedlab:
   yyerror (context, scanner, YY_("memory exhausted"));
   yyresult = 2;
-  /* Fall through.  */
-#endif
+  goto yyreturnlab;
 
-yyreturn:
+
+/*----------------------------------------------------------.
+| yyreturnlab -- parsing is finished, clean up and return.  |
+`----------------------------------------------------------*/
+yyreturnlab:
   if (yychar != YYEMPTY)
-     yydestruct ("Cleanup: discarding lookahead",
-		 yytoken, &yylval, context, scanner);
-  /* Do not reclaim the symbols of the rule which action triggered
+    {
+      /* Make sure we have latest lookahead translation.  See comments at
+         user semantic actions for why this is necessary.  */
+      yytoken = YYTRANSLATE (yychar);
+      yydestruct ("Cleanup: discarding lookahead",
+                  yytoken, &yylval, context, scanner);
+    }
+  /* Do not reclaim the symbols of the rule whose action triggered
      this YYABORT or YYACCEPT.  */
   YYPOPSTACK (yylen);
   YY_STACK_PRINT (yyss, yyssp);
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-		  yystos[*yyssp], yyvsp, context, scanner);
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, context, scanner);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
   if (yyss != yyssa)
     YYSTACK_FREE (yyss);
 #endif
-#if YYERROR_VERBOSE
   if (yymsg != yymsgbuf)
     YYSTACK_FREE (yymsg);
-#endif
-  /* Make sure YYID is used.  */
-  return YYID (yyresult);
+  return yyresult;
 }
 
-
-
-/* Line 1684 of yacc.c  */
 #line 481 "libmemcached/csl/parser.yy"
  
 
@@ -2344,5 +2288,4 @@ void Context::start()
 {
   config_parse(this, (void **)scanner);
 }
-
 

--- a/libmemcached/csl/parser.h
+++ b/libmemcached/csl/parser.h
@@ -1,22 +1,22 @@
-/* A Bison parser, made by GNU Bison 2.4.3.  */
+/* A Bison parser, made by GNU Bison 3.8.  */
 
-/* Skeleton interface for Bison's Yacc-like parsers in C
-   
-      Copyright (C) 1984, 1989, 1990, 2000, 2001, 2002, 2003, 2004, 2005, 2006,
-   2009, 2010 Free Software Foundation, Inc.
-   
+/* Bison interface for Yacc-like parsers in C
+
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+   Inc.
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -27,97 +27,112 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-   
+
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
 
-/* Tokens.  */
+#ifndef YY_CONFIG_LIBMEMCACHED_CSL_PARSER_H_INCLUDED
+# define YY_CONFIG_LIBMEMCACHED_CSL_PARSER_H_INCLUDED
+/* Debug traces.  */
+#ifndef YYDEBUG
+# define YYDEBUG 1
+#endif
+#if YYDEBUG
+extern int config_debug;
+#endif
+
+/* Token kinds.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
-   /* Put the tokens into the symbol table, so that GDB and other debuggers
-      know about them.  */
-   enum yytokentype {
-     COMMENT = 258,
-     END = 259,
-     ERROR = 260,
-     RESET = 261,
-     PARSER_DEBUG = 262,
-     INCLUDE = 263,
-     CONFIGURE_FILE = 264,
-     EMPTY_LINE = 265,
-     SERVER = 266,
-     SOCKET = 267,
-     SERVERS = 268,
-     SERVERS_OPTION = 269,
-     UNKNOWN_OPTION = 270,
-     UNKNOWN = 271,
-     BINARY_PROTOCOL = 272,
-     BUFFER_REQUESTS = 273,
-     CONNECT_TIMEOUT = 274,
-     DISTRIBUTION = 275,
-     HASH = 276,
-     HASH_WITH_NAMESPACE = 277,
-     IO_BYTES_WATERMARK = 278,
-     IO_KEY_PREFETCH = 279,
-     IO_MSG_WATERMARK = 280,
-     KETAMA_HASH = 281,
-     KETAMA_WEIGHTED = 282,
-     NOREPLY = 283,
-     NUMBER_OF_REPLICAS = 284,
-     POLL_TIMEOUT = 285,
-     RANDOMIZE_REPLICA_READ = 286,
-     RCV_TIMEOUT = 287,
-     REMOVE_FAILED_SERVERS = 288,
-     RETRY_TIMEOUT = 289,
-     SND_TIMEOUT = 290,
-     SOCKET_RECV_SIZE = 291,
-     SOCKET_SEND_SIZE = 292,
-     SORT_HOSTS = 293,
-     SUPPORT_CAS = 294,
-     USER_DATA = 295,
-     USE_UDP = 296,
-     VERIFY_KEY = 297,
-     _TCP_KEEPALIVE = 298,
-     _TCP_KEEPIDLE = 299,
-     _TCP_NODELAY = 300,
-     NAMESPACE = 301,
-     POOL_MIN = 302,
-     POOL_MAX = 303,
-     MD5 = 304,
-     CRC = 305,
-     FNV1_64 = 306,
-     FNV1A_64 = 307,
-     FNV1_32 = 308,
-     FNV1A_32 = 309,
-     HSIEH = 310,
-     MURMUR = 311,
-     JENKINS = 312,
-     CONSISTENT = 313,
-     MODULA = 314,
-     RANDOM = 315,
-     MC_TRUE = 316,
-     MC_FALSE = 317,
-     FLOAT = 318,
-     NUMBER = 319,
-     PORT = 320,
-     WEIGHT_START = 321,
-     IPADDRESS = 322,
-     HOSTNAME = 323,
-     STRING = 324,
-     QUOTED_STRING = 325,
-     FILE_PATH = 326
-   };
+  enum yytokentype
+  {
+    YYEMPTY = -2,
+    YYEOF = 0,                     /* "end of file"  */
+    YYerror = 256,                 /* error  */
+    YYUNDEF = 257,                 /* "invalid token"  */
+    COMMENT = 258,                 /* COMMENT  */
+    END = 259,                     /* END  */
+    ERROR = 260,                   /* ERROR  */
+    RESET = 261,                   /* RESET  */
+    PARSER_DEBUG = 262,            /* PARSER_DEBUG  */
+    INCLUDE = 263,                 /* INCLUDE  */
+    CONFIGURE_FILE = 264,          /* CONFIGURE_FILE  */
+    EMPTY_LINE = 265,              /* EMPTY_LINE  */
+    SERVER = 266,                  /* SERVER  */
+    SOCKET = 267,                  /* SOCKET  */
+    SERVERS = 268,                 /* SERVERS  */
+    SERVERS_OPTION = 269,          /* SERVERS_OPTION  */
+    UNKNOWN_OPTION = 270,          /* UNKNOWN_OPTION  */
+    UNKNOWN = 271,                 /* UNKNOWN  */
+    BINARY_PROTOCOL = 272,         /* BINARY_PROTOCOL  */
+    BUFFER_REQUESTS = 273,         /* BUFFER_REQUESTS  */
+    CONNECT_TIMEOUT = 274,         /* CONNECT_TIMEOUT  */
+    DISTRIBUTION = 275,            /* DISTRIBUTION  */
+    HASH = 276,                    /* HASH  */
+    HASH_WITH_NAMESPACE = 277,     /* HASH_WITH_NAMESPACE  */
+    IO_BYTES_WATERMARK = 278,      /* IO_BYTES_WATERMARK  */
+    IO_KEY_PREFETCH = 279,         /* IO_KEY_PREFETCH  */
+    IO_MSG_WATERMARK = 280,        /* IO_MSG_WATERMARK  */
+    KETAMA_HASH = 281,             /* KETAMA_HASH  */
+    KETAMA_WEIGHTED = 282,         /* KETAMA_WEIGHTED  */
+    NOREPLY = 283,                 /* NOREPLY  */
+    NUMBER_OF_REPLICAS = 284,      /* NUMBER_OF_REPLICAS  */
+    POLL_TIMEOUT = 285,            /* POLL_TIMEOUT  */
+    RANDOMIZE_REPLICA_READ = 286,  /* RANDOMIZE_REPLICA_READ  */
+    RCV_TIMEOUT = 287,             /* RCV_TIMEOUT  */
+    REMOVE_FAILED_SERVERS = 288,   /* REMOVE_FAILED_SERVERS  */
+    RETRY_TIMEOUT = 289,           /* RETRY_TIMEOUT  */
+    SND_TIMEOUT = 290,             /* SND_TIMEOUT  */
+    SOCKET_RECV_SIZE = 291,        /* SOCKET_RECV_SIZE  */
+    SOCKET_SEND_SIZE = 292,        /* SOCKET_SEND_SIZE  */
+    SORT_HOSTS = 293,              /* SORT_HOSTS  */
+    SUPPORT_CAS = 294,             /* SUPPORT_CAS  */
+    USER_DATA = 295,               /* USER_DATA  */
+    USE_UDP = 296,                 /* USE_UDP  */
+    VERIFY_KEY = 297,              /* VERIFY_KEY  */
+    _TCP_KEEPALIVE = 298,          /* _TCP_KEEPALIVE  */
+    _TCP_KEEPIDLE = 299,           /* _TCP_KEEPIDLE  */
+    _TCP_NODELAY = 300,            /* _TCP_NODELAY  */
+    NAMESPACE = 301,               /* NAMESPACE  */
+    POOL_MIN = 302,                /* POOL_MIN  */
+    POOL_MAX = 303,                /* POOL_MAX  */
+    MD5 = 304,                     /* MD5  */
+    CRC = 305,                     /* CRC  */
+    FNV1_64 = 306,                 /* FNV1_64  */
+    FNV1A_64 = 307,                /* FNV1A_64  */
+    FNV1_32 = 308,                 /* FNV1_32  */
+    FNV1A_32 = 309,                /* FNV1A_32  */
+    HSIEH = 310,                   /* HSIEH  */
+    MURMUR = 311,                  /* MURMUR  */
+    JENKINS = 312,                 /* JENKINS  */
+    CONSISTENT = 313,              /* CONSISTENT  */
+    MODULA = 314,                  /* MODULA  */
+    RANDOM = 315,                  /* RANDOM  */
+    TRUE = 316,                    /* TRUE  */
+    FALSE = 317,                   /* FALSE  */
+    FLOAT = 318,                   /* FLOAT  */
+    NUMBER = 319,                  /* NUMBER  */
+    PORT = 320,                    /* PORT  */
+    WEIGHT_START = 321,            /* WEIGHT_START  */
+    IPADDRESS = 322,               /* IPADDRESS  */
+    HOSTNAME = 323,                /* HOSTNAME  */
+    STRING = 324,                  /* STRING  */
+    QUOTED_STRING = 325,           /* QUOTED_STRING  */
+    FILE_PATH = 326                /* FILE_PATH  */
+  };
+  typedef enum yytokentype yytoken_kind_t;
 #endif
 
-
-
-#if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
-
-# define yystype YYSTYPE /* obsolescent; will be withdrawn */
-# define YYSTYPE_IS_DECLARED 1
-#endif
+/* Value type.  */
 
 
 
 
+int config_parse (Context *context, yyscan_t *scanner);
+
+
+#endif /* !YY_CONFIG_LIBMEMCACHED_CSL_PARSER_H_INCLUDED  */

--- a/libmemcached/csl/parser.h
+++ b/libmemcached/csl/parser.h
@@ -132,7 +132,6 @@ extern int config_debug;
 
 
 
-int config_parse (Context *context, yyscan_t *scanner);
 
 
 #endif /* !YY_CONFIG_LIBMEMCACHED_CSL_PARSER_H_INCLUDED  */

--- a/libmemcached/csl/parser.yy
+++ b/libmemcached/csl/parser.yy
@@ -1,0 +1,487 @@
+/*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
+ *
+ *  Configure Scripting Language
+ *
+ *  Copyright (C) 2011 DataDifferental, http://datadifferential.com
+ *  
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *  
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+%error-verbose
+%debug
+%defines
+%expect 0
+%output "libmemcached/csl/parser.cc"
+%defines "libmemcached/csl/parser.h"
+%lex-param { yyscan_t *scanner }
+%name-prefix="config_"
+%parse-param { Context *context }
+%parse-param { yyscan_t *scanner }
+%pure-parser
+%require "2.4"
+%start begin
+%verbose
+
+%{
+
+#include <libmemcached/csl/common.h>
+#include <libmemcached/options.hpp>
+
+#include <libmemcached/csl/context.h>
+#include <libmemcached/csl/symbol.h>
+#include <libmemcached/csl/scanner.h>
+
+#ifndef __INTEL_COMPILER
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
+int conf_lex(YYSTYPE* lvalp, void* scanner);
+
+#define select_yychar(__context) yychar == UNKNOWN ? ( (__context)->previous_token == END ? UNKNOWN : (__context)->previous_token ) : yychar   
+
+#define stryytname(__yytokentype) ((__yytokentype) <  YYNTOKENS ) ? yytname[(__yytokentype)] : ""
+
+#define parser_abort(__context, __error_message) do { (__context)->abort((__error_message), yytokentype(select_yychar(__context)), stryytname(YYTRANSLATE(select_yychar(__context)))); YYABORT; } while (0) 
+
+// This is bison calling error.
+inline void __config_error(Context *context, yyscan_t *scanner, const char *error, int last_token, const char *last_token_str)
+{
+  if (not context->end())
+  {
+    context->error(error, yytokentype(last_token), last_token_str);
+  }
+  else
+  {
+    context->error(error, yytokentype(last_token), last_token_str);
+  }
+}
+
+#define config_error(__context, __scanner, __error_msg) do { __config_error((__context), (__scanner), (__error_msg), select_yychar(__context), stryytname(YYTRANSLATE(select_yychar(__context)))); } while (0)
+
+
+%}
+
+%token COMMENT
+%token END
+%token ERROR
+%token RESET
+%token PARSER_DEBUG
+%token INCLUDE
+%token CONFIGURE_FILE
+%token EMPTY_LINE
+%token SERVER
+%token SOCKET
+%token SERVERS
+%token SERVERS_OPTION
+%token UNKNOWN_OPTION
+%token UNKNOWN
+
+/* All behavior options */
+%token BINARY_PROTOCOL
+%token BUFFER_REQUESTS
+%token CONNECT_TIMEOUT
+%token DISTRIBUTION
+%token HASH
+%token HASH_WITH_NAMESPACE
+%token IO_BYTES_WATERMARK
+%token IO_KEY_PREFETCH
+%token IO_MSG_WATERMARK
+%token KETAMA_HASH
+%token KETAMA_WEIGHTED
+%token NOREPLY
+%token NUMBER_OF_REPLICAS
+%token POLL_TIMEOUT
+%token RANDOMIZE_REPLICA_READ
+%token RCV_TIMEOUT
+%token REMOVE_FAILED_SERVERS
+%token RETRY_TIMEOUT
+%token SND_TIMEOUT
+%token SOCKET_RECV_SIZE
+%token SOCKET_SEND_SIZE
+%token SORT_HOSTS
+%token SUPPORT_CAS
+%token USER_DATA
+%token USE_UDP
+%token VERIFY_KEY
+%token _TCP_KEEPALIVE
+%token _TCP_KEEPIDLE
+%token _TCP_NODELAY
+
+/* Callbacks */
+%token NAMESPACE
+
+/* Pool */
+%token POOL_MIN
+%token POOL_MAX
+
+/* Hash types */
+%token MD5
+%token CRC
+%token FNV1_64
+%token FNV1A_64
+%token FNV1_32
+%token FNV1A_32
+%token HSIEH
+%token MURMUR
+%token JENKINS
+
+/* Distributions */
+%token CONSISTENT
+%token MODULA
+%token RANDOM
+
+/* Boolean values */
+%token <boolean> TRUE
+%token <boolean> FALSE
+
+%nonassoc ','
+%nonassoc '='
+
+%token <number> FLOAT
+%token <number> NUMBER
+%token <number> PORT
+%token <number> WEIGHT_START
+%token <server> IPADDRESS
+%token <server> HOSTNAME
+%token <string> STRING
+%token <string> QUOTED_STRING
+%token <string> FILE_PATH
+
+%type <behavior> behavior_boolean
+%type <behavior> behavior_number
+%type <distribution> distribution
+%type <hash> hash
+%type <number> optional_port
+%type <number> optional_weight
+%type <string> string
+
+%%
+
+begin:
+          statement
+        | begin ' ' statement
+        ;
+
+statement:
+         expression
+          { }
+        | COMMENT
+          { }
+        | EMPTY_LINE
+          { }
+        | END
+          {
+            context->set_end();
+            YYACCEPT;
+          }
+        | ERROR
+          {
+            context->rc= MEMCACHED_PARSE_USER_ERROR;
+            parser_abort(context, NULL);
+          }
+        | RESET
+          {
+            memcached_reset(context->memc);
+          }
+        | PARSER_DEBUG
+          {
+            yydebug= 1;
+          }
+        | INCLUDE ' ' string
+          {
+            if ((context->rc= memcached_parse_configure_file(*context->memc, $3.c_str, $3.size)) != MEMCACHED_SUCCESS)
+            {
+              parser_abort(context, NULL);
+            }
+          }
+        ;
+
+
+expression:
+          SERVER HOSTNAME optional_port optional_weight
+          {
+            if (memcached_failed(context->rc= memcached_server_add_with_weight(context->memc, $2.c_str, $3, $4)))
+            {
+              parser_abort(context, NULL);
+            }
+            context->unset_server();
+          }
+        | SERVER IPADDRESS optional_port optional_weight
+          {
+            if (memcached_failed(context->rc= memcached_server_add_with_weight(context->memc, $2.c_str, $3, $4)))
+            {
+              parser_abort(context, NULL);
+            }
+            context->unset_server();
+          }
+        | SOCKET string optional_weight
+          {
+            if (memcached_failed(context->rc= memcached_server_add_unix_socket_with_weight(context->memc, $2.c_str, $3)))
+            {
+              parser_abort(context, NULL);
+            }
+          }
+        | CONFIGURE_FILE string
+          {
+            memcached_set_configuration_file(context->memc, $2.c_str, $2.size);
+          }
+        | POOL_MIN NUMBER
+          {
+            context->memc->configure.initial_pool_size= $2;
+          }
+        | POOL_MAX NUMBER
+          {
+            context->memc->configure.max_pool_size= $2;
+          }
+        | behaviors
+        ;
+
+behaviors:
+          NAMESPACE string
+          {
+            if ((context->rc= memcached_set_namespace(context->memc, $2.c_str, $2.size)) != MEMCACHED_SUCCESS)
+            {
+              parser_abort(context, NULL);;
+            }
+          }
+        | DISTRIBUTION distribution
+          {
+            if ((context->rc= memcached_behavior_set(context->memc, MEMCACHED_BEHAVIOR_DISTRIBUTION, $2)) != MEMCACHED_SUCCESS)
+            {
+              parser_abort(context, NULL);;
+            }
+          }
+        | DISTRIBUTION distribution ',' hash
+          {
+            if ((context->rc= memcached_behavior_set(context->memc, MEMCACHED_BEHAVIOR_DISTRIBUTION, $2)) != MEMCACHED_SUCCESS)
+            {
+              parser_abort(context, NULL);;
+            }
+            if ((context->rc= memcached_behavior_set_distribution_hash(context->memc, $4)) != MEMCACHED_SUCCESS)
+            {
+              parser_abort(context, NULL);;
+            }
+          }
+        | HASH hash
+          {
+            if ((context->rc= memcached_behavior_set(context->memc, MEMCACHED_BEHAVIOR_HASH, $2)) != MEMCACHED_SUCCESS)
+            {
+              parser_abort(context, NULL);; 
+            }
+          }
+        | behavior_number NUMBER
+          {
+            if ((context->rc= memcached_behavior_set(context->memc, $1, $2)) != MEMCACHED_SUCCESS)
+            {
+              parser_abort(context, NULL);;
+            }
+          }
+        | behavior_boolean
+          {
+            if ((context->rc= memcached_behavior_set(context->memc, $1, true)) != MEMCACHED_SUCCESS)
+            {
+              parser_abort(context, NULL);;
+            }
+          }
+        |  USER_DATA
+          {
+          }
+        ;
+
+behavior_number:
+          REMOVE_FAILED_SERVERS
+          {
+            $$= MEMCACHED_BEHAVIOR_REMOVE_FAILED_SERVERS;
+          }
+        | CONNECT_TIMEOUT
+          {
+            $$= MEMCACHED_BEHAVIOR_CONNECT_TIMEOUT;
+          }
+        | IO_MSG_WATERMARK
+          {
+            $$= MEMCACHED_BEHAVIOR_IO_MSG_WATERMARK;
+          }
+        | IO_BYTES_WATERMARK
+          {
+            $$= MEMCACHED_BEHAVIOR_IO_BYTES_WATERMARK;
+          }
+        | IO_KEY_PREFETCH
+          {
+            $$= MEMCACHED_BEHAVIOR_IO_KEY_PREFETCH;
+          }
+        | NUMBER_OF_REPLICAS
+          {
+            $$= MEMCACHED_BEHAVIOR_NUMBER_OF_REPLICAS;
+          }
+        | POLL_TIMEOUT
+          {
+            $$= MEMCACHED_BEHAVIOR_POLL_TIMEOUT;
+          }
+        |  RCV_TIMEOUT
+          {
+            $$= MEMCACHED_BEHAVIOR_RCV_TIMEOUT;
+          }
+        |  RETRY_TIMEOUT
+          {
+            $$= MEMCACHED_BEHAVIOR_RETRY_TIMEOUT;
+          }
+        |  SND_TIMEOUT
+          {
+            $$= MEMCACHED_BEHAVIOR_SND_TIMEOUT;
+          }
+        |  SOCKET_RECV_SIZE
+          {
+            $$= MEMCACHED_BEHAVIOR_SOCKET_RECV_SIZE;
+          }
+        |  SOCKET_SEND_SIZE
+          {
+            $$= MEMCACHED_BEHAVIOR_SOCKET_SEND_SIZE;
+          }
+        ;
+
+behavior_boolean: 
+          BINARY_PROTOCOL
+          {
+            $$= MEMCACHED_BEHAVIOR_BINARY_PROTOCOL;
+          }
+        | BUFFER_REQUESTS
+          {
+            $$= MEMCACHED_BEHAVIOR_BUFFER_REQUESTS;
+          }
+        | HASH_WITH_NAMESPACE
+          {
+            $$= MEMCACHED_BEHAVIOR_HASH_WITH_PREFIX_KEY;
+          }
+        | NOREPLY
+          {
+            $$= MEMCACHED_BEHAVIOR_NOREPLY;
+          }
+        |  RANDOMIZE_REPLICA_READ
+          {
+            $$= MEMCACHED_BEHAVIOR_RANDOMIZE_REPLICA_READ;
+          }
+        |  SORT_HOSTS
+          {
+            $$= MEMCACHED_BEHAVIOR_SORT_HOSTS;
+          }
+        |  SUPPORT_CAS
+          {
+            $$= MEMCACHED_BEHAVIOR_SUPPORT_CAS;
+          }
+        |  _TCP_NODELAY
+          {
+            $$= MEMCACHED_BEHAVIOR_TCP_NODELAY;
+          }
+        |  _TCP_KEEPALIVE
+          {
+            $$= MEMCACHED_BEHAVIOR_TCP_KEEPALIVE;
+          }
+        |  _TCP_KEEPIDLE
+          {
+            $$= MEMCACHED_BEHAVIOR_TCP_KEEPIDLE;
+          }
+        |  USE_UDP
+          {
+            $$= MEMCACHED_BEHAVIOR_USE_UDP;
+          }
+        |  VERIFY_KEY
+          {
+            $$= MEMCACHED_BEHAVIOR_VERIFY_KEY;
+          }
+
+
+optional_port:
+          { $$= MEMCACHED_DEFAULT_PORT;}
+        | PORT
+          { };
+        ;
+
+optional_weight:
+          { $$= 1; }
+        | WEIGHT_START
+          { }
+        ;
+
+hash:
+          MD5
+          {
+            $$= MEMCACHED_HASH_MD5;
+          }
+        | CRC
+          {
+            $$= MEMCACHED_HASH_CRC;
+          }
+        | FNV1_64
+          {
+            $$= MEMCACHED_HASH_FNV1_64;
+          }
+        | FNV1A_64
+          {
+            $$= MEMCACHED_HASH_FNV1A_64;
+          }
+        | FNV1_32
+          {
+            $$= MEMCACHED_HASH_FNV1_32;
+          }
+        | FNV1A_32
+          {
+            $$= MEMCACHED_HASH_FNV1A_32;
+          }
+        | HSIEH
+          {
+            $$= MEMCACHED_HASH_HSIEH;
+          }
+        | MURMUR
+          {
+            $$= MEMCACHED_HASH_MURMUR;
+          }
+        | JENKINS
+          {
+            $$= MEMCACHED_HASH_JENKINS;
+          }
+        ;
+
+string:
+          STRING
+          {
+            $$= $1;
+          }
+        | QUOTED_STRING
+          {
+            $$= $1;
+          }
+        ;
+
+distribution:
+          CONSISTENT
+          {
+            $$= MEMCACHED_DISTRIBUTION_CONSISTENT;
+          }
+        | MODULA
+          {
+            $$= MEMCACHED_DISTRIBUTION_MODULA;
+          }
+        | RANDOM
+          {
+            $$= MEMCACHED_DISTRIBUTION_RANDOM;
+          }
+        ;
+
+%% 
+
+void Context::start() 
+{
+  config_parse(this, (void **)scanner);
+}
+

--- a/libmemcached/csl/scanner.cc
+++ b/libmemcached/csl/scanner.cc
@@ -45,7 +45,7 @@
 /* %endif */
 
 /* %if-c-only */
-    
+
 /* %endif */
 
 /* %if-c-only */
@@ -77,7 +77,7 @@
 #if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 
 /* C99 says to define __STDC_LIMIT_MACROS before including stdint.h,
- * if you want the limit (max/min) macros for int types. 
+ * if you want the limit (max/min) macros for int types.
  */
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS 1
@@ -94,7 +94,7 @@ typedef uint32_t flex_uint32_t;
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
 typedef int flex_int32_t;
-typedef unsigned char flex_uint8_t; 
+typedef unsigned char flex_uint8_t;
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
 #endif /* ! C99 */
@@ -244,7 +244,7 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 #define EOB_ACT_LAST_MATCH 2
 
     #define YY_LESS_LINENO(n)
-    
+
 /* Return all but the first "n" matched characters back to the input stream. */
 #define yyless(n) \
 	do \
@@ -311,7 +311,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -1115,17 +1115,17 @@ static yyconst flex_int16_t yy_rule_linenum[65] =
  *  Configure Scripting Language
  *
  *  Copyright (C) 2011 DataDifferental, http://datadifferential.com
- * 
+ *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
  *  published by the Free Software Foundation, either version 3 of the
  *  License, or (at your option) any later version.
- * 
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU Affero General Public License for more details.
- * 
+ *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -1224,7 +1224,7 @@ static int yy_init_globals (yyscan_t yyscanner );
     /* This must go here because YYSTYPE and YYLTYPE are included
      * from bison output in section 1.*/
     #    define yylval yyg->yylval_r
-    
+
 int config_lex_init (yyscan_t* scanner);
 
 int config_lex_init_extra (YY_EXTRA_TYPE user_defined,yyscan_t* scanner);
@@ -1812,12 +1812,12 @@ YY_RULE_SETUP
 case 46:
 YY_RULE_SETUP
 #line 141 "libmemcached/csl/scanner.l"
-{ return yyextra->previous_token= MC_TRUE; }
+{ return yyextra->previous_token= TRUE; }
 	YY_BREAK
 case 47:
 YY_RULE_SETUP
 #line 142 "libmemcached/csl/scanner.l"
-{ return yyextra->previous_token= MC_FALSE; }
+{ return yyextra->previous_token= FALSE; }
 	YY_BREAK
 case 48:
 YY_RULE_SETUP
@@ -2480,7 +2480,7 @@ static void config__load_buffer_state  (yyscan_t yyscanner)
 /* %endif */
 {
 	YY_BUFFER_STATE b;
-    
+
 	b = (YY_BUFFER_STATE) config_alloc(sizeof( struct yy_buffer_state ) ,yyscanner );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in config__create_buffer()" );
@@ -2530,7 +2530,7 @@ static void config__load_buffer_state  (yyscan_t yyscanner)
 #ifndef __cplusplus
 extern int isatty (int );
 #endif /* __cplusplus */
-    
+
 /* %endif */
 
 /* %if-c++-only */
@@ -2567,7 +2567,7 @@ extern int isatty (int );
 /* %if-c-only */
 
         b->yy_is_interactive = file ? (isatty( fileno(file) ) > 0) : 0;
-    
+
 /* %endif */
 /* %if-c++-only */
 /* %endif */
@@ -2697,9 +2697,9 @@ static void config_ensure_buffer_stack (yyscan_t yyscanner)
 								, yyscanner);
 		if ( ! yyg->yy_buffer_stack )
 			YY_FATAL_ERROR( "out of dynamic memory in config_ensure_buffer_stack()" );
-								  
+
 		memset(yyg->yy_buffer_stack, 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		yyg->yy_buffer_stack_max = num_to_alloc;
 		yyg->yy_buffer_stack_top = 0;
 		return;
@@ -2730,12 +2730,12 @@ static void config_ensure_buffer_stack (yyscan_t yyscanner)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * @param yyscanner The scanner object.
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE config__scan_buffer  (char * base, yy_size_t  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
-    
+
 	if ( size < 2 ||
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
@@ -2773,7 +2773,7 @@ YY_BUFFER_STATE config__scan_buffer  (char * base, yy_size_t  size , yyscan_t yy
  */
 YY_BUFFER_STATE config__scan_string (yyconst char * yystr , yyscan_t yyscanner)
 {
-    
+
 	return config__scan_bytes(yystr,strlen(yystr) ,yyscanner);
 }
 /* %endif */
@@ -2792,7 +2792,7 @@ YY_BUFFER_STATE config__scan_bytes  (yyconst char * yybytes, int  _yybytes_len ,
 	char *buf;
 	yy_size_t n;
 	int i;
-    
+
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = _yybytes_len + 2;
 	buf = (char *) config_alloc(n ,yyscanner );
@@ -2870,10 +2870,10 @@ YY_EXTRA_TYPE config_get_extra  (yyscan_t yyscanner)
 int config_get_lineno  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    
+
         if (! YY_CURRENT_BUFFER)
             return 0;
-    
+
     return yylineno;
 }
 
@@ -2883,10 +2883,10 @@ int config_get_lineno  (yyscan_t yyscanner)
 int config_get_column  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    
+
         if (! YY_CURRENT_BUFFER)
             return 0;
-    
+
     return yycolumn;
 }
 
@@ -2951,8 +2951,8 @@ void config_set_lineno (int  line_number , yyscan_t yyscanner)
 
         /* lineno is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
-           yy_fatal_error( "config_set_lineno called with no buffer" , yyscanner); 
-    
+           yy_fatal_error( "config_set_lineno called with no buffer" , yyscanner);
+
     yylineno = line_number;
 }
 
@@ -2966,8 +2966,8 @@ void config_set_column (int  column_no , yyscan_t yyscanner)
 
         /* column is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
-           yy_fatal_error( "config_set_column called with no buffer" , yyscanner); 
-    
+           yy_fatal_error( "config_set_column called with no buffer" , yyscanner);
+
     yycolumn = column_no;
 }
 
@@ -3069,20 +3069,20 @@ int config_lex_init_extra(YY_EXTRA_TYPE yy_user_defined,yyscan_t* ptr_yy_globals
         errno = EINVAL;
         return 1;
     }
-	
+
     *ptr_yy_globals = (yyscan_t) config_alloc ( sizeof( struct yyguts_t ), &dummy_yyguts );
-	
+
     if (*ptr_yy_globals == NULL){
         errno = ENOMEM;
         return 1;
     }
-    
+
     /* By setting to 0xAA, we expose bugs in
     yy_init_globals. Leave at 0x00 for releases. */
     memset(*ptr_yy_globals,0x00,sizeof(struct yyguts_t));
-    
+
     config_set_extra (yy_user_defined, *ptr_yy_globals);
-    
+
     return yy_init_globals ( *ptr_yy_globals );
 }
 


### PR DESCRIPTION
libmemcached-0.53버전의 parser.yy와 bison 3.8 버전을 사용해 parser를 재생성합니다.
변경 확인 및 리뷰 편의성을 위해 commit을 두 개로 나누었습니다.

1. parser.yy 추가
   - `parser.h`, `parser.cc` 재생성
   - `MC_TRUE` / `MC_FALSE` => `TRUE` / `FALSE`로 revert
   - make 실패하는 상태
2. Fix compile error
   - parser.h에서 config_parse 제거
   - parser.cc에 config_parse prototype 추가

parser.yy로 생성한 파일을 수정하지 않고 사용하려면 libmemcached 0.53이 아닌 최근 버전의 csl을 참고해야 할 것 같습니다.

@ing-eoking 추가로, #259 환경에서 테스트가 성공하는지도 확인하지 못했습니다.