### PR TITLE
INTERNAL: Fix the string handling for ketama distribution

### DIFF
--- a/libmemcached/hosts.cc
+++ b/libmemcached/hosts.cc
@@ -368,7 +368,6 @@ static memcached_return_t update_continuum(memcached_st *ptr)
         char sort_host[MEMCACHED_MAX_HOST_SORT_LENGTH]= "";
         int sort_host_length;
 
-#ifdef LIBMEMCACHED_WITH_ZK_INTEGRATION
         // Spymemcached ketema key format is: hostname/ip:port-index
         // If hostname is not available then: ip:port-index
         sort_host_length= snprintf(sort_host, MEMCACHED_MAX_HOST_SORT_LENGTH,
@@ -376,15 +375,6 @@ static memcached_return_t update_continuum(memcached_st *ptr)
                                    list[host_index].hostname,
                                    (uint32_t)list[host_index].port,
                                    pointer_index);
-#else
-        // Spymemcached ketema key format is: hostname/ip:port-index
-        // If hostname is not available then: /ip:port-index
-        sort_host_length= snprintf(sort_host, MEMCACHED_MAX_HOST_SORT_LENGTH,
-                                   "/%s:%u-%u",
-                                   list[host_index].hostname,
-                                   (uint32_t)list[host_index].port,
-                                   pointer_index);
-#endif
 
         if (sort_host_length >= MEMCACHED_MAX_HOST_SORT_LENGTH || sort_host_length < 0)
         {
@@ -416,8 +406,8 @@ static memcached_return_t update_continuum(memcached_st *ptr)
     }
     else
     {
-      for (uint32_t pointer_index= 1;
-           pointer_index <= pointer_per_server / pointer_per_hash;
+      for (uint32_t pointer_index= 0;
+           pointer_index < pointer_per_server / pointer_per_hash;
            pointer_index++)
       {
         char sort_host[MEMCACHED_MAX_HOST_SORT_LENGTH]= "";
@@ -428,7 +418,7 @@ static memcached_return_t update_continuum(memcached_st *ptr)
           sort_host_length= snprintf(sort_host, MEMCACHED_MAX_HOST_SORT_LENGTH,
                                      "%s-%u",
                                      list[host_index].hostname,
-                                     pointer_index - 1);
+                                     pointer_index);
         }
         else
         {
@@ -436,7 +426,7 @@ static memcached_return_t update_continuum(memcached_st *ptr)
                                      "%s:%u-%u",
                                      list[host_index].hostname,
                                      (uint32_t)list[host_index].port,
-                                     pointer_index - 1);
+                                     pointer_index);
         }
 
         if (sort_host_length >= MEMCACHED_MAX_HOST_SORT_LENGTH || sort_host_length < 0)


### PR DESCRIPTION
해당 PR은 아래의 수정 사항을 가집니다.

- ketama_spy 방식에서 문자열 구성이 최신 버전의 spymemcached와 다른 점을 수정합니다.
  `/IP:Port-[0~39 or 99]` -> `IP:Port-[0~39 or 99]` (앞의 '/' 문자 제거)

- `KETAMA`와 `KETAMA_SPY` 내에서 for문의 변수 pointer_index의 증가 범위(0~39 or 99)가 같음에도 불구하고,
   `KETAMA` 방식에서 pointer_index의 시작값을 0이 아닌 1부터 시작하는 것을 수정합니다.
  - 동작 방식에는 문제 없으나 코드 가독성 목적입니다.


