### PR TITLE
INTERNAL: Fix typos in a btree-API document

### DIFF
--- a/docs/07-btree-API.md
+++ b/docs/07-btree-API.md
@@ -6,7 +6,7 @@ B+tree item은 하나의 key에 대해 b+tree 구조 기반으로 b+tree key(bke
 
 - 저장 가능한 최대 element 개수 : 디폴트 4,000개 (attribute 설정으로 최대 50,000개 확장 가능)
 - 각 element에서 value 최대 크기 : 16KB
-- 하나의 b+tree 내에서 모든 element는 동일한 bkey 유형을 가져야 한다. 
+- 하나의 b+tree 내에서 모든 element는 동일한 bkey 유형을 가져야 한다.
   즉, 8바이트 unsigned integer bkey 유형과 byte array bkey 유형이 혼재할 수 없다.
 
 B+tree item 구조와 기본 특징은 [ARCUS Server Ascii Protocol 문서의 내용](https://github.com/naver/arcus-memcached/blob/master/doc/ch02-collection-items.md)을
@@ -21,7 +21,7 @@ B+tree item 연산의 설명에 앞서, b+tree 조회 및 변경에 사용하는
 
 B+tree item에 대해 수행가능한 기본 연산들은 다음과 같다.
 
-- [B+Tree Item 생성](07-btree-API.md#btree-item-%EC%83%9D%EC%84%B1) (B+tree item 삭제는 key-value item 삭제 함수로 수행한다) 
+- [B+Tree Item 생성](07-btree-API.md#btree-item-%EC%83%9D%EC%84%B1) (B+tree item 삭제는 key-value item 삭제 함수로 수행한다)
 - [B+Tree Element 삽입](07-btree-API.md#btree-element-%EC%82%BD%EC%9E%85)
 - [B+Tree Element Upsert](07-btree-API.md#btree-element-upsert)
 - [B+Tree Element 변경](07-btree-API.md#btree-element-%EB%B3%80%EA%B2%BD)
@@ -37,7 +37,7 @@ B+tree item에 대해 수행가능한 기본 연산들은 다음과 같다.
 
 여러 b+tree element들에 대해 sort-merge 조회하는 연산을 제공한다.
 
-- [B+Tree Element Sort-Merge 조회](07-btree-API.md#btree-element-sort-merge-%EC%A1%B0%ED%9A%8C) 
+- [B+Tree Element Sort-Merge 조회](07-btree-API.md#btree-element-sort-merge-%EC%A1%B0%ED%9A%8C)
 
 B+Tree내에서 element 순위(position)와 관련하여 아래 연산들을 제공한다.
 - [B+Tree Element 순위 조회](07-btree-API.md#btree-element-순위-조회)
@@ -49,7 +49,7 @@ B+Tree내에서 element 순위(position)와 관련하여 아래 연산들을 제
 B+tree item에서 사용 가능한 bkey 데이터 타입은 아래 두 가지이다.
 
 - 8바이트 unsigned integer
-- 최대 31 크기의 byte array 
+- 최대 31 크기의 byte array
 
 eflag는 현재 b+tree element에만 존재하는 필드이다.
 eflag 데이터 타입은 최대 31 크기의 byte array 타입만 가능하다.
@@ -101,7 +101,7 @@ memcached_coll_eflags_filter_init(memcached_coll_eflag_filter_st *ptr,
   - MEMCACHED_COLL_COMP_EQ
   - MEMCACHED_COLL_COMP_NE
 
-eflag의 전체/부분 값에 대해 어떤 operand로 bitwise 연산을 취함으로써 eflag의 특정 bits들만을 골라내어 compare할 수 있다.
+eflag의 전체/부분 값에 대해 어떤 operand로 bitwise 연산을 취함으로써 eflag의 특정 bit들만을 골라내어 compare할 수 있다.
 이와 같이 `eflag_filter`에 bitwise 연산을 추가할 경우에는 아래의 API를 이용할 수 있다.
 
 ``` c
@@ -280,7 +280,7 @@ memcached_bop_insert(memcached_st *ptr,
                      const unsigned char *eflag, size_t eflag_length,
                      const char *value, size_t value_length,
                      memcached_coll_create_attrs_st *attributes)
-                     
+
 memcached_return_t
 memcached_bop_ext_insert(memcached_st *ptr,
                      const char *key, size_t key_length,
@@ -365,7 +365,7 @@ memcached_bop_upsert(memcached_st *ptr,
                      const unsigned char *eflag, size_t eflag_length,
                      const char *value, size_t value_length,
                      memcached_coll_create_attrs_st *attributes)
-                     
+
 memcached_return_t
 memcached_bop_ext_upsert(memcached_st *ptr,
                      const char *key, size_t key_length,
@@ -493,8 +493,8 @@ memcached_bop_ext_delete(memcached_st *ptr,
                      bool drop_if_empty)
 ```
 
-둘째, b+tree에서 bkey range에 해당하는 element들을 스캔하면서 
-eflag filter 조건을 만족하는 N개의 element를 삭제하는 함수이다.
+둘째, b+tree에서 bkey range에 해당하는 element들을 스캔하면서
+eflag filter 조건을 만족하는 N개의 element들을 삭제하는 함수이다.
 
 ``` c
 memcached_return_t
@@ -510,11 +510,11 @@ memcached_bop_ext_delete_by_range(memcached_st *ptr,
                               const unsigned char *from, size_t from_length,
                               const unsigned char *to, size_t to_length,
                               memcached_coll_eflag_filter_st *eflag_filter,
-                              size_t count, bool drop_if_empty)                    
+                              size_t count, bool drop_if_empty)
 ```
 
 - key, key_length: b+tree item의 key
-- bkeuy 또는 \<from, to\>:  삭제할 element의 bkey(b+tree key) 또는 bkey range 
+- bkeuy 또는 \<from, to\>:  삭제할 element의 bkey(b+tree key) 또는 bkey range
 - eflag_filter: element의 eflag에 대한 filter 조건
 - count: 삭제할 element 개수, 0이면 bkey range의 모든 element가 삭제 대상이 된다.
 - drop_if_empty: element 삭제로 empty b+tree가 될 경우, 그 b+tree도 삭제할 것인지를 지정
@@ -578,7 +578,7 @@ void arcus_btree_element_delete(memcached_st *memc)
 
 ## B+Tree Element 값의 증감
 
-B+tree element의 값을 증가/감소시키는 함수는 아래와 같다. 
+B+tree element의 값을 증가/감소시키는 함수는 아래와 같다.
 Element의 값은 숫자형 값이어야 한다.
 
 전자는 8바이트 unsigned integer 타입의 bkey를, 후자는 최대 31 크기의 byte array 타입의 bkey를 사용한다.
@@ -599,12 +599,12 @@ memcached_return_t
 memcached_bop_ext_incr(memcached_st *ptr,
                    const char *key, size_t key_length,
                    const unsigned char *bkey, size_t bkey_length,
-                   const uint64_t delta, uint64_t *value)                   
+                   const uint64_t delta, uint64_t *value)
 memcached_return_t
 memcached_bop_ext_decr(memcached_st *ptr,
                    const char *key, size_t key_length,
                    const unsigned char *bkey, size_t bkey_length,
-                   const uint64_t delta, uint64_t *value)                   
+                   const uint64_t delta, uint64_t *value)
 ```
 
 - key, key_length: b+tree item의 key
@@ -705,7 +705,7 @@ memcached_bop_ext_count(memcached_st *ptr,
                     const char *key, size_t key_length,
                     const unsigned char *bkey, size_t bkey_length,
                     memcached_coll_eflag_filter_st *eflag_filter,
-                    size_t *count)                    
+                    size_t *count)
 ```
 
 둘째, b+tree에서 bkey range에 해당하는 element들 중 eflag filter 조건을 만족하는 element 개수를 확인하는 함수이다.
@@ -724,7 +724,7 @@ memcached_bop_ext_count_by_range(memcached_st *ptr,
                              const unsigned char *from, size_t from_length,
                              const unsigned char *to, size_t to_length,
                              memcached_coll_eflag_filter_st *eflag_filter,
-                             size_t *count)                    
+                             size_t *count)
 ```
 
 - key, key_length: b+tree item의 key
@@ -806,7 +806,7 @@ memcached_bop_ext_get(memcached_st *ptr,
                   memcached_coll_result_st *result)
 ```
 
-둘째, b+tree에서 bkey range에 해당하는 element들을 스캔하면서 
+둘째, b+tree에서 bkey range에 해당하는 element들을 스캔하면서
 eflag filter 조건을 만족하는 element들 중 offset 개를 skip한 후 count 개의 element를 조회하는 함수이다.
 
 ``` c
@@ -948,7 +948,7 @@ void arcus_btree_element_get(memcached_st *memc)
 
 B+tree에 여러 element를 한번에 삽입하는 함수는 두 유형이 있다.
 
-첫째, 하나의 key가 가리키는 b+tree에 다수의 element를 삽입하는 함수이다.
+첫째, 하나의 key가 가리키는 b+tree에 다수의 element들을 삽입하는 함수이다.
 전자는 8바이트 unsigned integer 타입의 bkey를, 후자는 최대 31 크기의 byte array 타입의 bkey를 사용한다.
 
 ``` c
@@ -972,7 +972,7 @@ memcached_bop_ext_piped_insert(memcached_st *ptr,
                            const char * const *values, const size_t *values_length,
                            memcached_coll_create_attrs_st *attributes,
                            memcached_return_t *results,
-                           memcached_return_t *piped_rc)     
+                           memcached_return_t *piped_rc)
 ```
 
 - key, key_length: b+tree item의 key
@@ -980,9 +980,9 @@ memcached_bop_ext_piped_insert(memcached_st *ptr,
 - bkeys 또는 bkeys, bkeys_length: element 개수만큼의 bkey array (필수)
 - eflags, eflags_length: element 개수만큼의 eflag array (옵션)
 - values, values_length: element 개수만큼의 value array (필수)
-- attributes: B+tree 없을 시에 attributes에 따라 empty b+tree를 생성 후에 element 삽입한다.
+- attributes: B+tree 없을 시에 attributes에 따라 empty b+tree를 생성 후에 element를 삽입한다.
 
-둘째, 여러 key들이 가리키는 b+tree들에 각각 하나의 element를 삽입하는 함수이다. 
+둘째, 여러 key들이 가리키는 b+tree들에 각각 하나의 element를 삽입하는 함수이다.
 전자는 8바이트 unsigned integer 타입의 bkey를, 후자는 최대 31 크기의 byte array 타입의 bkey를 사용한다.
 
 ``` c
@@ -1085,7 +1085,7 @@ void arcus_btree_element_piped_insert(memcached_st *memc)
 
 서로 다른 key로 분산되어 있는 b+tree들의 element들을 한 번의 요청으로 조회할 수 있는 기능이다.
 이 기능은 비동기(asynchronous) 방식으로 수행하며,
-(1) 다수 b+tree들의 element 조회 요청을 보내는 단계와 
+(1) 다수 b+tree들의 element 조회 요청을 보내는 단계와
 (2) 조회 결과를 받아내는 단계로 구분된다.
 
 첫째 단계로, 다수 b+tree들에 대한 element 조회 요청을 보내는 함수는 아래와 같다.
@@ -1100,7 +1100,7 @@ memcached_bop_mget(memcached_st *ptr,
                    memcached_coll_query_st *query)
 ```
 
-- keys, keys_length: 다수 bt+tree item들의 key array
+- keys, keys_length: 다수 b+tree item들의 key array
 - number_of_keys: key 개수
 - query: 조회 조건을 가진 query 구조체
 
@@ -1249,7 +1249,7 @@ memcached_bop_smget(memcached_st *ptr,
                     memcached_bop_query_st *query,
                     memcached_coll_smget_result_st *result)
 ```
-- keys, keys_length: 다수 bt+tree item들의 key array
+- keys, keys_length: 다수 b+tree item들의 key array
 - number_of_keys: key 개수
 - query: 조회 조건을 가진 query 구조체
 - result: sort-merge 조회 결과는 담는 구조체
@@ -1261,7 +1261,7 @@ Sort-Merge 조회 질의를 표현하는 memcached_bop_query_st 구조체 생성
 신규 sort-merge 조회에서는 아래의 sort-merge 질의 생성하는 전용 API를 사용해
 bkey range, element flag, count 그리고 unique를 명시하여 query 구조체를 생성한다.
 마지막 인자인 unique가 false이면 중복 bkey를 허용하여 조회하며,
-true이면 중복 bkey를 제거하여 unique bkey만을 조회한다. 
+true이면 중복 bkey를 제거하여 unique bkey만을 조회한다.
 
 ``` c
 memcached_return_t
@@ -1287,7 +1287,7 @@ Response code는 아래와 같다.
     - 정상적으로 element를 조회하였으나, 조회 범위가 특정 B+tree의 overflow 정책에 의해 삭제되는 영역에 걸쳐 있음.
     - 즉, 해당 B+tree 크기 제한으로 인해 삭제되어 조회되지 않은 element가 어딘가(DB)에 존재할 수도 있음을 뜻함.
   - MEMCACHED_DUPLICATED_TRIMMED (기존 sort-merge 조회에 한정)
-    - MEMCACHED_DUPLICATED 상태와MEMCACHED_TRIMMED 상태가 모두 존재.
+    - MEMCACHED_DUPLICATED 상태와 MEMCACHED_TRIMMED 상태가 모두 존재.
 - not MEMCACHED_SUCCESS
   - MEMCACHED_OUT_OF_RANGE (기존 sort-merge 조회에 한정)
     - 주어진 조회 범위에 해당하는 element가 없으나, 조회 범위가 overflow 정책에 의해 삭제되는 영역에 걸쳐 있음.
@@ -1471,7 +1471,7 @@ memcached_bop_find_position(memcached_st *ptr,
                             const uint64_t bkey,
                             memcached_coll_order_t order,
                             size_t *position)
-                                     
+
 memcached_return_t
 memcached_bop_ext_find_position(memcached_st *ptr,
                             const char *key, size_t key_length,
@@ -1577,7 +1577,7 @@ void arcus_btree_get_by_position(memcached_st *memc)
     memcached_coll_create_attrs_st attributes;
     memcached_coll_create_attrs_init(&attributes, flags, exptime, maxcount);
 
-    // bkey 범위가 0 ~ 999인 1000개 element를 가진 b+tree 생성.
+    // bkey 범위가 0 ~ 999인 1000개 element들을 가진 b+tree 생성.
     for (uint32_t bkey=0; bkey<maxcount; bkey++)
     {
       buffer_len= snprintf(buffer, 15, "value%u", bkey);
@@ -1689,7 +1689,7 @@ Response code는 아래와 같다.
 
 
 B+Tree에서 특정 bkey에 대한 순위 및 element 조회와 함께
-앞뒤 양방향으로 N개 element를 조회하는 예제는 아래와 같다.
+앞뒤 양방향으로 N개 element들을 조회하는 예제는 아래와 같다.
 
 ```c
 void arcus_btree_find_position_with_get(memcached_st *memc)
@@ -1735,7 +1735,7 @@ void arcus_btree_find_position_with_get(memcached_st *memc)
     }
     memcached_coll_result_free(result);
 
-    // 내림차순으로 100번째 bkey의 순위 및 element와 함께 앞뒤 양방향으로 각 10개 element를 조회한다.
+    // 내림차순으로 100번째 bkey의 순위 및 element와 함께 앞뒤 양방향으로 각 10개 element들을 조회한다.
     result = memcached_coll_result_create(memc, NULL);
     bkdata_len= snprintf(bkdata, 15, "%04u", ((maxcount-1)-99));
     rc= memcached_bop_ext_find_position_with_get(memc, test_literal_param("btree:a_btree"),


### PR DESCRIPTION
- #269 

btree 문서 내 space 문제 및 오타를 수정합니다.

현재 문서 내에 `b+tree`에 대한 대문자 표기가 다르게 나타나는데 해당 부분도 수정할까요?

- `b+tree` : 59개
- `B+tree` : 96개
- `B+Tree` : 52개


추가적으로 아래 표현이 조금 어색하다고 생각됩니다.
```
eflag filter 조건을 만족하는 element들 중 offset 개를 skip한 후 count 개의 element를 조회하는 함수이다.
```
좋은 방식인지는 모르겠으나 우선 현재 제가 생각하는 변경안은 아래와 같습니다.
```
eflag filter 조건을 만족하는 element들 중 offset 만큼 skip한 후 count 크기의 element 개수를 조회하는 함수이다.
```