### PR TITLE
INTERNAL: Return a correct type when getting distibution hash type

### DIFF
--- a/libmemcached/behavior.cc
+++ b/libmemcached/behavior.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -529,7 +529,7 @@ memcached_return_t memcached_behavior_set_distribution_hash(memcached_st *ptr, m
 
 memcached_hash_t memcached_behavior_get_distribution_hash(memcached_st *ptr)
 {
-  return (memcached_hash_t)hashkit_get_function(&ptr->hashkit);
+  return (memcached_hash_t)hashkit_get_distribution_function(&ptr->hashkit);
 }
 
 const char *libmemcached_string_behavior(const memcached_behavior_t flag)


### PR DESCRIPTION
- jam2in/arcus-works#476

위의 올려진 이슈를 해결합니다.


추가적으로
최신 버전의 libmemcached를 확인한 결과, `get_distribution_hash` 내에 `hashkit_get_key_fuction`을 그대로 사용 중입니다.


[link](https://github.com/awesomized/libmemcached/blob/374774dffe5f1560225648d023a121cb03dd2831/src/libmemcached/behavior.cc#L573-L580)

```c
memcached_hash_t memcached_behavior_get_distribution_hash(memcached_st *shell) {
  Memcached *ptr = memcached2Memcached(shell);
  if (ptr) {
    return (memcached_hash_t) hashkit_get_function(&ptr->hashkit);
  }

  return MEMCACHED_HASH_MAX;
}
```
