### PR TITLE
INTERNAL: Remove whitespace and typos in source files

### DIFF
--- a/arcus/include.am
+++ b/arcus/include.am
@@ -4,13 +4,13 @@
 
 ARCUS_LDADD= \
 	libmemcached/libmemcached.la \
-	libmemcached/libmemcachedutil.la 
+	libmemcached/libmemcachedutil.la
 
 # Multi-Threaded Example
 
 noinst_PROGRAMS+= arcus/multi_threaded
 arcus_multi_threaded_SOURCES= arcus/multi_threaded.c
-				 
+
 arcus_multi_threaded_LDFLAGS= -g -O0
 arcus_multi_threaded_LDADD= $(ARCUS_LDADD)
 arcus_multi_threaded_DEPENDENCIES= $(ARCUS_LDADD)
@@ -19,7 +19,7 @@ arcus_multi_threaded_DEPENDENCIES= $(ARCUS_LDADD)
 
 noinst_PROGRAMS+= arcus/multi_process
 arcus_multi_process_SOURCES= arcus/multi_process.c
-				 
+
 arcus_multi_process_LDFLAGS= -g -O0
 arcus_multi_process_LDADD= $(ARCUS_LDADD)
 arcus_multi_process_DEPENDENCIES= $(ARCUS_LDADD)

--- a/arcus/multi_threaded.c
+++ b/arcus/multi_threaded.c
@@ -166,21 +166,21 @@ sample_sop_piped_exist(memcached_st *mc, int id, uint32_t userid)
 
   memcached_coll_create_attrs_st attributes;
   memcached_coll_create_attrs_init(&attributes, flags, exptime, 10000);
-  
+
   memcached_return_t rc;
   memcached_return_t piped_rc;
   memcached_return_t results[MANY_PIPED_COUNT];
-  
+
   char **values = (char **)malloc(sizeof(char *) * MANY_PIPED_COUNT);
   size_t valuelengths[MANY_PIPED_COUNT];
-  
+
   for (i=0; i<maxcount; i++)
-  { 
+  {
     values[i]= (char *)malloc(sizeof(char) * 15);
     valuelengths[i]= snprintf(values[i], 15, "%u", i);
     //valuelengths[i]= snprintf(values[i], 15, "value%llu", (unsigned long long)i);
   }
-  
+
   memcached_sop_create(mc, key, strlen(key), &attributes);
   memcached_sop_insert(mc, key, strlen(key), "0", 1, NULL);
   memcached_sop_insert(mc, key, strlen(key), "499", 3, NULL);
@@ -204,14 +204,14 @@ sample_sop_piped_exist(memcached_st *mc, int id, uint32_t userid)
   gettimeofday(&e_time, NULL);
   double elapsed_ms = ((e_time.tv_sec - s_time.tv_sec) * 1000.0)
                     + ((e_time.tv_usec - s_time.tv_usec) / 1000.0);
-  
+
   if (rc != MEMCACHED_SUCCESS && piped_rc != MEMCACHED_ALL_EXIST)
     fprintf(stderr, "sop_piped_exist failed, reason=%s\n", memcached_strerror(NULL, rc));
   else
     fprintf(stderr, "elapsed time : %lf ms\n", elapsed_ms);
-  
+
   for (i=0; i<maxcount; i++)
-  { 
+  {
     free((void*)values[i]);
   }
 

--- a/arcus/sample.c
+++ b/arcus/sample.c
@@ -44,11 +44,11 @@ main(int argc, char *argv[])
       false /* do not delete the empty key */,
       &result))
     return -1;
-  
+
   /* Print */
   printf("Retrieved the element. value=%s\n",
     memcached_coll_result_get_value(&result, 0));
   memcached_coll_result_free(&result);
-  
+
   return 0;
 }

