### PR TITLE
FEATURE: Add multi store APIs

### DIFF
--- a/libmemcached/memcached.cc
+++ b/libmemcached/memcached.cc
@@ -176,6 +176,7 @@ static inline bool _memcached_init(memcached_st *self)
   self->configure.filename= NULL;
 
   self->flags.piped= false;
+  self->flags.bulk= false;
 #ifdef LIBMEMCACHED_WITH_ZK_INTEGRATION
   self->server_manager= NULL;
   self->logfile= NULL;

--- a/libmemcached/memcached.h
+++ b/libmemcached/memcached.h
@@ -136,6 +136,7 @@ struct memcached_st {
     bool no_block:1; // Don't block
     bool no_reply:1;
     bool piped:1;
+    bool bulk:1;
     bool randomize_replica_read:1;
     bool support_cas:1;
     bool tcp_nodelay:1;

--- a/libmemcached/storage.h
+++ b/libmemcached/storage.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -128,6 +128,54 @@ memcached_return_t memcached_cas_by_key(memcached_st *ptr,
                                         time_t expiration,
                                         uint32_t flags,
                                         uint64_t cas);
+
+LIBMEMCACHED_API
+memcached_return_t memcached_set_bulk(memcached_st *ptr,
+                                      const char * const *keys, const size_t *key_length,
+                                      size_t number_of_keys,
+                                      const char * const *values, const size_t *value_length,
+                                      time_t *expirations, uint32_t flags,
+                                      memcached_return_t *results);
+
+LIBMEMCACHED_API
+memcached_return_t memcached_add_bulk(memcached_st *ptr,
+                                      const char * const *keys, const size_t *key_length,
+                                      size_t number_of_keys,
+                                      const char * const *values, const size_t *value_length,
+                                      time_t *expirations, uint32_t flags,
+                                      memcached_return_t *results);
+
+LIBMEMCACHED_API
+memcached_return_t memcached_replace_bulk(memcached_st *ptr,
+                                      const char * const *keys, const size_t *key_length,
+                                      size_t number_of_keys,
+                                      const char * const *values, const size_t *value_length,
+                                      time_t *expirations, uint32_t flags,
+                                      memcached_return_t *results);
+
+LIBMEMCACHED_API
+memcached_return_t memcached_prepend_bulk(memcached_st *ptr,
+                                      const char * const *keys, const size_t *key_length,
+                                      size_t number_of_keys,
+                                      const char * const *values, const size_t *value_length,
+                                      time_t *expirations, uint32_t flags,
+                                      memcached_return_t *results);
+
+LIBMEMCACHED_API
+memcached_return_t memcached_append_bulk(memcached_st *ptr,
+                                      const char * const *keys, const size_t *key_length,
+                                      size_t number_of_keys,
+                                      const char * const *values, const size_t *value_length,
+                                      time_t *expirations, uint32_t flags,
+                                      memcached_return_t *results);
+
+LIBMEMCACHED_API
+memcached_return_t memcached_cas_bulk(memcached_st *ptr,
+                                      const char * const *keys, const size_t *key_length,
+                                      size_t number_of_keys,
+                                      const char * const *values, const size_t *value_length,
+                                      time_t *expirations, uint32_t flags, uint64_t *cas,
+                                      memcached_return_t *results);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### 🔗 Related Issue
- jam2in/arcus-works#589

### ⌨️ What I did
- store 관련 bulk 명령어 수행을 추가합니다.
  - `set`, `add`, `replace`, `append`, `prepend`, `cas`
  - store 관련 명령어 send 과정에서 response를 나중에 한번에 처리하는 `memcached_send_bulk`를 추가합니다.

### 🤔 Others
- delete, incr, decr 관련 multi 명령어는 store가 아닌 다른 모듈에 있어 별도의 PR로 올릴 예정입니다.
- Memcached::Fast::Safe 에서 flag 값은 모두 0으로 설정되는 것을 확인했습니다.
  - bulk 명령어 내 모든 명령은 모두 동일한 플래그값을 갖습니다.
