### PR TITLE
INTERNAL: Add fallthrough comments to avoid compile warning

### DIFF
--- a/libhashkit/jenkins.cc
+++ b/libhashkit/jenkins.cc
@@ -188,17 +188,17 @@ uint32_t hashkit_jenkins(const char *key, size_t length, void *)
     /*-------------------------------- last block: affect all 32 bits of (c) */
     switch(length)                   /* all the case statements fall through */
     {
-    case 12: c+=((uint32_t)k[11])<<24;
-    case 11: c+=((uint32_t)k[10])<<16;
-    case 10: c+=((uint32_t)k[9])<<8;
-    case 9 : c+=k[8];
-    case 8 : b+=((uint32_t)k[7])<<24;
-    case 7 : b+=((uint32_t)k[6])<<16;
-    case 6 : b+=((uint32_t)k[5])<<8;
-    case 5 : b+=k[4];
-    case 4 : a+=((uint32_t)k[3])<<24;
-    case 3 : a+=((uint32_t)k[2])<<16;
-    case 2 : a+=((uint32_t)k[1])<<8;
+    case 12: c+=((uint32_t)k[11])<<24; /* fall through */
+    case 11: c+=((uint32_t)k[10])<<16; /* fall through */
+    case 10: c+=((uint32_t)k[9])<<8;   /* fall through */
+    case 9 : c+=k[8];                  /* fall through */
+    case 8 : b+=((uint32_t)k[7])<<24;  /* fall through */
+    case 7 : b+=((uint32_t)k[6])<<16;  /* fall through */
+    case 6 : b+=((uint32_t)k[5])<<8;   /* fall through */
+    case 5 : b+=k[4];                  /* fall through */
+    case 4 : a+=((uint32_t)k[3])<<24;  /* fall through */
+    case 3 : a+=((uint32_t)k[2])<<16;  /* fall through */
+    case 2 : a+=((uint32_t)k[1])<<8;   /* fall through */
     case 1 : a+=k[0];
              break;
     case 0 : return c;

--- a/libhashkit/murmur.cc
+++ b/libhashkit/murmur.cc
@@ -59,8 +59,8 @@ uint32_t hashkit_murmur(const char *key, size_t length, void *context)
 
   switch(length)
   {
-  case 3: h ^= ((uint32_t)data[2]) << 16;
-  case 2: h ^= ((uint32_t)data[1]) << 8;
+  case 3: h ^= ((uint32_t)data[2]) << 16; /* fall through */
+  case 2: h ^= ((uint32_t)data[1]) << 8;  /* fall through */
   case 1: h ^= data[0];
           h *= m;
   default: break;

--- a/libmemcached/io.cc
+++ b/libmemcached/io.cc
@@ -491,7 +491,7 @@ static memcached_return_t _io_fill(memcached_server_write_instance_st ptr)
       case ENOTSOCK:
         WATCHPOINT_ASSERT(0);
       case EBADF:
-        assert_msg(ptr->fd != INVALID_SOCKET, "Programmer error, invalid socket");
+        assert_msg(ptr->fd != INVALID_SOCKET, "Programmer error, invalid socket"); /* fall through */
       case EINVAL:
       case EFAULT:
       case ECONNREFUSED:
@@ -619,7 +619,7 @@ memcached_return_t memcached_io_slurp(memcached_server_write_instance_st ptr)
       case ENOTSOCK:
         WATCHPOINT_ASSERT(0);
       case EBADF:
-        assert_msg(ptr->fd != INVALID_SOCKET, "Invalid socket state");
+        assert_msg(ptr->fd != INVALID_SOCKET, "Invalid socket state"); /* fall through */
       case EINVAL:
       case EFAULT:
       case ECONNREFUSED:


### PR DESCRIPTION
- jam2in/arcus-works#467

fallthrough 주석을 추가하여 redhat8계열에서 발생하는 compile warning 중 하나인 implicit-fallthrough 에러를 회피합니다.