--- a/clients/execute.cc
+++ b/clients/execute.cc
@@ -29,7 +29,7 @@ unsigned int execute_set(memcached_st *memc, pairs_st *pairs, unsigned int numbe
                                          0, 0);
     if (rc != MEMCACHED_SUCCESS && rc != MEMCACHED_BUFFERED)
     {
-      fprintf(stderr, "Failured on insert of %.*s\n",
+      fprintf(stderr, "Failure on insert of %.*s\n",
               (unsigned int)pairs[x].key_length, pairs[x].key);
     }
     else

--- a/clients/memcapable.cc
+++ b/clients/memcapable.cc
@@ -48,7 +48,7 @@
 #undef ntohl
 #endif
 
-/* Should we generate coredumps when we enounter an error (-c) */
+/* Should we generate coredumps when we encounter an error (-c) */
 static bool do_core= false;
 /* connection to the server */
 static memcached_socket_t sock;
@@ -199,7 +199,7 @@ static ssize_t timeout_io_op(memcached_socket_t fd, short direction, void *buf, 
     ret= recv(fd, buf, len, 0);
   }
 
-  if (ret == SOCKET_ERROR && get_socket_errno() == EWOULDBLOCK) 
+  if (ret == SOCKET_ERROR && get_socket_errno() == EWOULDBLOCK)
   {
     struct pollfd fds;
     memset(&fds, 0, sizeof(struct pollfd));
@@ -258,7 +258,7 @@ static enum test_return ensure(bool val, const char *expression, const char *fil
 #define execute(expression) do { if (ensure(expression == TEST_PASS, #expression, __FILE__, __LINE__) == TEST_FAIL) return TEST_FAIL; } while (0)
 
 /**
- * Send a chunk of memory over the socket (retry if the call is iterrupted
+ * Send a chunk of memory over the socket (retry if the call is interrupted
  */
 static enum test_return retry_write(const void* buf, size_t len)
 {
@@ -334,7 +334,7 @@ static enum test_return retry_read(void *buf, size_t len)
 }
 
 /**
- * Receive a response from the server and conver the fields in the header
+ * Receive a response from the server and convert the fields in the header
  * to local byte order
  */
 static enum test_return recv_packet(response *rsp)

--- a/clients/memcat.cc
+++ b/clients/memcat.cc
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
           }
 
           written= fwrite(string, 1, string_length, fp);
-          if (written != string_length) 
+          if (written != string_length)
           {
             fprintf(stderr, "error writing file (written %lu, should be %lu)\n", (unsigned long)written, (unsigned long)string_length);
             return_code= -1;

--- a/clients/memerror.cc
+++ b/clients/memerror.cc
@@ -23,7 +23,7 @@
 #include "utilities.h"
 
 #define PROGRAM_NAME "memerror"
-#define PROGRAM_DESCRIPTION "Translate a memcached errror code into a string."
+#define PROGRAM_DESCRIPTION "Translate a memcached error code into a string."
 
 
 /* Prototypes */
@@ -71,7 +71,7 @@ void options_parse(int argc, char *argv[])
   bool opt_version= false;
   bool opt_help= false;
   int option_index= 0;
-  while (1) 
+  while (1)
   {
     int option_rv= getopt_long(argc, argv, "Vhvds:", long_options, &option_index);
     if (option_rv == -1)

--- a/clients/memexist.cc
+++ b/clients/memexist.cc
@@ -163,7 +163,7 @@ static void options_parse(int argc, char *argv[])
   while (1)
   {
     int option_rv= getopt_long(argc, argv, "Vhvds:", long_options, &option_index);
-    if (option_rv == -1) 
+    if (option_rv == -1)
     {
       break;
     }

--- a/clients/memparse.cc
+++ b/clients/memparse.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/clients/memrm.cc
+++ b/clients/memrm.cc
@@ -168,7 +168,7 @@ static void options_parse(int argc, char *argv[])
   while (1)
   {
     int option_rv= getopt_long(argc, argv, "Vhvds:", long_options, &option_index);
-    if (option_rv == -1) 
+    if (option_rv == -1)
     {
       break;
     }

--- a/clients/memslap.cc
+++ b/clients/memslap.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/clients/memstat.cc
+++ b/clients/memstat.cc
@@ -7,7 +7,7 @@
  *
  * Summary:
  *
- * Authors: 
+ * Authors:
  *          Brian Aker
  *          Toru Maesaka
  */
@@ -266,7 +266,7 @@ static void run_analyzer(memcached_st *memc, memcached_stat_st *memc_stat)
 
 static void print_analysis_report(memcached_st *memc,
                                   memcached_analysis_st *report)
-                                  
+
 {
   uint32_t server_count= memcached_server_count(memc);
   memcached_server_instance_st most_consumed_server= memcached_server_instance_by_position(memc, report->most_consumed_server);
@@ -313,7 +313,7 @@ static void options_parse(int argc, char *argv[])
 
   bool opt_version= false;
   bool opt_help= false;
-  while (1) 
+  while (1)
   {
     int option_rv= getopt_long(argc, argv, "Vhvds:a", long_options, &option_index);
 

--- a/clients/ms_conn.c
+++ b/clients/ms_conn.c
@@ -794,7 +794,7 @@ static int ms_network_connect(ms_conn_t *c,
   int flags= 1;
 
   /*
-   * the memset call clears nonstandard fields in some impementations
+   * the memset call clears nonstandard fields in some implementations
    * that otherwise mess things up.
    */
   memset(&hints, 0, sizeof(hints));

--- a/clients/ms_memslap.h
+++ b/clients/ms_memslap.h
@@ -105,7 +105,7 @@ typedef struct global
   ms_sync_lock_t warmup_lock;
   ms_sync_lock_t run_lock;
 
-  /* mutex for outputing error log synchronously when memslap crashes */
+  /* mutex for outputting error log synchronously when memslap crashes */
   pthread_mutex_t quit_mutex;
 
   /* mutex for generating key prefix */

--- a/clients/ms_setting.c
+++ b/clients/ms_setting.c
@@ -323,7 +323,7 @@ static void ms_no_config_file()
     perror(strerror(errno));
     exit(1);
   }
-  fprintf(fd, "%s", DEFAULT_CONGIF_STR);
+  fprintf(fd, "%s", DEFAULT_CONFIG_STR);
   fclose(fd);
 
 exit:

--- a/clients/ms_setting.h
+++ b/clients/ms_setting.h
@@ -28,7 +28,7 @@ extern "C" {
 #define MAX_VALUE_SIZE            (1024 * 1024)
 
 /* the content of the configuration file for memslap running without configuration file */
-#define DEFAULT_CONGIF_STR \
+#define DEFAULT_CONFIG_STR \
   "key\n"                  \
   "64 64 1\n"              \
   "value\n"                \

--- a/example/byteorder.cc
+++ b/example/byteorder.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/example/byteorder.h
+++ b/example/byteorder.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Byteorder for example
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/example/memcached_light.c
+++ b/example/memcached_light.c
@@ -428,7 +428,7 @@ int main(int argc, char **argv)
 
   /*
    * Create and initialize the handles to the protocol handlers. I want
-   * to be able to trace the traffic throught the pre/post handlers, and
+   * to be able to trace the traffic through the pre/post handlers, and
    * set up a common handler for unknown messages
    */
   interface->pre_execute= pre_execute;

--- a/example/storage_innodb.c
+++ b/example/storage_innodb.c
@@ -48,7 +48,7 @@ do {                                                           \
  * @return true if the database schema was created without any problems
  *         false otherwise.
  */
-static bool create_schema(void) 
+static bool create_schema(void)
 {
   ib_tbl_sch_t schema= NULL;
   ib_idx_sch_t dbindex= NULL;
@@ -102,7 +102,7 @@ static bool create_schema(void)
  * @param item the item to store
  * @return true if we can go ahead and commit the transaction, false otherwise
  */
-static bool do_put_item(ib_trx_t trx, struct item* item) 
+static bool do_put_item(ib_trx_t trx, struct item* item)
 {
   update_cas(item);
 
@@ -129,9 +129,9 @@ static bool do_put_item(ib_trx_t trx, struct item* item)
   if (tuple != NULL)
     ib_tuple_delete(tuple);
 
-  ib_err_t currsor_error;
+  ib_err_t cursor_error;
   if (cursor != NULL)
-    currsor_error= ib_cursor_close(cursor);
+    cursor_error= ib_cursor_close(cursor);
 
   return retval;
 }
@@ -201,13 +201,13 @@ static bool do_locate_item(ib_trx_t trx,
  * @param nkey the lenght of the key
  * @return a pointer to the item if I found it in the database
  */
-static struct item* do_get_item(ib_trx_t trx, const void* key, size_t nkey) 
+static struct item* do_get_item(ib_trx_t trx, const void* key, size_t nkey)
 {
   ib_crsr_t cursor= NULL;
   ib_tpl_t tuple= NULL;
   struct item* retval= NULL;
 
-  if (do_locate_item(trx, key, nkey, &cursor)) 
+  if (do_locate_item(trx, key, nkey, &cursor))
   {
     tuple= ib_clust_read_tuple_create(cursor);
     if (tuple == NULL)
@@ -224,25 +224,25 @@ static struct item* do_get_item(ib_trx_t trx, const void* key, size_t nkey)
     const void *dataptr= ib_col_get_value(tuple, data_col_idx);
 
     retval= create_item(key, nkey, dataptr, datalen, 0, 0);
-    if (retval == NULL) 
+    if (retval == NULL)
     {
       fprintf(stderr, "Failed to allocate memory\n");
       goto error_exit;
     }
 
-    if (flaglen != 0) 
+    if (flaglen != 0)
     {
       ib_u32_t val;
       checked(ib_tuple_read_u32(tuple, flags_col_idx, &val));
       retval->flags= (uint32_t)val;
     }
-    if (caslen != 0) 
+    if (caslen != 0)
     {
       ib_u64_t val;
       checked(ib_tuple_read_u64(tuple, cas_col_idx, &val));
       retval->cas= (uint64_t)val;
     }
-    if (explen != 0) 
+    if (explen != 0)
     {
       ib_u32_t val;
       checked(ib_tuple_read_u32(tuple, exp_col_idx, &val));
@@ -304,7 +304,7 @@ static bool do_delete_item(ib_trx_t trx, const void* key, size_t nkey) {
  * Initialize the database storage
  * @return true if the database was initialized successfully, false otherwise
  */
-bool initialize_storage(void) 
+bool initialize_storage(void)
 {
   ib_err_t error;
   ib_id_t tid;
@@ -317,14 +317,14 @@ bool initialize_storage(void)
 
   /* check to see if the table exists or if we should create the schema */
   error= ib_table_get_id(tablename, &tid);
-  if (error == DB_TABLE_NOT_FOUND) 
+  if (error == DB_TABLE_NOT_FOUND)
   {
-    if (!create_schema()) 
+    if (!create_schema())
     {
       return false;
     }
-  } 
-  else if (error != DB_SUCCESS) 
+  }
+  else if (error != DB_SUCCESS)
   {
     fprintf(stderr, "Failed to get table id: %s\n", ib_strerror(error));
     return false;
@@ -340,7 +340,7 @@ bool initialize_storage(void)
 /**
  * Shut down this storage engine
  */
-void shutdown_storage(void) 
+void shutdown_storage(void)
 {
   checked(ib_shutdown(IB_SHUTDOWN_NORMAL));
  error_exit:
@@ -352,19 +352,19 @@ void shutdown_storage(void)
  *
  * @param item the item to store
  */
-void put_item(struct item* item) 
+void put_item(struct item* item)
 {
   ib_trx_t transaction= ib_trx_begin(IB_TRX_SERIALIZABLE);
-  if (do_put_item(transaction, item)) 
+  if (do_put_item(transaction, item))
   {
     ib_err_t error= ib_trx_commit(transaction);
-    if (error != DB_SUCCESS) 
+    if (error != DB_SUCCESS)
     {
       fprintf(stderr, "Failed to store key:\n\t%s\n",
               ib_strerror(error));
     }
-  } 
-  else 
+  }
+  else
   {
     ib_err_t error= ib_trx_rollback(transaction);
     if (error != DB_SUCCESS)
@@ -379,7 +379,7 @@ void put_item(struct item* item)
  * @param nkey number of bytes in the key
  * @return pointer to the item if found
  */
-struct item* get_item(const void* key, size_t nkey) 
+struct item* get_item(const void* key, size_t nkey)
 {
   ib_trx_t transaction= ib_trx_begin(IB_TRX_SERIALIZABLE);
   struct item* ret= do_get_item(transaction, key, nkey);
@@ -475,7 +475,7 @@ bool delete_item(const void* key, size_t nkey) {
  * Flush the entire cache
  * @param when when the cache should be flushed (0 == immediately)
  */
-void flush(uint32_t when __attribute__((unused))) 
+void flush(uint32_t when __attribute__((unused)))
 {
   /* @TODO implement support for when != 0 */
   ib_trx_t transaction= ib_trx_begin(IB_TRX_REPEATABLE_READ);
@@ -486,7 +486,7 @@ void flush(uint32_t when __attribute__((unused)))
   checked(ib_cursor_first(cursor));
   checked(ib_cursor_lock(cursor, IB_LOCK_X));
 
-  do 
+  do
   {
     checked(ib_cursor_delete_row(cursor));
   } while ((err= ib_cursor_next(cursor)) == DB_SUCCESS);
@@ -518,7 +518,7 @@ void flush(uint32_t when __attribute__((unused)))
  * Update the cas ID in the item structure
  * @param item the item to update
  */
-void update_cas(struct item* item) 
+void update_cas(struct item* item)
 {
   item->cas= ++cas;
 }
@@ -527,7 +527,7 @@ void update_cas(struct item* item)
  * Release all the resources allocated by the item
  * @param item the item to release
  */
-void release_item(struct item* item) 
+void release_item(struct item* item)
 {
   free(item->key);
   free(item->data);

--- a/libhashkit/digest.h
+++ b/libhashkit/digest.h
@@ -17,7 +17,7 @@ HASHKIT_API
 uint32_t hashkit_digest(const hashkit_st *self, const char *key, size_t key_length);
 
 /**
-  This is a utilitly function provided so that you can directly access hashes with a hashkit_st.
+  This is a utility function provided so that you can directly access hashes with a hashkit_st.
 */
 
 HASHKIT_API

--- a/libhashkit/fnv_32.cc
+++ b/libhashkit/fnv_32.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  HashKit library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libhashkit/fnv_64.cc
+++ b/libhashkit/fnv_64.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  HashKit library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libhashkit/function.cc
+++ b/libhashkit/function.cc
@@ -53,7 +53,7 @@ static hashkit_return_t _set_function(struct hashkit_st::hashkit_function_st *se
     if (libhashkit_has_algorithm(HASHKIT_HASH_HSIEH))
     {
       self->function= hashkit_hsieh;
-      break;    
+      break;
     }
     return HASHKIT_INVALID_ARGUMENT;
 
@@ -61,13 +61,13 @@ static hashkit_return_t _set_function(struct hashkit_st::hashkit_function_st *se
     if (libhashkit_has_algorithm(HASHKIT_HASH_MURMUR))
     {
       self->function= hashkit_murmur;
-      break;    
+      break;
     }
     return HASHKIT_INVALID_ARGUMENT;
 
   case HASHKIT_HASH_JENKINS:
     self->function= hashkit_jenkins;
-    break;    
+    break;
 
   case HASHKIT_HASH_CUSTOM:
     return HASHKIT_INVALID_ARGUMENT;

--- a/libhashkit/has.cc
+++ b/libhashkit/has.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libhashkit/has.h
+++ b/libhashkit/has.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libhashkit/hashkit.cc
+++ b/libhashkit/hashkit.cc
@@ -66,7 +66,7 @@ hashkit_st *hashkit_clone(hashkit_st *destination, const hashkit_st *source)
     return hashkit_create(destination);
   }
 
-  /* new_clone will be a pointer to destination */ 
+  /* new_clone will be a pointer to destination */
   destination= _hashkit_create(destination);
 
   // Should only happen on allocation failure.

--- a/libhashkit/hashkit.h
+++ b/libhashkit/hashkit.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  HashKit library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libhashkit/hashkit.hpp
+++ b/libhashkit/hashkit.hpp
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libhashkit/jenkins.cc
+++ b/libhashkit/jenkins.cc
@@ -89,7 +89,7 @@ uint32_t hashkit_jenkins(const char *key, size_t length, void *)
      * rest of the string.  Every machine with memory protection I've seen
      * does it on word boundaries, so is OK with this.  But VALGRIND will
      * still catch it and complain.  The masking trick does make the hash
-     * noticably faster for short strings (like English words).
+     * noticeably faster for short strings (like English words).
      */
     switch(length)
     {

--- a/libhashkit/str_algorithm.cc
+++ b/libhashkit/str_algorithm.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  HashKit
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libhashkit/str_algorithm.h
+++ b/libhashkit/str_algorithm.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  HashKit
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libhashkit/types.h
+++ b/libhashkit/types.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  HashKit
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libhashkit/visibility.h
+++ b/libhashkit/visibility.h
@@ -4,7 +4,7 @@
  *
  * Use and distribution licensed under the BSD license.  See
  * the COPYING file in this directory for full text.
- * 
+ *
  * Author: Monty Taylor
  */
 
@@ -32,7 +32,7 @@
 #  define HASHKIT_API __global
 #  define HASHKIT_LOCAL __hidden
 # elif defined(_MSC_VER)
-#  define HASHKIT_API extern __declspec(dllexport) 
+#  define HASHKIT_API extern __declspec(dllexport)
 #  define HASHKIT_LOCAL
 # else
 #  define HASHKIT_API
@@ -40,7 +40,7 @@
 # endif /* defined(HAVE_VISIBILITY) */
 #else  /* defined(BUILDING_HASHKIT) */
 # if defined(_MSC_VER)
-#  define HASHKIT_API extern __declspec(dllimport) 
+#  define HASHKIT_API extern __declspec(dllimport)
 #  define HASHKIT_LOCAL
 # else
 #  define HASHKIT_API

--- a/libtest/binaries.cc
+++ b/libtest/binaries.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/binaries.h
+++ b/libtest/binaries.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/blobslap_worker.cc
+++ b/libtest/blobslap_worker.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -49,7 +49,7 @@ private:
 public:
   BlobslapWorker(in_port_t port_arg) :
     Server("localhost", port_arg)
-  { 
+  {
     set_pid_file();
   }
 

--- a/libtest/blobslap_worker.h
+++ b/libtest/blobslap_worker.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/callbacks.h
+++ b/libtest/callbacks.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/cmdline.cc
+++ b/libtest/cmdline.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -59,7 +59,7 @@ bool exec_cmdline(const std::string& executable, const char *args[])
   return true;
 }
 
-const char *gearmand_binary() 
+const char *gearmand_binary()
 {
   return GEARMAND_BINARY;
 }

--- a/libtest/cmdline.h
+++ b/libtest/cmdline.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -26,7 +26,7 @@ namespace libtest {
 
 bool exec_cmdline(const std::string& executable, const char *args[]);
 
-const char *gearmand_binary(); 
+const char *gearmand_binary();
 
 }
 

--- a/libtest/collection.h
+++ b/libtest/collection.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/common.h
+++ b/libtest/common.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -46,10 +46,10 @@
 #include <sys/wait.h>
 #endif
 
-#ifdef HAVE_SYS_RESOURCE_H 
-#include <sys/resource.h> 
+#ifdef HAVE_SYS_RESOURCE_H
+#include <sys/resource.h>
 #endif
- 
+
 #ifdef HAVE_FNMATCH_H
 #include <fnmatch.h>
 #endif

--- a/libtest/comparison.hpp
+++ b/libtest/comparison.hpp
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -56,27 +56,27 @@ bool _compare(const char *file, int line, const char *func, const T1_comparable 
       const char *expected_str= test_strerror(test_return_t(__expected));
       const char *got_str= test_strerror(test_return_t(__actual));
 
-      libtest::stream::make_cerr(file, line, func) << "Expected \"" 
+      libtest::stream::make_cerr(file, line, func) << "Expected \""
         << expected_str
-        << "\" got \"" 
+        << "\" got \""
         << got_str
         << "\"";
     }
 #if defined(HAVE_LIBMEMCACHED) && HAVE_LIBMEMCACHED
     else if (typeid(__expected) == typeid(memcached_return_t))
     {
-      libtest::stream::make_cerr(file, line, func) << "Expected \"" 
-        << memcached_strerror(NULL, memcached_return_t(__expected)) 
-        << "\" got \"" 
+      libtest::stream::make_cerr(file, line, func) << "Expected \""
+        << memcached_strerror(NULL, memcached_return_t(__expected))
+        << "\" got \""
         << memcached_strerror(NULL, memcached_return_t(__actual)) << "\"";
     }
 #endif
 #if defined(HAVE_LIBGEARMAN) && HAVE_LIBGEARMAN
     else if (typeid(__expected) == typeid(gearman_return_t))
     {
-      libtest::stream::make_cerr(file, line, func) << "Expected \"" 
-        << gearman_strerror(gearman_return_t(__expected)) 
-        << "\" got \"" 
+      libtest::stream::make_cerr(file, line, func) << "Expected \""
+        << gearman_strerror(gearman_return_t(__expected))
+        << "\" got \""
         << gearman_strerror(gearman_return_t(__actual)) << "\"";
     }
 #endif
@@ -124,9 +124,9 @@ bool _compare_hint(const char *file, int line, const char *func, T1_comparable _
       const char *expected_str= test_strerror(test_return_t(__expected));
       const char *got_str= test_strerror(test_return_t(__actual));
 
-      libtest::stream::make_cerr(file, line, func) << "Expected \"" 
+      libtest::stream::make_cerr(file, line, func) << "Expected \""
         << expected_str
-        << "\" got \"" 
+        << "\" got \""
         << got_str
         << "\""
         << " Additionally: \"" << __hint << "\"";
@@ -134,9 +134,9 @@ bool _compare_hint(const char *file, int line, const char *func, T1_comparable _
 #if defined(HAVE_LIBMEMCACHED) && HAVE_LIBMEMCACHED
     else if (typeid(__expected) == typeid(memcached_return_t))
     {
-      libtest::stream::make_cerr(file, line, func) << "Expected \"" 
-        << memcached_strerror(NULL, memcached_return_t(__expected)) 
-        << "\" got \"" 
+      libtest::stream::make_cerr(file, line, func) << "Expected \""
+        << memcached_strerror(NULL, memcached_return_t(__expected))
+        << "\" got \""
         << memcached_strerror(NULL, memcached_return_t(__actual)) << "\""
         << " Additionally: \"" << __hint << "\"";
     }
@@ -144,9 +144,9 @@ bool _compare_hint(const char *file, int line, const char *func, T1_comparable _
 #if defined(HAVE_LIBGEARMAN) && HAVE_LIBGEARMAN
     else if (typeid(__expected) == typeid(gearman_return_t))
     {
-      libtest::stream::make_cerr(file, line, func) << "Expected \"" 
-        << gearman_strerror(gearman_return_t(__expected)) 
-        << "\" got \"" 
+      libtest::stream::make_cerr(file, line, func) << "Expected \""
+        << gearman_strerror(gearman_return_t(__expected))
+        << "\" got \""
         << gearman_strerror(gearman_return_t(__actual)) << "\""
         << " Additionally: \"" << __hint << "\"";
     }

--- a/libtest/core.cc
+++ b/libtest/core.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/core.h
+++ b/libtest/core.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/error.h
+++ b/libtest/error.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/failed.h
+++ b/libtest/failed.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/framework.cc
+++ b/libtest/framework.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -32,7 +32,7 @@ static test_return_t _default_callback(void *p)
   return TEST_SUCCESS;
 }
 
-static Runner defualt_runners;
+static Runner default_runners;
 
 Framework::Framework() :
   collections(NULL),
@@ -119,7 +119,7 @@ test_return_t Framework::Item::startup(void* arg)
 
 libtest::Runner *Framework::runner()
 {
-  return _runner ? _runner : &defualt_runners;
+  return _runner ? _runner : &default_runners;
 }
 
 void* Framework::create(test_return_t& arg)

--- a/libtest/framework.h
+++ b/libtest/framework.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -75,9 +75,9 @@ public:
 
     test_return_t startup(void*);
 
-    /* 
+    /*
       This called on a test if the test requires a flush call (the bool is
-      from test_st) 
+      from test_st)
     */
     test_callback_fn *_flush;
 
@@ -154,7 +154,7 @@ public:
   {
     return _servers;
   }
-  
+
   /**
     Runner represents the callers for the tests. If not implemented we will use
     a set of default implementations.

--- a/libtest/gearmand.cc
+++ b/libtest/gearmand.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/gearmand.h
+++ b/libtest/gearmand.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/get.h
+++ b/libtest/get.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/include.am
+++ b/libtest/include.am
@@ -18,7 +18,7 @@
 #
 # included from Top Level Makefile.am
 # All paths should be given relative to the root
-# 
+#
 
 LIBTOOL_COMMAND= ${abs_top_builddir}/libtool --mode=execute
 VALGRIND_COMMAND= $(LIBTOOL_COMMAND) valgrind --error-exitcode=1 --leak-check=yes --show-reachable=yes --track-fds=yes --malloc-fill=A5 --free-fill=DE

--- a/libtest/is_local.cc
+++ b/libtest/is_local.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/is_local.hpp
+++ b/libtest/is_local.hpp
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/is_pid.hpp
+++ b/libtest/is_pid.hpp
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/killpid.cc
+++ b/libtest/killpid.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -109,7 +109,7 @@ bool check_pid(const std::string &filename)
       }
     }
   }
-  
+
   return false;
 }
 
@@ -141,7 +141,7 @@ bool kill_file(const std::string &filename)
       }
     }
   }
-  
+
   return false;
 }
 
@@ -188,6 +188,6 @@ pid_t get_pid_from_file(const std::string &filename, std::stringstream& error_me
     char *current_directory= getcwd(buffer, sizeof(buffer));
     error_message << "Error while opening " << current_directory << "/" << filename << " " << strerror(errno);
   }
-  
+
   return ret;
 }

--- a/libtest/killpid.h
+++ b/libtest/killpid.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/libtool.cc
+++ b/libtest/libtool.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/libtool.hpp
+++ b/libtest/libtool.hpp
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/memcached.cc
+++ b/libtest/memcached.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright 2010-2014 NAVER Corp.

--- a/libtest/memcached.h
+++ b/libtest/memcached.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/port.cc
+++ b/libtest/port.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -53,7 +53,7 @@ in_port_t default_port()
 {
   return global_port;
 }
- 
+
 void set_default_port(in_port_t port)
 {
   global_port= port;
@@ -63,7 +63,7 @@ in_port_t max_port()
 {
   return global_max_port;
 }
- 
+
 void set_max_port(in_port_t port)
 {
   if (port > global_max_port)

--- a/libtest/port.h
+++ b/libtest/port.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/runner.cc
+++ b/libtest/runner.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/runner.h
+++ b/libtest/runner.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/server.cc
+++ b/libtest/server.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -27,8 +27,8 @@
 #include <cstdlib>
 #include <iostream>
 
-#include <algorithm> 
-#include <functional> 
+#include <algorithm>
+#include <functional>
 #include <locale>
 
 #include <libtest/server.h>
@@ -366,7 +366,7 @@ bool Server::args(std::string& options)
       return false;
     }
 
-    arg_buffer << " " << pid_file_option() << pid_file(); 
+    arg_buffer << " " << pid_file_option() << pid_file();
   }
 
   assert(daemon_file_option());

--- a/libtest/server.h
+++ b/libtest/server.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/server_container.cc
+++ b/libtest/server_container.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -26,15 +26,15 @@
 #include <cstdlib>
 #include <iostream>
 
-#include <algorithm> 
-#include <functional> 
+#include <algorithm>
+#include <functional>
 #include <locale>
 
-// trim from end 
+// trim from end
 static inline std::string &rtrim(std::string &s)
-{ 
-  s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end()); 
-  return s; 
+{
+  s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+  return s;
 }
 
 namespace libtest {
@@ -179,7 +179,7 @@ bool server_startup(server_startup_st& construct, const std::string& server_type
       {
         Error << "Libgearman was not found";
       }
-    } 
+    }
     else
     {
       Error << "No gearmand binary is available";

--- a/libtest/server_container.h
+++ b/libtest/server_container.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/signal.cc
+++ b/libtest/signal.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -103,7 +103,7 @@ SignalThread::~SignalThread()
 extern "C" {
 
 static void *sig_thread(void *arg)
-{   
+{
   SignalThread *context= (SignalThread*)arg;
 
   context->test();

--- a/libtest/signal.h
+++ b/libtest/signal.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/skiptest.cc
+++ b/libtest/skiptest.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/socket.hpp
+++ b/libtest/socket.hpp
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/stats.h
+++ b/libtest/stats.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/stream.h
+++ b/libtest/stream.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/strerror.cc
+++ b/libtest/strerror.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -21,7 +21,7 @@
 
 #include <libtest/common.h>
 
-namespace libtest { 
+namespace libtest {
 
 const char *test_strerror(test_return_t code)
 {

--- a/libtest/strerror.h
+++ b/libtest/strerror.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/string.hpp
+++ b/libtest/string.hpp
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/test.cc
+++ b/libtest/test.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/test.h
+++ b/libtest/test.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/test.hpp
+++ b/libtest/test.hpp
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/unittest.cc
+++ b/libtest/unittest.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -64,7 +64,7 @@ static test_return_t GDB_COMMAND_test(void *)
 static test_return_t test_success_equals_one_test(void *)
 {
   test_skip(HAVE_LIBMEMCACHED, true);
-#if defined(HAVE_LIBMEMCACHED) && HAVE_LIBMEMCACHED 
+#if defined(HAVE_LIBMEMCACHED) && HAVE_LIBMEMCACHED
   test_zero(MEMCACHED_SUCCESS);
 #endif
   return TEST_SUCCESS;
@@ -208,7 +208,7 @@ static test_return_t _compare_test_return_t_test(void *)
 static test_return_t _compare_memcached_return_t_test(void *)
 {
   test_skip(HAVE_LIBMEMCACHED, true);
-#if defined(HAVE_LIBMEMCACHED) && HAVE_LIBMEMCACHED 
+#if defined(HAVE_LIBMEMCACHED) && HAVE_LIBMEMCACHED
   test_compare(MEMCACHED_SUCCESS, MEMCACHED_SUCCESS);
 #endif
 
@@ -247,7 +247,7 @@ static test_return_t memcached_cycle_test(void *object)
   server_startup_st *servers= (server_startup_st*)object;
   test_true(servers);
 
-  if (MEMCACHED_BINARY and HAVE_LIBMEMCACHED) 
+  if (MEMCACHED_BINARY and HAVE_LIBMEMCACHED)
   {
     test_true(has_memcached_binary());
     const char *argv[1]= { "cycle_memcached" };

--- a/libtest/version.h.in
+++ b/libtest/version.h.in
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/libtest/visibility.h
+++ b/libtest/visibility.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -31,7 +31,7 @@
 #  define LIBTEST_API __global
 #  define LIBTEST_LOCAL __global
 # elif defined(_MSC_VER)
-#  define LIBTEST_API extern __declspec(dllexport) 
+#  define LIBTEST_API extern __declspec(dllexport)
 #  define LIBTEST_LOCAL extern __declspec(dllexport)
 # else
 #  define LIBTEST_API
@@ -46,7 +46,7 @@
 #   define LIBTEST_API __global
 #   define LIBTEST_LOCAL __hidden
 #  elif defined(_MSC_VER)
-#   define LIBTEST_API extern __declspec(dllexport) 
+#   define LIBTEST_API extern __declspec(dllexport)
 #   define LIBTEST_LOCAL
 #  else
 #   define LIBTEST_API
@@ -54,7 +54,7 @@
 #  endif /* defined(HAVE_VISIBILITY) */
 # else  /* defined(BUILDING_LIBTEST) */
 #  if defined(_MSC_VER)
-#   define LIBTEST_API extern __declspec(dllimport) 
+#   define LIBTEST_API extern __declspec(dllimport)
 #   define LIBTEST_LOCAL
 #  else
 #   define LIBTEST_API

--- a/libtest/wait.cc
+++ b/libtest/wait.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -107,7 +107,7 @@ static void options_parse(int argc, char *argv[])
   while (1)
   {
     int option_rv= getopt_long(argc, argv, "Vhvds:", long_options, &option_index);
-    if (option_rv == -1) 
+    if (option_rv == -1)
     {
       break;
     }

--- a/libtest/wait.h
+++ b/libtest/wait.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -28,7 +28,7 @@
 
 namespace libtest {
 
-class Wait 
+class Wait
 {
 public:
 

--- a/tests/atomsmasher.cc
+++ b/tests/atomsmasher.cc
@@ -301,5 +301,5 @@ void get_world(Framework *world)
   world->collection_startup= (test_callback_fn*)world_container_startup;
   world->collection_shutdown= (test_callback_fn*)world_container_shutdown;
 
-  world->set_runner(&defualt_libmemcached_runner);
+  world->set_runner(&default_libmemcached_runner);
 }

--- a/tests/basic.cc
+++ b/tests/basic.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/tests/basic.h
+++ b/tests/basic.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/tests/c_sasl_test.c
+++ b/tests/c_sasl_test.c
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached C sasl test app
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/tests/c_test.c
+++ b/tests/c_test.c
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached C test app
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/tests/cpp_example.cc
+++ b/tests/cpp_example.cc
@@ -60,13 +60,13 @@ public:
 
   Memcache *getCache()
   {
-    /* 
+    /*
      * pick a random element from the vector of clients. Obviously, this is
      * not very random but suffices as an example!
      */
     uint32_t index= rand() % num_of_clients;
     return clients[index];
-  } 
+  }
 
 private:
 
@@ -172,7 +172,7 @@ int main()
   Memcache first_client("127.0.0.1:19191");
   map< string, map<string, string> > my_stats;
   first_client.getStats(my_stats);
-  
+
   /*
    * Iterate through the retrieved stats.
    */

--- a/tests/cycle.cc
+++ b/tests/cycle.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -146,7 +146,7 @@ void get_world(Framework *world)
   world->collection_startup= (test_callback_fn*)world_container_startup;
   world->collection_shutdown= (test_callback_fn*)world_container_shutdown;
 
-  world->set_runner(&defualt_libmemcached_runner);
+  world->set_runner(&default_libmemcached_runner);
   world->set_socket();
 }
 

--- a/tests/debug.cc
+++ b/tests/debug.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached client and server library.
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -54,7 +54,7 @@ static memcached_return_t print_keys_callback(const memcached_st *,
 {
 
   Out << "\t" << key << " (" << key_length << ")";
-  
+
 
   return MEMCACHED_SUCCESS;
 }

--- a/tests/debug.h
+++ b/tests/debug.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached client and server library.
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/tests/deprecated.cc
+++ b/tests/deprecated.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/tests/deprecated.h
+++ b/tests/deprecated.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/tests/error_conditions.cc
+++ b/tests/error_conditions.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/tests/error_conditions.h
+++ b/tests/error_conditions.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/tests/exist.cc
+++ b/tests/exist.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/tests/exist.h
+++ b/tests/exist.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/tests/failure.cc
+++ b/tests/failure.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -225,7 +225,7 @@ void get_world(Framework *world)
   world->collection_startup= (test_callback_fn*)world_container_startup;
   world->collection_shutdown= (test_callback_fn*)world_container_shutdown;
 
-  world->set_runner(&defualt_libmemcached_runner);
+  world->set_runner(&default_libmemcached_runner);
 
   global_framework= world;
 }

--- a/tests/ketama.h
+++ b/tests/ketama.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/tests/libmemcached_world.h
+++ b/tests/libmemcached_world.h
@@ -298,6 +298,6 @@ public:
   }
 };
 
-static LibmemcachedRunner defualt_libmemcached_runner;
+static LibmemcachedRunner default_libmemcached_runner;
 
 #endif /* __TESTS_LIBMEMCACHED_WORLD_H__ */

--- a/tests/mem_functions.cc
+++ b/tests/mem_functions.cc
@@ -12030,7 +12030,7 @@ void get_world(Framework *world)
   world->collection_startup= (test_callback_fn*)world_container_startup;
   world->collection_shutdown= (test_callback_fn*)world_container_shutdown;
 
-  world->set_runner(&defualt_libmemcached_runner);
+  world->set_runner(&default_libmemcached_runner);
 
   world->set_socket();
 }

--- a/tests/mem_udp.cc
+++ b/tests/mem_udp.cc
@@ -508,5 +508,5 @@ void get_world(Framework *world)
   world->collection_startup= (test_callback_fn*)world_container_startup;
   world->collection_shutdown= (test_callback_fn*)world_container_shutdown;
 
-  world->set_runner(&defualt_libmemcached_runner);
+  world->set_runner(&default_libmemcached_runner);
 }

--- a/tests/plus.cpp
+++ b/tests/plus.cpp
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -184,7 +184,7 @@ static test_return_t mget_test(memcached_st *original)
 
   test_true(memc.mget(keys));
 
-  test_compare(MEMCACHED_NOTFOUND, 
+  test_compare(MEMCACHED_NOTFOUND,
                memc.fetch(return_key, return_value));
 
   test_true(memc.setAll(keys, values, 50, 9));
@@ -301,5 +301,5 @@ void get_world(Framework *world)
   world->collection_startup= reinterpret_cast<test_callback_fn*>(world_container_startup);
   world->collection_shutdown= reinterpret_cast<test_callback_fn*>(world_container_shutdown);
 
-  world->set_runner(&defualt_libmemcached_runner);
+  world->set_runner(&default_libmemcached_runner);
 }

--- a/tests/sasl.cc
+++ b/tests/sasl.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -73,7 +73,7 @@ static test_return_t sasl_auth_test(memcached_st *memc)
     test_compare(MEMCACHED_INVALID_ARGUMENTS, memcached_destroy_sasl_auth_data(NULL));
     memcached_quit(memc);
 
-    test_compare(MEMCACHED_AUTH_FAILURE, 
+    test_compare(MEMCACHED_AUTH_FAILURE,
                  memcached_set(memc, "foo", 3, "bar", 3, (time_t)0, (uint32_t)0));
     test_compare(MEMCACHED_SUCCESS, memcached_destroy_sasl_auth_data(memc));
 
@@ -116,7 +116,7 @@ void get_world(Framework *world)
   world->collection_startup= (test_callback_fn*)world_container_startup;
   world->collection_shutdown= (test_callback_fn*)world_container_shutdown;
 
-  world->set_runner(&defualt_libmemcached_runner);
+  world->set_runner(&default_libmemcached_runner);
 
   world->set_sasl("memcached", "memcached");
 }

--- a/tests/server_add.cc
+++ b/tests/server_add.cc
@@ -1,6 +1,6 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
- *  Libmemcached Client and Server 
+ *
+ *  Libmemcached Client and Server
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
  *  All rights reserved.

--- a/tests/server_add.h
+++ b/tests/server_add.h
@@ -1,6 +1,6 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
- *  Libmemcached Client and Server 
+ *
+ *  Libmemcached Client and Server
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
  *  All rights reserved.

--- a/tests/string.cc
+++ b/tests/string.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached client and server library.
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/tests/string.h
+++ b/tests/string.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached client and server library.
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/tests/virtual_buckets.cc
+++ b/tests/virtual_buckets.cc
@@ -1,6 +1,6 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
- *  Libmemcached Client and Server 
+ *
+ *  Libmemcached Client and Server
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
  *  All rights reserved.
@@ -132,7 +132,7 @@ test_return_t virtual_back_map(memcached_st *)
   /* verify the standard ketama set. */
   for (expect_t *ptr= basic_keys; not libtest_string_is_null(ptr->key); ptr++)
   {
-    uint32_t server_idx = memcached_generate_hash(memc, ptr->key.c_str, ptr->key.size); 
+    uint32_t server_idx = memcached_generate_hash(memc, ptr->key.c_str, ptr->key.size);
 
     char buffer[1024];
     snprintf(buffer, sizeof(buffer), "%.*s:%lu Got/Expected %u == %u", (int)ptr->key.size, ptr->key.c_str, (unsigned long)ptr->key.size, server_idx, ptr->server_id);

--- a/tests/virtual_buckets.h
+++ b/tests/virtual_buckets.h
@@ -1,6 +1,6 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
- *  Libmemcached Client and Server 
+ *
+ *  Libmemcached Client and Server
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
  *  All rights reserved.

--- a/util/instance.cc
+++ b/util/instance.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  DataDifferential Utility Library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -240,7 +240,7 @@ bool Instance::run()
       {
         if (not _finish_fn->call(success, response))
         {
-          // Error was sent from _finish_fn 
+          // Error was sent from _finish_fn
           return false;
         }
       }

--- a/util/instance.hpp
+++ b/util/instance.hpp
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  DataDifferential Utility Library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/util/logfile.hpp
+++ b/util/logfile.hpp
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  DataDifferential Utility Library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/util/operation.cc
+++ b/util/operation.cc
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  DataDifferential Utility Library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -60,7 +60,7 @@ bool Operation::response(std::string &arg)
     arg.append(&_response[4], _response.size() -4);
     return false;
   }
-  else 
+  else
   {
     arg.append(&_response[0], _response.size());
   }

--- a/util/operation.hpp
+++ b/util/operation.hpp
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  DataDifferential Utility Library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/util/pidfile.hpp
+++ b/util/pidfile.hpp
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  DataDifferential Utility Library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/util/signal.hpp
+++ b/util/signal.hpp
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  libtest
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/

--- a/util/string.hpp
+++ b/util/string.hpp
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  DataDifferential Utility Library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/


### PR DESCRIPTION
### ⌨️ What I did
- 모든 코드 파일(Document 제외)의 whitespace를 제거합니다.
- 몇몇 오탈자를 수정합니다.

### 🤔 Others
- 이후에 이루어질 개발을 위해 전체적인 withespace 제거가 필요하다고 생각됩니다.
- Docs는 나중에 확인할 예정입니다.