### PR TITLE
DOC: Correct typos

### DIFF
--- a/docs/02-arcus-c-client.md
+++ b/docs/02-arcus-c-client.md
@@ -3,7 +3,7 @@
 ARCUS client는 ARCUS admin과 ARCUS cache server군 들과의 연결을 유지하며 client로 들어온 명령을 처리하여 그 결과를 반환한다
 
 ARCUS C client는 C/C++ 개발환경에서 ARCUS를 사용하기 위한 라이브러리로서,
-대표적인 memcached C client인 [libmemcached](https://code.launchpad.net/libmemcached)를 기반으로 개발하였다. 
+대표적인 memcached C client인 [libmemcached](https://code.launchpad.net/libmemcached)를 기반으로 개발하였다.
 따라서 libmemcached의 기능을 대부분 사용할 수 있으며,
 ARCUS cache server에서 제공하는 failover 기능과 collection 기능 등을 추가로 지원한다.
 
@@ -28,23 +28,23 @@ ARCUS cache server에서 제공하는 failover 기능과 collection 기능 등�
   arcus_return_t arcus_connect(memcached_st *mc, const char *ensemble_list, const char *svc_code)
   ```
   싱글 스레드 서버에서 ARCUS에 연결하기 위해 사용한다.
-  
+
 - Multi-Threaded
- 
+
   ```c
-  arcus_return_t arcus_pool_connect(memcached_pool_st *pool, const char *ensemble_list, const char *svc_code) 
+  arcus_return_t arcus_pool_connect(memcached_pool_st *pool, const char *ensemble_list, const char *svc_code)
   ```
 
   멀티 스레드 서버에서 ARCUS에 연결하기 위해 사용한다.
-  
+
 - Multi-Process
 
   ```c
   arcus_return_t arcus_proxy_create(memcached_st *mc, const char *ensemble_list, const char *svc_code)
   arcus_return_t arcus_proxy_connect(memcached_st *mc, memcached_pool_st *pool, memcached_st *proxy)
   ```
- 
-  `arcus_proxy_create` 함수는 
+
+  `arcus_proxy_create` 함수는
   멀티 프로세스 서버의 부모 프로세스가 ARCUS에 연결한 뒤, 자식 프로세스들이 사용할 proxy를 생성하기 위해 사용한다.
   `arcus_proxy_connect` 함수는
   멀티 프로세스 서버의 자식 프로세스에서 부모 프로세스가 생성한 proxy에 연결하기 위해 사용한다.
@@ -169,7 +169,7 @@ static inline void process_child(memcached_st *proxy_mc)
     arcus_proxy_connect(per_child_mc, pool, proxy_mc);
 
     if (!pool) {
-        fprintf(stderr, "memcahed_pool_create: failed\n");
+        fprintf(stderr, "memcached_pool_create: failed\n");
         goto RETURN;
     }
 
@@ -249,7 +249,7 @@ RELEASE:
 ### 로그 남기기
 
 ARCUS C client는 ARCUS admin과의 연결 상태 및 ARCUS cache server 리스트의 변경 사항에 대해 로그를 남긴다.
-로그는 ZooKeeper client에 내장된 로깅 API를 사용하고 있으며 기본적으로 표준 에러(stderr )로 출력된다.
+로그는 ZooKeeper client에 내장된 로깅 API를 사용하고 있으며 기본적으로 표준 에러(stderr)로 출력된다.
 ARCUS cache server 리스트 변경에 대한 로그는 문제 상황 발생 시 귀중한 힌트가 될 수 있으므로
 별도의 파일로 남기는 것을 추천한다.
 
@@ -286,7 +286,7 @@ const char *memcached_detail_error_message(memcached_st *mc, memcached_return_t 
     - mc_id : 서로다른 mc를 구분하기 위해 사용하는 구분자로, mc 생성마다 1 씩 증가하는 값
     - mc_qid : mc가 현재 수행하는 operation의 query id
     - er_qid : error message를 생성한 operation의 query id
-    - error mssage : 실제 오류 원인이 되는 error message string
+    - error message : 실제 오류 원인이 되는 error message string
 
 위 API는 아래와 같은 방법으로 사용이 가능하며,
 정확한 오류 출력을 위해 `memcached_detail_error_message(memcached_st *mc, memcached_return_t rc)`의 사용을 추천한다.
@@ -336,7 +336,7 @@ ARCUS의 admin인 ZooKeeper에 의해 failed 캐시 노드로 감지되어 cache
 
 그리고, 정상적으로 연결되지 않은 캐시 노드로의 요청에 대해서는
 MEMCACHED_SERVER_TEMPORARILY_DISABLED (“SERVER HAS FAILED AND IS DISABLED UNTIL TIMED RETRY”) 오류가 발생한다.
- 
+
 ### 캐시 API의 응답코드 확인
 
 캐시 명령을 실행한 후에 캐시 서버로부터 받은 응답 코드를 확인할 수 있다.

--- a/docs/04-list-API.md
+++ b/docs/04-list-API.md
@@ -133,7 +133,7 @@ memcached_lop_insert(memcached_st *ptr,
 - index: list index (0-based index)
   - 0, 1, 2, ... : list의 앞에서 시작하여 각 element 위치를 나타냄
   - -1, -2, -3, ... : list의 뒤에서 시작하여 각 element 위치를 나타냄
-- value, value_lenth: 삽입할 element의 value
+- value, value_length: 삽입할 element의 value
 - attributes: List 없을 시에 attributes에 따라 empty list를 생성 후에 element 삽입한다.
 
 Response code는 아래와 같다.
@@ -204,7 +204,7 @@ memcached_lop_delete(memcached_st *ptr,
   - -1, -2, -3, ... : list의 뒤에서 시작하여 각 element 위치를 나타냄
 - drop_if_empty: element 삭제로 empty list가 될 경우, 그 list도 삭제할 것인지를 지정
 
-둘째, list index range로 다수의 element를 삭제하는 함수이다.
+둘째, list index range로 다수의 elements를 삭제하는 함수이다.
 
 ``` c
 memcached_return_t
@@ -287,7 +287,7 @@ memcached_lop_get(memcached_st *ptr,
 - drop_if_empty: element 삭제로 empty list가 될 경우, 그 list도 삭제할 것인지를 지정
 
 
-둘째, list index range로 다수의 element를 조회하는 함수이다.
+둘째, list index range로 다수의 elements를 조회하는 함수이다.
 
 ``` c
 memcached_return_t
@@ -353,7 +353,7 @@ void arcus_list_element_get(memcached_st *memc)
     memcached_return_t rc;
     memcached_coll_result_st *result;
 
-    for (uint32_t i=0; i<maxcount; i++)    {
+    for (uint32_t i=0; i<maxcount; i++) {
         char buffer[15];
         size_t buffer_len= snprintf(buffer, 15, "value%d", i);
         rc= memcached_lop_insert(memc, "a_list", strlen("a_list"), i,
@@ -394,15 +394,15 @@ void arcus_list_element_get(memcached_st *memc)
 
 ## List Element 일괄 삽입
 
-List에 여러 element를 한번에 삽입하는 함수는 두 가지가 있다.
+List에 여러 elements를 한번에 삽입하는 함수는 두 가지가 있다.
 
-첫째, 하나의 key가 가리키는 list에 다수의 element를 삽입하는 함수이다.
+첫째, 하나의 key가 가리키는 list에 다수의 elements를 삽입하는 함수이다.
 
 ``` c
 memcached_return_t
 memcached_lop_piped_insert(memcached_st *ptr,
                            const char *key, const size_t key_length,
-                           const size_t numr_of_piped_items,
+                           const size_t number_of_piped_items,
                            const int32_t *indexes,
                            const char * const *values, const size_t *values_length,
                            memcached_coll_create_attrs_st *attributes,
@@ -411,10 +411,10 @@ memcached_lop_piped_insert(memcached_st *ptr,
 ```
 
 - key, key_length: 하나의 key를 지정
-- numr_of_piped_items: 한번에 삽입할 element 개수
+- number_of_piped_items: 한번에 삽입할 element 개수
 - indexes: list index array (0-based index)
 - values, values_length: 다수 element 각각의 value와 그 길이
-- attributes: 해당 list가 없을 시에, attrbiutes에 따라 list를 생성 후에 삽입한다.
+- attributes: 해당 list가 없을 시에, attributes에 따라 list를 생성 후에 삽입한다.
 
 둘째, 여러 key들이 가리키는 list들에 각각 하나의 element를 삽입하는 함수이다.
 
@@ -430,11 +430,11 @@ memcached_lop_piped_insert_bulk(memcached_st *ptr,
                                 memcached_return_t *piped_rc)
 ```
 
-- keys, keys_length: 다수 key들을 지정
+- keys, key_length: 다수 key들을 지정
 - number_of_keys: key들의 수
 - index: list index (0-based index)
 - value, value_length: 각 list에 삽입할 element의 value와 그 길이
-- attributes: 해당 list가 없을 시에, attrbiutes에 따라 list를 생성 후에 삽입한다.
+- attributes: 해당 list가 없을 시에, attributes에 따라 list를 생성 후에 삽입한다.
 
 List element 일괄 삽입의 결과는 아래의 인자를 통해 받는다.
 

--- a/docs/05-set-API.md
+++ b/docs/05-set-API.md
@@ -9,7 +9,7 @@ Set item은 하나의 key에 대해 unique value의 집합을 저장한다. 주�
 
 Set item에 수행 가능한 기본 연산들은 다음과 같다.
 
-- [Set Item 생성](05-set-API.md#set-item-%EC%83%9D%EC%84%B1) (Set item 삭제는 key-value item 삭제 함수로 수행한다) 
+- [Set Item 생성](05-set-API.md#set-item-%EC%83%9D%EC%84%B1) (Set item 삭제는 key-value item 삭제 함수로 수행한다)
 - [Set Element 삽입](05-set-API.md#set-element-%EC%82%BD%EC%9E%85)
 - [Set Element 삭제](05-set-API.md#set-element-%EC%82%AD%EC%A0%9C)
 - [Set Element 존재 여부 확인](05-set-API.md#set-element-존재-여부-확인)
@@ -305,7 +305,7 @@ void arcus_set_element_exist(memcached_st *memc)
 
 ## Set Element 조회
 
-Set element를 조회하는 함수이다. 이 함수는 임의의 count 개 element를 조회한다.
+Set element를 조회하는 함수이다. 이 함수는 임의의 count 개 elements를 조회한다.
 
 ``` c
 memcached_return_t
@@ -383,7 +383,7 @@ void arcus_set_element_get(memcached_st *memc)
                              &attributes);
     assert(MEMCACHED_SUCCESS == rc);
 
-    result = memcached_coll_result_create(memc, NULL);
+    memcached_coll_result_st *result = memcached_coll_result_create(memc, NULL);
 
     rc= memcached_sop_get(memc, "an_empty_set", strlen("an_empty_set"),
                           maxcount, false, false, result);
@@ -408,44 +408,44 @@ void arcus_set_element_get(memcached_st *memc)
 
 ## Set Element 일괄 삽입
 
-Set에 여러 element를 한번에 삽입하는 함수는 두 가지가 있다.
+Set에 여러 elements를 한번에 삽입하는 함수는 두 가지가 있다.
 
-첫째, 하나의 key가 가리키는 set에 다수의 element를 삽입하는 함수이다.
+첫째, 하나의 key가 가리키는 set에 다수의 elements를 삽입하는 함수이다.
 
 ``` c
 memcached_return_t
 memcached_sop_piped_insert(memcached_st *ptr,
                            const char *key, const size_t key_length,
-                           const size_t num_of_piped_items,
+                           const size_t number_of_piped_items,
                            const char * const *values, const size_t *values_length,
                            memcached_coll_create_attrs_st *attributes,
                            memcached_return_t *results,
-                           memcached_return_t *piped_rc) 
+                           memcached_return_t *piped_rc)
 ```
 
 - key, key_length: 하나의 key를 지정
-- numr_of_piped_items: 한번에 삽입할 element 개수
+- number_of_piped_items: 한번에 삽입할 element 개수
 - values, values_length: 다수 element 각각의 value와 그 길이
 - attributes: 해당 set이 없을 시에, attributes에 따라 set을 생성 후에 삽입한다.
 
-둘째, 여러 key들이 가리키는 set들에 각각 하나의 element를 삽입하는 함수이다. 
+둘째, 여러 key들이 가리키는 set들에 각각 하나의 element를 삽입하는 함수이다.
 
 ``` c
 memcached_return_t
 memcached_sop_piped_insert_bulk(memcached_st *ptr,
                                 const char * const *keys,
-                                const size_t *keys_length,
-                                const size_t num_of_keys,
+                                const size_t *key_length,
+                                const size_t number_of_keys,
                                 const char *value, size_t value_length,
                                 memcached_coll_create_attrs_st *attributes,
                                 memcached_return_t *results,
                                 memcached_return_t *piped_rc)
 ```
 
-- keys, keys_length: 다수 key들을 지정
-- numr_of_keys: key들의 수
+- keys, key_length: 다수 key들을 지정
+- number_of_keys: key들의 수
 - values, values_length: 각 set에 삽입할 element의 value와 그 길이
-- attributes: 해당 set이 없을 시에, attrbiutes에 따라 set을 생성 후에 삽입한다.
+- attributes: 해당 set이 없을 시에, attributes에 따라 set을 생성 후에 삽입한다.
 
 Set element 일괄 삽입의 결과는 아래의 인자를 통해 받는다.
 
@@ -507,7 +507,7 @@ void arcus_set_element_piped_insert(memcached_st *memc)
 
 ## Set Element 일괄 존재 여부 확인
 
-Set에서 여러 element의 존재 여부를 한번에 확인하는 함수이다.
+Set에서 여러 elements의 존재 여부를 한번에 확인하는 함수이다.
 
 ``` c
 memcached_return_t
@@ -520,7 +520,7 @@ memcached_sop_piped_exist(memcached_st *ptr,
 ```
 
 - key, key_length: 하나의 key를 지정
-- numr_of_piped_items: 한번에 확인할 element 개수
+- number_of_piped_items: 한번에 확인할 element 개수
 - values, values_length: 각 element의 value와 길이
 
 Set element 일괄 존재 여부 확인의 결과는 아래의 인자를 통해 받는다.

--- a/docs/06-map-API.md
+++ b/docs/06-map-API.md
@@ -166,7 +166,7 @@ void arcus_map_element_insert(memcached_st *memc)
     assert(MEMCACHED_CREATED_STORED == memcached_get_last_response_code(memc));
 
     // 2. STORED
-    rc= memcached_mop_insert(memc, "a_map", strlen("a_map"), "mkey1", strlne("mkey1"),
+    rc= memcached_mop_insert(memc, "a_map", strlen("a_map"), "mkey1", strlen("mkey1"),
                              "value", strlen("value"), &attributes);
     assert(MEMCACHED_SUCCESS == rc);
     assert(MEMCACHED_STORED == memcached_get_last_response_code(memc));
@@ -175,7 +175,7 @@ void arcus_map_element_insert(memcached_st *memc)
     rc= memcached_mop_insert(memc, "a_map", strlen("a_map"), "mkey1", strlen("mkey1"),
                              "value", strlen("value"), &attributes);
     assert(MEMCACHED_SUCCESS != rc);
-    assert(MEMCACHED_ELEMENT_EXIST == rc);
+    assert(MEMCACHED_ELEMENT_EXISTS == rc);
 }
 ```
 
@@ -225,7 +225,7 @@ void arcus_map_element_update(memcached_st *memc)
     assert(MEMCACHED_CREATED_STORED == memcached_get_last_response_code(memc));
 
     // 2. UPDATED
-    rc= memcached_mop_update(memc, "a_map", strlen("a_map"), "mkey", strlne("mkey"),
+    rc= memcached_mop_update(memc, "a_map", strlen("a_map"), "mkey", strlen("mkey"),
                              "new_value", strlen("new_value"));
     assert(MEMCACHED_SUCCESS == rc);
     assert(MEMCACHED_UPDATED == memcached_get_last_response_code(memc));
@@ -391,7 +391,7 @@ Map element를 조회하는 예제는 아래와 같다.
 void arcus_map_element_get(memcached_st *memc)
 {
     uint32_t flags= 10;
-    uint32_t exptime= 600; 
+    uint32_t exptime= 600;
     uint32_t maxcount= 1000;
 
     memcached_coll_create_attrs_st attributes;
@@ -399,7 +399,7 @@ void arcus_map_element_get(memcached_st *memc)
     memcached_return_t rc;
     memcached_coll_result_st *result;
 
-    for (uint32_t i=0; i<maxcount; i++)    { 
+    for (uint32_t i=0; i<maxcount; i++) {
         char mkey[15];
         char buffer[15];
         size_t mkey_len = snprintf(mkey, 15, "mkey%d", i);
@@ -456,15 +456,15 @@ void arcus_map_element_get(memcached_st *memc)
 
 ## Map Element 일괄 삽입
 
-Map에 여러 element를 한번에 삽입하는 함수는 두 가지가 있다.
+Map에 여러 elements를 한번에 삽입하는 함수는 두 가지가 있다.
 
-첫째, 하나의 key가 가리키는 map에 다수의 element를 삽입하는 함수이다.
+첫째, 하나의 key가 가리키는 map에 다수의 elements를 삽입하는 함수이다.
 
 ``` c
 memcached_return_t
 memcached_mop_piped_insert(memcached_st *ptr,
                            const char *key, const size_t key_length,
-                           const size_t numr_of_piped_items,
+                           const size_t number_of_piped_items,
                            const char * const *mkeys, const size_t *mkeys_length,
                            const char * const *values, const size_t *values_length,
                            memcached_coll_create_attrs_st *attributes,
@@ -473,19 +473,19 @@ memcached_mop_piped_insert(memcached_st *ptr,
 ```
 
 - key, key_length: 하나의 key를 지정
-- numr_of_piped_items: 한번에 삽입할 element 개수
+- number_of_piped_items: 한번에 삽입할 element 개수
 - mkeys, mkeys_length: 다수 element 각각의 mkey와 그 길이
 - values, values_length: 다수 element 각각의 value와 그 길이
-- attributes: 해당 map이 없을 시에, attrbiutes에 따라 map을 생성 후에 삽입한다.
+- attributes: 해당 map이 없을 시에, attributes에 따라 map을 생성 후에 삽입한다.
 
-둘째, 여러 key들이 가리키는 map들에 각각 하나의 element를 삽입하는 함수이다. 
+둘째, 여러 key들이 가리키는 map들에 각각 하나의 element를 삽입하는 함수이다.
 
 ``` c
 memcached_return_t
 memcached_mop_piped_insert_bulk(memcached_st *ptr,
                                 const char * const *keys,
-                                const size_t *keys_length,
-                                const size_t numr_of_keys,
+                                const size_t *key_length,
+                                const size_t number_of_keys,
                                 const char *mkey, size_t mkey_length,
                                 const char *value, size_t value_length,
                                 memcached_coll_create_attrs_st *attributes,
@@ -493,11 +493,11 @@ memcached_mop_piped_insert_bulk(memcached_st *ptr,
                                 memcached_return_t *piped_rc)
 ```
 
-- keys, keys_length: 다수 key들을 지정
-- numr_of_keys: key들의 수
+- keys, key_length: 다수 key들을 지정
+- number_of_keys: key들의 수
 - mkey, mkey_length: element의 mkey
 - value, value_length: element의 value
-- attributes: 해당 map이 없을 시에, attrbiutes에 따라 map을 생성 후에 삽입한다.
+- attributes: 해당 map이 없을 시에, attributes에 따라 map을 생성 후에 삽입한다.
 
 Map element 일괄 삽입의 결과는 아래의 인자를 통해 받는다.
 
@@ -559,7 +559,7 @@ void arcus_map_element_piped_insert(memcached_st *memc)
     for (uint32_t i=0; i<maxcount; i++)
     {
         free((void *)mkeys[i]);
-        free((void *)values[i]);    
+        free((void *)values[i]);
     }
     free((void *)mkeys);
     free((void *)values);

--- a/docs/08-attribute-API.md
+++ b/docs/08-attribute-API.md
@@ -51,7 +51,7 @@ memcached_coll_attrs_set_maxbkeyrange_by_byte(memcached_coll_attrs_st *attrs,
 memcached_return_t
 memcached_coll_attrs_set_readable(memcached_coll_attrs_st *attrs)
 ```
-- memcached_coll_attrs_init : memcached_coll_sttrs_st 구초체를 초기화한다.
+- memcached_coll_attrs_init : memcached_coll_attrs_st 구초체를 초기화한다.
 - memcached_coll_attrs_set_flags : 변경할 Flag 값을 설정한다.
 - memcached_coll_attrs_set_expiretime : 변경할 Expire time 값을 설정한다.
 - memcached_coll_attrs_set_overflowaction : 변경할 Overflowaction을 설정한다.

--- a/docs/arcus-c-client-user-guide.md
+++ b/docs/arcus-c-client-user-guide.md
@@ -57,7 +57,7 @@ ARCUS C Client User Guide
   - [B+Tree 순위 기반의 Element 조회](07-btree-API.md#btree-순위-기반의-element-조회)
   - [B+Tree 순위와 Element 동시 조회](07-btree-API.md#btree-순위와-element-동시-조회)
 
-- [Item Attribue 연산](08-attribute-API.md)
+- [Item Attribute 연산](08-attribute-API.md)
   - [Attribute 변경](08-attribute-API.md#attribute-%EB%B3%80%EA%B2%BD)
   - [Attribute 조회](08-attribute-API.md#attribute-%EC%A1%B0%ED%9A%8C)
 - [그 외 연산](09-other-API.md)


### PR DESCRIPTION
### ⌨️ What I did
- DOCS 내 오탈자를 제거합니다.
- 일부 API와 DOCS와 변수명이 다른 것에 대해서는 유지했습니다.
  - ex) response → result
  - 추후에 코드 변수명을 변경할 지 Docs를 수정할 지는 고려해야 할 것 같습니다.