### PR TITLE
INTERNAL: Fix typos from source files in libmemcached folder

### DIFF
--- a/libmemcached/arcus.cc
+++ b/libmemcached/arcus.cc
@@ -1094,9 +1094,9 @@ static inline void do_arcus_zk_watch_and_update_cachelist(memcached_st *mc,
                           (void *)mc, &strings);
   if (zkrc == ZOK) {
     /* TODO (next commit)
-     * Error handling of update_chacelist process,
-     * must distinguish retrys by failure and by event.
-     * If it is retrys by failure, watcher should not register.
+     * Error handling of update_cachelist process,
+     * must distinguish retries by failure and by event.
+     * If it is retries by failure, watcher should not register.
      */
     /* Update the cache server list. */
     do_arcus_zk_update_cachelist(mc, &strings);

--- a/libmemcached/auto.cc
+++ b/libmemcached/auto.cc
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -137,7 +137,7 @@ do_action:
   }
 
   /*
-    So why recheck responce? Because the protocol is brain dead :)
+    So why recheck response? Because the protocol is brain dead :)
     The number returned might end up equaling one of the string
     values. Less chance of a mistake with strncmp() so we will
     use it. We still called memcached_response() though since it
@@ -379,7 +379,7 @@ memcached_return_t memcached_increment_with_initial_by_key(memcached_st *ptr,
     //rc= MEMCACHED_PROTOCOL_ERROR;
     rc= binary_incr_decr(ptr, PROTOCOL_BINARY_CMD_INCREMENT,
                          group_key, group_key_length, key, key_length,
-                         offset, initial, expiration, value); 
+                         offset, initial, expiration, value);
   }
   else
   {
@@ -441,7 +441,7 @@ memcached_return_t memcached_decrement_with_initial_by_key(memcached_st *ptr,
     //rc= MEMCACHED_PROTOCOL_ERROR;
     rc= binary_incr_decr(ptr, PROTOCOL_BINARY_CMD_DECREMENT,
                          group_key, group_key_length, key, key_length,
-                         offset, initial, expiration, value); 
+                         offset, initial, expiration, value);
   }
   else
   {

--- a/libmemcached/collection.cc
+++ b/libmemcached/collection.cc
@@ -1981,7 +1981,7 @@ static memcached_return_t do_coll_mget(memcached_st *ptr,
   if (query->count < 1 or query->count > MEMCACHED_COLL_MAX_BOP_MGET_ELEM_COUNT)
   {
     return memcached_set_error(*ptr, MEMCACHED_INVALID_ARGUMENTS, MEMCACHED_AT,
-                               memcached_literal_param("count should be beween 1 and 50"));
+                               memcached_literal_param("count should be between 1 and 50"));
   }
   if (memcached_server_count(ptr) > MAX_SERVERS_FOR_MULTI_KEY_OPERATION)
   {

--- a/libmemcached/collection.h
+++ b/libmemcached/collection.h
@@ -598,7 +598,7 @@ memcached_return_t memcached_bop_ext_range_query_init(memcached_bop_query_st *pt
  * @param bkey_to  last bkey in the range.
  * @param eflag_filter  optional eflag filter, maybe NULL.
  * @param count  number of elements.
- * @param unique boolean value for unique bkey or duplcate bkey retreival.
+ * @param unique boolean value for unique bkey or duplicate bkey retrieval.
  */
 LIBMEMCACHED_API
 memcached_return_t memcached_bop_smget_query_init(memcached_bop_query_st *ptr,
@@ -613,7 +613,7 @@ memcached_return_t memcached_bop_smget_query_init(memcached_bop_query_st *ptr,
  * @param bkey_to  last byte-array bkey in the range.
  * @param eflag_filter  optional eflag filter, maybe NULL.
  * @param count  number of elements.
- * @param unique boolean value for unique bkey or duplcate bkey retreival.
+ * @param unique boolean value for unique bkey or duplicate bkey retrieval.
  */
 LIBMEMCACHED_API
 memcached_return_t memcached_bop_ext_smget_query_init(memcached_bop_query_st *ptr,
@@ -719,7 +719,7 @@ memcached_return_t memcached_coll_eflag_filter_set_bitwise(memcached_coll_eflag_
 
 /**
  * B+tree eflag filter used for certain update commands.
- * This is just for convinience.
+ * This is just for convenience.
  */
 struct memcached_coll_update_filter_st {
   size_t fwhere;

--- a/libmemcached/connect.cc
+++ b/libmemcached/connect.cc
@@ -131,7 +131,7 @@ static memcached_return_t set_hostinfo(memcached_server_st *server)
     server->address_info_next= NULL;
   }
 
-#ifdef KETAMA_HASH_COLLSION
+#ifdef KETAMA_HASH_COLLISION
 #else
   char str_port[NI_MAXSERV];
   int length= snprintf(str_port, NI_MAXSERV, "%u", (uint32_t)server->port);
@@ -160,7 +160,7 @@ static memcached_return_t set_hostinfo(memcached_server_st *server)
 
   server->address_info= NULL;
   int errcode;
-#ifdef KETAMA_HASH_COLLSION
+#ifdef KETAMA_HASH_COLLISION
   switch(errcode= getaddrinfo(server->hostname, server->str_port, &hints, &server->address_info))
 #else
   switch(errcode= getaddrinfo(server->hostname, str_port, &hints, &server->address_info))

--- a/libmemcached/constants.h
+++ b/libmemcached/constants.h
@@ -65,7 +65,7 @@
 #define BOP_ARITHMETIC_INITIAL 1
 #define POOL_UPDATE_SERVERLIST 1
 #define POOL_MORE_CONCURRENCY 1
-#define KETAMA_HASH_COLLSION 1
+#define KETAMA_HASH_COLLISION 1
 
 /* Public defines */
 #define MEMCACHED_DEFAULT_PORT 11211
@@ -76,7 +76,7 @@
 #define MEMCACHED_CONTINUUM_SIZE MEMCACHED_POINTS_PER_SERVER*100 /* This would then set max hosts to 100 */
 #define MEMCACHED_STRIDE 4
 /* poll timeout (or operation timeout): 700ms
- * It avoids the occurence of operation timeout
+ * It avoids the occurrence of operation timeout
  * even if two packet retransmissions exist in linux.
  */
 #define MEMCACHED_DEFAULT_TIMEOUT 700

--- a/libmemcached/do.hpp
+++ b/libmemcached/do.hpp
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -40,7 +40,7 @@
 
 LIBMEMCACHED_LOCAL
 memcached_return_t memcached_do(memcached_server_write_instance_st ptr,
-                                const void *commmand,
+                                const void *command,
                                 size_t command_length,
                                 bool with_flush);
 

--- a/libmemcached/get.cc
+++ b/libmemcached/get.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -838,7 +838,7 @@ memcached_return_t memcached_mget_by_key(memcached_st *ptr,
 
     if (memcached_server_response_count(instance))
     {
-      /* We need to do something about non-connnected hosts in the future */
+      /* We need to do something about non-connected hosts in the future */
       if ((memcached_io_write(instance, "\r\n", 2, true)) == -1)
       {
         failures_occurred_in_sending= true;

--- a/libmemcached/hash.cc
+++ b/libmemcached/hash.cc
@@ -79,7 +79,7 @@ static uint32_t dispatch_host(const memcached_st *ptr, uint32_t hash)
       }
       if (right == end)
         right= begin;
-#ifdef KETAMA_HASH_COLLSION
+#ifdef KETAMA_HASH_COLLISION
       while (right > begin && (right-1)->value == hash)
         right= right-1;
 #endif

--- a/libmemcached/hosts.cc
+++ b/libmemcached/hosts.cc
@@ -59,13 +59,13 @@
 #include <cmath>
 #include <sys/time.h>
 
-/* Protoypes (static) */
+/* Prototypes (static) */
 static memcached_return_t update_continuum(memcached_st *ptr);
 #ifdef ENABLE_REPLICATION
 static memcached_return_t update_continuum_based_on_rgroups(memcached_st *ptr);
 #endif
 
-#ifdef KETAMA_HASH_COLLSION
+#ifdef KETAMA_HASH_COLLISION
 #ifdef ENABLE_REPLICATION
 memcached_rgroup_st *cmp_rgroups= NULL;
 #endif
@@ -205,7 +205,7 @@ static int continuum_item_cmp(const void *t1, const void *t2)
   WATCHPOINT_ASSERT(ct1->value != 153);
   if (ct1->value == ct2->value)
   {
-#ifdef KETAMA_HASH_COLLSION
+#ifdef KETAMA_HASH_COLLISION
 #ifdef ENABLE_REPLICATION
     if (cmp_rgroups != NULL) {
       return strcmp(cmp_rgroups[ct1->index].groupname, cmp_rgroups[ct2->index].groupname);
@@ -434,11 +434,11 @@ static memcached_return_t update_continuum(memcached_st *ptr)
   WATCHPOINT_ASSERT(new_continuum);
   WATCHPOINT_ASSERT(memcached_server_count(ptr) * MEMCACHED_POINTS_PER_SERVER <= MEMCACHED_CONTINUUM_SIZE);
 
-#ifdef KETAMA_HASH_COLLSION
+#ifdef KETAMA_HASH_COLLISION
   cmp_servers= ptr->servers;
 #endif
   qsort(new_continuum, pointer_counter, sizeof(memcached_continuum_item_st), continuum_item_cmp);
-#ifdef KETAMA_HASH_COLLSION
+#ifdef KETAMA_HASH_COLLISION
   cmp_servers= NULL;
 #endif
 
@@ -613,11 +613,11 @@ static memcached_return_t update_continuum_based_on_rgroups(memcached_st *ptr)
   WATCHPOINT_ASSERT(new_continuum);
   WATCHPOINT_ASSERT(memcached_server_count(ptr) * MEMCACHED_POINTS_PER_SERVER <= MEMCACHED_CONTINUUM_SIZE);
 
-#ifdef KETAMA_HASH_COLLSION
+#ifdef KETAMA_HASH_COLLISION
   cmp_rgroups= ptr->rgroups;
 #endif
   qsort(new_continuum, pointer_counter, sizeof(memcached_continuum_item_st), continuum_item_cmp);
-#ifdef KETAMA_HASH_COLLSION
+#ifdef KETAMA_HASH_COLLISION
   cmp_rgroups= NULL;
 #endif
 

--- a/libmemcached/io.cc
+++ b/libmemcached/io.cc
@@ -330,7 +330,7 @@ static ssize_t io_flush(memcached_server_write_instance_st ptr,
 
   WATCHPOINT_ASSERT(ptr->fd != INVALID_SOCKET);
 
-  // UDP Sanity check, make sure that we are not sending somthing too big
+  // UDP Sanity check, make sure that we are not sending something too big
   if (ptr->type == MEMCACHED_CONNECTION_UDP && write_length > MAX_UDP_DATAGRAM_LENGTH)
   {
     *error= MEMCACHED_WRITE_FAILURE;
@@ -443,7 +443,7 @@ static ssize_t io_flush(memcached_server_write_instance_st ptr,
   // Need to study this assert() WATCHPOINT_ASSERT(return_length ==
   // ptr->write_buffer_offset);
 
-  // if we are a udp server, the begining of the buffer is reserved for
+  // if we are a udp server, the beginning of the buffer is reserved for
   // the upd frame header
   if (ptr->type == MEMCACHED_CONNECTION_UDP)
     ptr->write_buffer_offset= UDP_DATAGRAM_HEADER_LENGTH;

--- a/libmemcached/memcached.h
+++ b/libmemcached/memcached.h
@@ -144,7 +144,7 @@ struct memcached_st {
     bool verify_key:1;
     bool tcp_keepalive:1;
 #ifdef ENABLE_REPLICATION
-    bool repl_enabled:1; /* internaly set and used */
+    bool repl_enabled:1; /* internally set and used */
 #endif
   } flags;
 

--- a/libmemcached/memcached.hpp
+++ b/libmemcached/memcached.hpp
@@ -187,7 +187,7 @@ public:
     tmp_str.append(strstm.str());
 
     //memcached_return_t rc= memcached_server_remove(server);
-    
+
     return false;
   }
 
@@ -214,7 +214,7 @@ public:
 
       // Actual value, null terminated
       ret_val.reserve(memcached_result_length(result) +1);
-      ret_val.assign(memcached_result_value(result), 
+      ret_val.assign(memcached_result_value(result),
                      memcached_result_value(result) +memcached_result_length(result));
 
       // Misc
@@ -346,7 +346,7 @@ public:
    * @param[in] value value of object to write to server
    * @param[in] expiration time to keep the object stored in the server for
    * @param[in] flags flags to store with the object
-   * @return true on succcess; false otherwise
+   * @return true on success; false otherwise
    */
   bool set(const std::string &key,
            const std::vector<char> &value,
@@ -369,7 +369,7 @@ public:
    * @param[in] value value of object to write to server
    * @param[in] expiration time to keep the object stored in the server for
    * @param[in] flags flags to store with the object
-   * @return true on succcess; false otherwise
+   * @return true on success; false otherwise
    */
   bool setByKey(const std::string &master_key,
                 const std::string &key,
@@ -810,7 +810,7 @@ public:
         server_stats[*ptr]= value;
         free(value);
       }
-     
+
       stats_map[server_name]= server_stats;
       free(list);
     }

--- a/libmemcached/protocol_handler.h
+++ b/libmemcached/protocol_handler.h
@@ -104,7 +104,7 @@ LIBMEMCACHED_API
 void memcached_binary_protocol_set_pedantic(memcached_protocol_st *instance, bool enable);
 
 /**
- * Is the library inpecting each package?
+ * Is the library inspecting each package?
  * @param instance the instance to check
  * @return true it the library is inspecting each package, false otherwise
  */
@@ -124,7 +124,7 @@ void memcached_protocol_destroy_instance(memcached_protocol_st *instance);
  * functions should behave like recv(3socket) and send(3socket).
  *
  * @param instance the instance to specify the IO functions for
- * @param recv the function to call for reciving data
+ * @param recv the function to call for receiving data
  * @param send the function to call for sending data
  */
 LIBMEMCACHED_API
@@ -144,7 +144,7 @@ memcached_protocol_client_st *memcached_protocol_create_client(memcached_protoco
 
 /**
  * Destroy a client handle.
- * The caller needs to close the socket accociated with the client
+ * The caller needs to close the socket associated with the client
  * <b>before</b> calling this function. This function invalidates the
  * client memory area.
  *
@@ -205,7 +205,7 @@ int memcached_protocol_client_get_errno(memcached_protocol_client_st *client);
 /**
  * Get a raw response handler for the given cookie
  * @param cookie the cookie passed along into the callback
- * @return the raw reponse handler you may use if you find
+ * @return the raw response handler you may use if you find
  *         the generic callback too limiting
  */
 LIBMEMCACHED_API

--- a/libmemcached/quit.cc
+++ b/libmemcached/quit.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -87,7 +87,7 @@ void memcached_quit_server(memcached_server_st *ptr, bool io_death)
 
       /*
        * memcached_io_read may call memcached_quit_server with io_death if
-       * it encounters problems, but we don't care about those occurences.
+       * it encounters problems, but we don't care about those occurrences.
        * The intention of that loop is to drain the data sent from the
        * server to ensure that the server processed all of the data we
        * sent to the server.

--- a/libmemcached/result.cc
+++ b/libmemcached/result.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -40,7 +40,7 @@
   memcached_result_st are used to internally represent the return values from
   memcached. We use a structure so that long term as identifiers are added
   to memcached we will be able to absorb new attributes without having
-  to addjust the entire API.
+  to adjust the entire API.
 */
 #include <libmemcached/common.h>
 

--- a/libmemcached/rgroup.cc
+++ b/libmemcached/rgroup.cc
@@ -289,7 +289,7 @@ do_rgroup_server_switchover(memcached_rgroup_st *rgroup, int sindex)
 }
 
 /*
- * memcached rgroup sructure management
+ * memcached rgroup structure management
  */
 
 static memcached_rgroup_st *
@@ -746,7 +746,7 @@ void
 memcached_rgroup_sort(memcached_st *memc)
 {
   if (memc->rgroups) {
-    /* sort rgoups */
+    /* sort rgroups */
     qsort(memc->rgroups, memc->number_of_hosts,
           sizeof(memcached_rgroup_st), do_rgroup_compare);
 

--- a/libmemcached/server.cc
+++ b/libmemcached/server.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -88,7 +88,7 @@ static inline void _server_init(memcached_server_st *self, memcached_st *root,
   self->limit_maxbytes= 0;
   memcpy(self->hostname, hostname.c_str, hostname.size);
   self->hostname[hostname.size]= 0;
-#ifdef KETAMA_HASH_COLLSION
+#ifdef KETAMA_HASH_COLLISION
   snprintf(self->str_port, MEMCACHED_NI_MAXSERV, "%u", (uint32_t)port);
 #endif
 
@@ -129,7 +129,7 @@ memcached_server_st *__server_create_with(memcached_st *memc,
                                           memcached_server_write_instance_st self,
                                           const memcached_string_t& hostname,
                                           const in_port_t port,
-                                          uint32_t weight, 
+                                          uint32_t weight,
                                           const memcached_connection_t type)
 {
   if (memcached_is_valid_servername(hostname) == false)

--- a/libmemcached/server.h
+++ b/libmemcached/server.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -48,17 +48,17 @@
 #else
 #define MEMCACHED_NI_MAXHOST 1025
 #endif
-#ifdef KETAMA_HASH_COLLSION
+#ifdef KETAMA_HASH_COLLISION
 #ifdef NI_MAXSERV
 #define MEMCACHED_NI_MAXSERV NI_MAXSERV
 #else
 #define MEMCACHED_NI_MAXSERV 32
 #endif
-#endif /* KETAMA_HASH_COLLSION */
+#endif /* KETAMA_HASH_COLLISION */
 
 enum memcached_server_state_t {
   MEMCACHED_SERVER_STATE_NEW, // fd == -1, no address lookup has been done
-  MEMCACHED_SERVER_STATE_ADDRINFO, // ADDRRESS information has been gathered
+  MEMCACHED_SERVER_STATE_ADDRINFO, // ADDRESS information has been gathered
   MEMCACHED_SERVER_STATE_IN_PROGRESS,
   MEMCACHED_SERVER_STATE_CONNECTED,
   MEMCACHED_SERVER_STATE_IN_TIMEOUT
@@ -102,7 +102,7 @@ struct memcached_server_st {
 #endif
 #ifdef ENABLE_REPLICATION
   /* In replication, a group may have one master and zero or more slaves. */
-  int32_t groupindex; 
+  int32_t groupindex;
   int32_t switchover_sidx;      /* slave index for switchover */
   char    switchover_peer[128]; /* FIXME: constant macro must be defined */
   struct memcached_server_st *next;
@@ -113,7 +113,7 @@ struct memcached_server_st {
   char read_buffer[MEMCACHED_MAX_BUFFER];
   char write_buffer[MEMCACHED_MAX_BUFFER];
   char hostname[MEMCACHED_NI_MAXHOST];
-#ifdef KETAMA_HASH_COLLSION
+#ifdef KETAMA_HASH_COLLISION
   char str_port[MEMCACHED_NI_MAXSERV];
 #endif
 };

--- a/libmemcached/server.hpp
+++ b/libmemcached/server.hpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -106,7 +106,7 @@ static inline void memcached_mark_server_for_timeout(memcached_server_write_inst
     }
     else
     {
-      server->next_retry= 1; // Setting the value to 1 causes the timeout to occur immediatly
+      server->next_retry= 1; // Setting the value to 1 causes the timeout to occur immediately
     }
 #ifdef IMMEDIATELY_RECONNECT
     if (server->immediate_reconnect)

--- a/libmemcached/string.cc
+++ b/libmemcached/string.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -47,7 +47,7 @@ inline static memcached_return_t _string_check(memcached_string_st *string, size
     size_t adjust;
     size_t new_size;
 
-    /* This is the block multiplier. To keep it larger and surive division errors we must round it up */
+    /* This is the block multiplier. To keep it larger and survive division errors we must round it up */
     adjust= (need - (size_t)(string->current_size - (size_t)(string->end - string->string))) / MEMCACHED_BLOCK_SIZE;
     adjust++;
 

--- a/libmemcached/string.h
+++ b/libmemcached/string.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -45,7 +45,7 @@
   about them.
 
   1) is_initialized is always valid.
-  2) A string once intialized will always be, until free where we
+  2) A string once initialized will always be, until free where we
      unset this flag.
   3) A string always has a root.
 */


### PR DESCRIPTION
[libmemcached](https://github.com/naver/arcus-c-client/tree/develop/libmemcached) 폴더 내의 소스파일에 있는 오탈자를 수정합니다.