### PR TITLE
INTERNAL: Remove a duplicate init macro in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,7 @@ AC_CONFIG_AUX_DIR(config)
 
 AC_CANONICAL_TARGET
 
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([-Wall -Werror -Wno-portability subdir-objects foreign tar-ustar])
 
 AC_CANONICAL_HOST
 AC_CANONICAL_BUILD

--- a/m4/pandora_canonical.m4
+++ b/m4/pandora_canonical.m4
@@ -78,17 +78,19 @@ AC_DEFUN([PANDORA_CANONICAL_TARGET],[
         [CFLAGS=""])
   AS_IF([test "x${ac_cv_env_CXXFLAGS_set}" = "x"],
         [CXXFLAGS=""])
-  
-  AM_INIT_AUTOMAKE(-Wall -Werror -Wno-portability subdir-objects foreign tar-ustar)
+
+  # A duplicate AM_INIT_AUTOMAKE macro that exists in configure.ac
+  # makes an error at automake 1.16.5 and above.
+  # AM_INIT_AUTOMAKE(-Wall -Werror -Wno-portability subdir-objects foreign tar-ustar)
 
   m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 
   m4_if(m4_substr(m4_esyscmd(test -d gnulib && echo 0),0,1),0,[
     gl_EARLY
   ],[
-    PANDORA_EXTENSIONS 
+    PANDORA_EXTENSIONS
   ])
-  
+
   AC_REQUIRE([AC_PROG_CC])
   m4_if(PCT_FORCE_GCC42, [yes], [
     AC_REQUIRE([PANDORA_ENSURE_GCC_VERSION])
@@ -140,7 +142,7 @@ AC_DEFUN([PANDORA_CANONICAL_TARGET],[
   ])
   PANDORA_CXX_CSTDINT
   PANDORA_CXX_CINTTYPES
-  
+
   m4_if(m4_substr(m4_esyscmd(test -d gnulib && echo 0),0,1),0,[
     gl_INIT
     AC_CONFIG_LIBOBJ_DIR([gnulib])
@@ -253,7 +255,7 @@ AC_DEFUN([PANDORA_CANONICAL_TARGET],[
   AC_CHECK_PROGS([SPHINXBUILD], [sphinx-build], [:])
   AS_IF([test "x${SPHINXBUILD}" != "x:"],[
     AC_CACHE_CHECK([if sphinx is new enough],[ac_cv_recent_sphinx],[
-    
+
     ${SPHINXBUILD} -Q -C -b man -d conftest.d . . >/dev/null 2>&1
     AS_IF([test $? -eq 0],[ac_cv_recent_sphinx=yes],
           [ac_cv_recent_sphinx=no])
@@ -268,7 +270,7 @@ AC_DEFUN([PANDORA_CANONICAL_TARGET],[
   m4_if(m4_substr(m4_esyscmd(test -d po && echo 0),0,1),0, [
     AM_PO_SUBDIRS
     IT_PROG_INTLTOOL([0.35],[no-xml])
-    
+
     GETTEXT_PACKAGE=$PACKAGE
     AC_CHECK_LIB(intl, libintl_gettext)
     AC_SUBST([GETTEXT_PACKAGE])


### PR DESCRIPTION
automake 1.16.5 버전에서 발생하는 현상인 중복 `AM_INIT_AUTOMAKE` 에러를 수정합니다.
```
autoreconf: export WARNINGS=all
autoreconf: Entering directory '.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
configure.ac:46: error: AM_INIT_AUTOMAKE expanded multiple times
/usr/local/Cellar/automake/1.16.5/share/aclocal-1.16/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
configure.ac:33: the top level
/usr/local/Cellar/automake/1.16.5/share/aclocal-1.16/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
m4/pandora_canonical.m4:33: PANDORA_CANONICAL_TARGET is expanded from...
configure.ac:46: the top level
autom4te: error: /usr/local/opt/m4/bin/m4 failed with exit status: 1
aclocal: error: /usr/local/Cellar/autoconf/2.71/bin/autom4te failed with exit status: 1
autoreconf: error: aclocal failed with exit status: 1
```

해당 에러는 c 클라이언트 빌드에서 활용되는 `configure.ac`와 `pandora_canonical.m4`에서 `AM_INIT_AUTOMAKE`를 중복사용함으로써 발생하는 것으로 configure.ac에서는 선언 이외에 다른 인자를 주고 있지 않으므로 제거했습니다.