### PR TITLE
INTERNAL: Make `devtools/maketags.sh` not ignorable by git.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ tests/memstat
 tests/sasl
 unittests/unittests
 devtools/*
+!devtools/maketags.sh


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- devtools/maketags.sh 파일은 커밋 이력으로 보아 필요한 파일로 추정되지만 gitignore에서는 devtools 내의 모든 파일을 무시하도록 되어 있다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- gitignore에서 devtools/maketags.sh 파일을 무시하지 않도록 합니다.