### PR TITLE
INTERNAL: Handle string overflow when using strncpy

### DIFF
--- a/libtest/socket.cc
+++ b/libtest/socket.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright 2010-2014 NAVER Corp.
@@ -37,7 +37,7 @@ const char *default_socket()
 
 void set_default_socket(const char *socket)
 {
-  if (socket)
+  if (socket && strlen(socket) < sizeof(global_socket))
   {
     strncpy(global_socket, socket, sizeof(global_socket));
   }


### PR DESCRIPTION
- jam2in/arcus-works#467

redhat8계열 리눅스에서 발생하는 컴파일 경고 중 하나인 `strncpy`에 의한 string overflow 문제 해결을 위한 PR입니다.

우선 문제가 발생한 코드는 실제 서비스에서 사용되는 `unix_socket_connect` 함수와
테스트를 위한 코드인 `set_default_socket`에서 문자열 형태의 socket path를 저장하기 위한 공간 크기 문제로 인하여 발생했습니다.

- `unix_socket_connect` 함수의 경우 다른 로직의 에러 처리와 유사하게 `memcached_set_error` 함수를 활용했습니다.

- 테스트 코드에서 활용되는 `set_default_socket`의 경우 invalid 값이 들어온 경우 변수 `global_socket`을 갱신하지 못하도록 했습니다.
  - 해당 코드의 경우 실제에 쓰이지는 않고, 테스트 용도에서만 사용되므로 별도의 에러 처리 로직을 추가할 필요는 없다고 생각됩니다.
    - 해당 로직을 활용하는 테스트 쪽에서 유효성을 미리 갖고 가는 편이 좋을 것으로 생각됩니다.
  - 테스트에서 실제 `global_socket`을 활용하는 경우는 unix 소켓을 생성하는 함수 `pre_unix_socket` 밖에 없습니다.
    - 추가적으로 테스트에서 `memcached_is_valid_servername`를 통하여 소켓 주소의 validation을 검사하나 이는 tcp/udp, unix 세 통신 프로토콜을 같은 방식으로 검사하고 있어, unix의 경우 이에 맞게 변경이 필요하다고 생각됩니다.