### PR TITLE
INTERNAL: Fix compile errors with zookeeper in redhat8

### DIFF
--- a/arcus/multi_process.c
+++ b/arcus/multi_process.c
@@ -102,7 +102,7 @@ static inline void process_child(memcached_st *proxy_mc)
 
       // results
       memcached_return_t errors[NUM_OF_PIPED_ITEMS];
-      memset(errors, 0, NUM_OF_PIPED_ITEMS);
+      memset(errors, 0, NUM_OF_PIPED_ITEMS * sizeof(memcached_return_t));
 
       // do piped insert
       memcached_return_t piped_rc;
@@ -117,7 +117,7 @@ static inline void process_child(memcached_st *proxy_mc)
       memcached_coll_attrs_set_maxbkeyrange(&attrs, maxbkeyrange);
 
       rc = memcached_set_attrs(mc, key, strlen(key), &attrs);
-    
+
       rc = memcached_get_attrs(mc, key, strlen(key), &attrs);
       maxbkeyrange = memcached_coll_attrs_get_maxbkeyrange(&attrs);
 
@@ -247,7 +247,7 @@ static inline void process_child(memcached_st *proxy_mc)
 int main(int argc __attribute__((unused)), char *argv[] __attribute__((unused)))
 {
   memcached_st *proxy_mc;
-  arcus_return_t rc; 
+  arcus_return_t rc;
   int i;
 
   proxy_mc = memcached_create(NULL);
@@ -266,12 +266,12 @@ int main(int argc __attribute__((unused)), char *argv[] __attribute__((unused)))
       case 0:
         process_child(proxy_mc);
         exit(EXIT_SUCCESS);
-      case -1: 
+      case -1:
         perror("fork error");
         exit(EXIT_FAILURE);
       default:
         break;
-    }   
+    }
   }
 
   //siginfo_t info;

--- a/libmemcached/arcus.cc
+++ b/libmemcached/arcus.cc
@@ -556,7 +556,7 @@ static inline int do_arcus_cluster_validation_check(memcached_st *mc, arcus_st *
 static inline int do_add_client_info(arcus_st *arcus)
 {
   int result;
-  char path[250];
+  char path[512];
   char hostname[256];
   struct hostent *host = NULL;
   time_t timer;
@@ -933,12 +933,15 @@ static inline void do_arcus_zk_update_cachelist_by_string(memcached_st *mc,
   memcached_server_info_st *serverinfo;
   char buffer[ARCUS_MAX_PROXY_FILE_LENGTH];
 
+  if (strlen(serverlist) >= ARCUS_MAX_PROXY_FILE_LENGTH) {
+    return;
+  }
+  strncpy(buffer, serverlist, ARCUS_MAX_PROXY_FILE_LENGTH);
+
   serverinfo = static_cast<memcached_server_info_st *>(libmemcached_malloc(mc, sizeof(memcached_server_info_st)*(size+1)));
   if (not serverinfo) {
     return;
   }
-
-  strncpy(buffer, serverlist, ARCUS_MAX_PROXY_FILE_LENGTH);
 
   /* Parse the cache server list strings. */
   if (size > 0) {

--- a/libmemcached/arcus_priv.h
+++ b/libmemcached/arcus_priv.h
@@ -30,7 +30,7 @@ struct arcus_zk_st
   clientid_t myid;
   char       ensemble_list[1024];
   char       svc_code[256];
-  char       path[256];
+  char       path[512];
   uint32_t   port;
   uint32_t   session_timeout;
   size_t     maxbytes;


### PR DESCRIPTION
-  jam2in/arcus-works#467
- #281 

`with-zk-integration` 옵션을 넣고 compile 시, redhat8 계열에서 일어나는 컴파일 에러 수정입니다.

```
arcus/multi_process.c:105:7: error: ‘memset’ used with length equal to number of elements without multiplication by element size [-Werror=memset-elt-size]
       memset(errors, 0, NUM_OF_PIPED_ITEMS);
       ^~~~~~

libmemcached/arcus.cc:941:10: error: ‘char* strncpy(char*, const char*, size_t)’ specified bound 10240 equals destination size [-Werror=stringop-truncation]
   strncpy(buffer, serverlist, ARCUS_MAX_PROXY_FILE_LENGTH);
   ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

libmemcached/arcus.cc:584:32: error: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 232 and 237 [-Werror=format-truncation=]
   snprintf(path, sizeof(path), "%s/%s/%.*s_%s_%u_c_%s_%d%02d%02d%02d%02d%02d_%llx",
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```
### 에러 원인 및 처리
1. `sprintf` 수행 시 output 버퍼의 크기가 (input 버퍼의 크기 + 기타 문자열 크기) 보다 작음.
    - output 버퍼의 크기를 2배(512bytes) 늘렸습니다. 
2. `strnpcy` 수행 시 input 문자열의 크기가 output 버퍼보다 클 수 있음
    - 수행 이전에 비교 조건문을 추가했습니다.
    - 기존 코드에서 에러에 대한 별다른 핸들링이 존재하지 않아 똑같이 바로 return 하도록 했습니다.
      - 반복적으로 수행될 수 있는 코드이기에 별다른 에러 핸들링이 존재하지 않는 것이 아닐까 싶습니다.
3. memset 시, 잘못된 byte 크기가 주어지는 것을 수정했습니다.
