### PR TITLE
INTERNAL: Print 'arcus-c-client', not 'libmemcached' when compiling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@
 # the COPYING file in this directory for full text.
 
 m4_include([m4/version.m4])
-AC_INIT([libmemcached],[VERSION_NUMBER],[http://libmemcached.org/])
+AC_INIT([arcus-c-client],[VERSION_NUMBER],[https://github.com/naver/arcus-c-client])
 
 AC_CONFIG_AUX_DIR(config)
 


### PR DESCRIPTION
`./configure` 을 성공적으로 수행할 경우 아래와 같은 메시지가 출력됩니다.
```
Configuration summary for libmemcached version 1.13.2_52

   * Installation prefix:       /usr/local
   * System type:               apple-darwin22.6.0
   * Host CPU:                  x86_64
   * C Compiler:                Apple clang version 15.0.0 (clang-1500.0.40.1)
   * Assertions enabled:        yes
   * Debug enabled:             no
   * Warnings as failure:       yes
```
해당 버전(1.13.2)은 libmemcached 가 아니며, 컴파일 또한 arcus-c-client에 대한 것이므로 이를 수정합니다.
```
Configuration summary for arcus-c-client version 1.13.2_52

   * Installation prefix:       /usr/local
   * System type:               apple-darwin22.6.0
   * Host CPU:                  x86_64
   * C Compiler:                Apple clang version 15.0.0 (clang-1500.0.40.1)
   * Assertions enabled:        yes
   * Debug enabled:             no
   * Warnings as failure:       yes
```

추가적으로 [config/version.pl](https://github.com/naver/arcus-c-client/blob/develop/config/version.pl) 에 사용되지 않는 libmemcached 버전 정보가 들어있는데 주석 처리를 할까요?
```sh
# LIBMEMCACHED VERSION
my $libmemcached_version = "0.53";
```