### PR TITLE
TEST: Cancel previous CI when PR or branch is pushed.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
       branches: [ "develop" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
> <img width="468" alt="image" src="https://github.com/naver/arcus-java-client/assets/51937838/7f66cf78-14f7-4fc4-929f-e78e65b46b27">
>
> 동일한 PR 혹은 브랜치에 새로 커밋이 Push 되었을 때, 이전에 CI가 돌아가는 중이었다면 이전 CI를 자동으로 취소합니다.

- https://github.com/naver/arcus-java-client/pull/696