### PR TITLE
DOC: Fix typo in Multi-Threaded Example

### DIFF
--- a/docs/02-arcus-c-client.md
+++ b/docs/02-arcus-c-client.md
@@ -92,7 +92,7 @@ int main(int argc, char** argv)
     // 생성된 자원을 반환한다.
     arcus_pool_close(pool);
     memcached_pool_destroy(pool);
-    memcached_free(mc);
+    memcached_free(master_mc);
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
### ⌨️ What I did
- 예시 문서를 copy & paste 했을 때 발생하는 컴파일 에러를 수정합니다.

```
main.c: In function ‘main’:
main.c:25:20: error: ‘mc’ undeclared (first use in this function)
     memcached_free(mc);
                    ^
main.c:25:20: note: each undeclared identifier is reported only once for each function it appears in
```