### PR TITLE
CLEANUP: Remove non-existent files from EXTRA_DIST

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,8 +20,6 @@ BUILT_SOURCES=
 EXTRA_DIST= \
 	    ${srcdir}/m4/pandora_*.m4 \
 	    .quickly \
-	    README.FIRST \
-	    README.win32 \
 	    config/autorun.sh \
 	    config/pandora-plugin \
 	    config/uncrustify.cfg


### PR DESCRIPTION
`README.FIRST`와 `README.win32`는 libmemcached-0.53에는 있었지만 arcus-c-client에서는 존재하지 않는 파일입니다.
(initial commit d148fa3 에서 제거되었습니다.)

따라서 `EXTRA_DIST`에서 두 파일을 제거합니다.