### PR TITLE
INTERNAL: Fix compile errors occured in redhat8

### DIFF
--- a/libhashkit/jenkins.cc
+++ b/libhashkit/jenkins.cc
@@ -188,17 +188,17 @@ uint32_t hashkit_jenkins(const char *key, size_t length, void *)
     /*-------------------------------- last block: affect all 32 bits of (c) */
     switch(length)                   /* all the case statements fall through */
     {
-    case 12: c+=((uint32_t)k[11])<<24;
-    case 11: c+=((uint32_t)k[10])<<16;
-    case 10: c+=((uint32_t)k[9])<<8;
-    case 9 : c+=k[8];
-    case 8 : b+=((uint32_t)k[7])<<24;
-    case 7 : b+=((uint32_t)k[6])<<16;
-    case 6 : b+=((uint32_t)k[5])<<8;
-    case 5 : b+=k[4];
-    case 4 : a+=((uint32_t)k[3])<<24;
-    case 3 : a+=((uint32_t)k[2])<<16;
-    case 2 : a+=((uint32_t)k[1])<<8;
+    case 12: c+=((uint32_t)k[11])<<24; __attribute__((fallthrough));
+    case 11: c+=((uint32_t)k[10])<<16; __attribute__((fallthrough));
+    case 10: c+=((uint32_t)k[9])<<8;   __attribute__((fallthrough));
+    case 9 : c+=k[8];                  __attribute__((fallthrough));
+    case 8 : b+=((uint32_t)k[7])<<24;  __attribute__((fallthrough));
+    case 7 : b+=((uint32_t)k[6])<<16;  __attribute__((fallthrough));
+    case 6 : b+=((uint32_t)k[5])<<8;   __attribute__((fallthrough));
+    case 5 : b+=k[4];                  __attribute__((fallthrough));
+    case 4 : a+=((uint32_t)k[3])<<24;  __attribute__((fallthrough));
+    case 3 : a+=((uint32_t)k[2])<<16;  __attribute__((fallthrough));
+    case 2 : a+=((uint32_t)k[1])<<8;   __attribute__((fallthrough));
     case 1 : a+=k[0];
              break;
     case 0 : return c;

--- a/libhashkit/murmur.cc
+++ b/libhashkit/murmur.cc
@@ -59,8 +59,8 @@ uint32_t hashkit_murmur(const char *key, size_t length, void *context)
 
   switch(length)
   {
-  case 3: h ^= ((uint32_t)data[2]) << 16;
-  case 2: h ^= ((uint32_t)data[1]) << 8;
+  case 3: h ^= ((uint32_t)data[2]) << 16; __attribute__((fallthrough));
+  case 2: h ^= ((uint32_t)data[1]) << 8;  __attribute__((fallthrough));
   case 1: h ^= data[0];
           h *= m;
   default: break;

--- a/libmemcached/assert.hpp
+++ b/libmemcached/assert.hpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libmcachedd client library.
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libmemcached/behavior.cc
+++ b/libmemcached/behavior.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -170,13 +170,16 @@ memcached_return_t memcached_behavior_set(memcached_st *ptr,
 
   case MEMCACHED_BEHAVIOR_KETAMA_WEIGHTED:
     {
+      if (bool(data) == false)
+      {
+        return memcached_behavior_set(ptr, MEMCACHED_BEHAVIOR_KETAMA, true);
+      }
       (void)memcached_behavior_set_key_hash(ptr, MEMCACHED_HASH_MD5);
       (void)memcached_behavior_set_distribution_hash(ptr, MEMCACHED_HASH_MD5);
-      ptr->ketama.weighted= bool(data);
       /**
         @note We try to keep the same distribution going. This should be deprecated and rewritten.
       */
-      return memcached_behavior_set_distribution(ptr, MEMCACHED_DISTRIBUTION_CONSISTENT_KETAMA);
+      return memcached_behavior_set_distribution(ptr, MEMCACHED_DISTRIBUTION_CONSISTENT_WEIGHTED);
     }
 
   case MEMCACHED_BEHAVIOR_HASH:
@@ -477,7 +480,7 @@ memcached_return_t memcached_behavior_set_distribution(memcached_st *ptr, memcac
 {
   if (type < MEMCACHED_DISTRIBUTION_CONSISTENT_MAX)
   {
-    if (MEMCACHED_DISTRIBUTION_CONSISTENT_WEIGHTED)
+    if (type == MEMCACHED_DISTRIBUTION_CONSISTENT_WEIGHTED)
     {
       ptr->ketama.weighted= true;
     }

--- a/libmemcached/connect.cc
+++ b/libmemcached/connect.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -364,7 +364,7 @@ static memcached_return_t unix_socket_connect(memcached_server_st *server)
 
   memset(&servAddr, 0, sizeof (struct sockaddr_un));
   servAddr.sun_family= AF_UNIX;
-  strncpy(servAddr.sun_path, server->hostname, sizeof(servAddr.sun_path)); /* Copy filename */
+  memcpy(servAddr.sun_path, server->hostname, sizeof(servAddr.sun_path)); /* Copy filename */
 
   do {
     if (connect(server->fd, (struct sockaddr *)&servAddr, sizeof(servAddr)) < 0)
@@ -559,7 +559,7 @@ static memcached_return_t network_connect(memcached_server_st *server)
 */
 static memcached_return_t backoff_handling(memcached_server_write_instance_st server, bool& in_timeout)
 {
-  /* 
+  /*
     If we hit server_failure_limit then something is completely wrong about the server.
 
     1) If autoeject is enabled we do that.
@@ -568,7 +568,7 @@ static memcached_return_t backoff_handling(memcached_server_write_instance_st se
   if (server->server_failure_counter >= server->root->server_failure_limit)
   {
     /*
-      We just auto_eject if we hit this point 
+      We just auto_eject if we hit this point
     */
     if (_is_auto_eject_host(server->root))
     {

--- a/libmemcached/io.cc
+++ b/libmemcached/io.cc
@@ -492,6 +492,7 @@ static memcached_return_t _io_fill(memcached_server_write_instance_st ptr)
         WATCHPOINT_ASSERT(0);
       case EBADF:
         assert_msg(ptr->fd != INVALID_SOCKET, "Programmer error, invalid socket");
+        __attribute__((fallthrough));
       case EINVAL:
       case EFAULT:
       case ECONNREFUSED:
@@ -620,6 +621,7 @@ memcached_return_t memcached_io_slurp(memcached_server_write_instance_st ptr)
         WATCHPOINT_ASSERT(0);
       case EBADF:
         assert_msg(ptr->fd != INVALID_SOCKET, "Invalid socket state");
+        __attribute__((fallthrough));
       case EINVAL:
       case EFAULT:
       case ECONNREFUSED:

--- a/libtest/socket.cc
+++ b/libtest/socket.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright 2010-2014 NAVER Corp.
@@ -39,7 +39,7 @@ void set_default_socket(const char *socket)
 {
   if (socket)
   {
-    strncpy(global_socket, socket, sizeof(global_socket));
+    memcpy(global_socket, socket, sizeof(global_socket));
   }
 }
 


### PR DESCRIPTION
Redhat8 계열에서 발생하는 컴파일 에러를 수정합니다.

에러 상황은 3가지 입니다.
- switch 문에서 case에 break이 없이 사용하는 경우 (fallthrough)
  - `__attribute__((fallthrough))` 옵션을 추가하여 fallthrough 사용을 명시했습니다.
- copy될 string에 null문자 포함이 보장되지 않으면 strncpy 사용 불가
  - 기존 구현과 유사한 동작을 하도록 strncpy 대신 memcpy를 사용했습니다. 
- int type을 boolean으로 활용 불가
  - 비교 연산( != 0)을 추가했습니다. 

컴파일 에러
```
libtest/socket.cc:42:12: error: ‘char* strncpy(char*, const char*, size_t)’ specified bound 1024 equals destination size [-Werror=stringop-truncation]
     strncpy(global_socket, socket, sizeof(global_socket));

libhashkit/jenkins.cc:191:15: error: this statement may fall through [-Werror=implicit-fallthrough=]
     case 12: c+=((uint32_t)k[11])<<24;

libmemcached/behavior.cc:480:51: error: enum constant in boolean context [-Werror=int-in-bool-context]
     if (MEMCACHED_DISTRIBUTION_CONSISTENT_WEIGHTED)

```
<br></br>
사용된 g++ 버전
```
g++ (GCC) 8.5.0 20210514 (Red Hat 8.5.0-18)
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```