### PR TITLE
FIX: Do not use MEMCACHED_POINTS_PER_SERVER_KETAMA

### DIFF
--- a/libmemcached/hosts.cc
+++ b/libmemcached/hosts.cc
@@ -526,7 +526,7 @@ static memcached_return_t update_continuum_based_on_rgroups(memcached_st *ptr)
     {
         if (!all_weights_same) {
           float pct= (float)list[host_index].weight / (float)total_weight;
-          pointer_per_server= (uint32_t) ((floor((float) (pct * MEMCACHED_POINTS_PER_SERVER_KETAMA / 4 * (float)live_servers + 0.0000000001))) * 4);
+          pointer_per_server= (uint32_t) ((floor((float) (pct * MEMCACHED_POINTS_PER_SERVER / 4 * (float)live_servers + 0.0000000001))) * 4);
         }
         if (DEBUG)
         {


### PR DESCRIPTION
- #275

```
libmemcached/hosts.cc: In function 'memcached_return_t update_continuum_based_on_rgroups(memcached_st*)':
libmemcached/hosts.cc:529:65: error: 'MEMCACHED_POINTS_PER_SERVER_KETAMA' was not declared in this scope
           pointer_per_server= (uint32_t) ((floor((float) (pct * MEMCACHED_POINTS_PER_SERVER_KETAMA / 4 * (float)live_servers + 0.0000000001))) * 4);
                                                                 ^
make[1]: *** [libmemcached/libmemcached_libmemcached_la-hosts.lo] 오류 1
make[1]: Leaving directory `/home/test/arcus-c-client-version/develop'
make: *** [all] 오류 2
```

현재 `--enable-zk-integration` 플래그 설정 시 make 실패합니다.