### PR TITLE
INTERNAL: Add a limit of count about bop mget/smget commands

### DIFF
--- a/docs/07-btree-API.md
+++ b/docs/07-btree-API.md
@@ -1102,7 +1102,9 @@ memcached_bop_mget(memcached_st *ptr,
 
 - keys, keys_length: 다수 b+tree item들의 key array
 - number_of_keys: key 개수
+  - key array에 담을 수 있는 최대 key 개수는 200개로 제한된다.
 - query: 조회 조건을 가진 query 구조체
+  - query 구조체를 구성할 때 count는 1 이상, 50 이하의 값을 가져야 한다.
 
 Response code는 아래와 같다.
 
@@ -1251,7 +1253,9 @@ memcached_bop_smget(memcached_st *ptr,
 ```
 - keys, keys_length: 다수 b+tree item들의 key array
 - number_of_keys: key 개수
+  - key array에 담을 수 있는 최대 key 개수는 2000 개로 제한된다.
 - query: 조회 조건을 가진 query 구조체
+  - query 구조체를 구성할 때 count는 1 이상의 값을 가져야 하며, offset + count가 1000을 초과해서는 아니 된다.
 - result: sort-merge 조회 결과는 담는 구조체
 
 Sort-Merge 조회 질의를 표현하는 memcached_bop_query_st 구조체 생성 방법은

--- a/libmemcached/collection.cc
+++ b/libmemcached/collection.cc
@@ -1978,10 +1978,10 @@ static memcached_return_t do_coll_mget(memcached_st *ptr,
     return memcached_set_error(*ptr, MEMCACHED_INVALID_ARGUMENTS, MEMCACHED_AT,
                                memcached_literal_param("size of key list should be <= 200"));
   }
-  if (query->count > MEMCACHED_COLL_MAX_BOP_MGET_ELEM_COUNT)
+  if (query->count < 1 or query->count > MEMCACHED_COLL_MAX_BOP_MGET_ELEM_COUNT)
   {
     return memcached_set_error(*ptr, MEMCACHED_INVALID_ARGUMENTS, MEMCACHED_AT,
-                               memcached_literal_param("count should be <= 50"));
+                               memcached_literal_param("count should be beween 1 and 50"));
   }
   if (memcached_server_count(ptr) > MAX_SERVERS_FOR_MULTI_KEY_OPERATION)
   {
@@ -2550,6 +2550,11 @@ static memcached_return_t do_bop_smget(memcached_st *ptr,
   {
     return memcached_set_error(*ptr, MEMCACHED_INVALID_ARGUMENTS, MEMCACHED_AT,
                                memcached_literal_param("result is null"));
+  }
+  if (query->count < 1)
+  {
+    return memcached_set_error(*ptr, MEMCACHED_INVALID_ARGUMENTS, MEMCACHED_AT,
+                               memcached_literal_param("'count' should be > 0"));
   }
   if (query->offset + query->count > MEMCACHED_COLL_MAX_BOP_SMGET_ELEM_COUNT)
   {


### PR DESCRIPTION
- jam2in/arcus-works#472
- naver/arcus-java-client#698


c client 내의 btree 관련 문서에서 일부 오타 및 smget/mget count 관련 내용 추가,
count 0일 시에 대한 에러 로직 추가 입니다.