### PR TITLE
FIX: Exclude tests/storage.h during installation

### DIFF
--- a/tests/include.am
+++ b/tests/include.am
@@ -39,6 +39,7 @@ noinst_HEADERS+= \
 		 tests/print.h \
 		 tests/replication.h \
 		 tests/server_add.h \
+		 tests/storage.h \
 		 tests/string.h \
 		 tests/virtual_buckets.h
 


### PR DESCRIPTION
### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 현재 Make install 시 tests/storage.h가 포함됩니다.
- `noinst_HEADERS`에 지정되지 않는 경우 make dist를 통한 tar.gz 생성 시 해당 헤더 파일이 포함되지 않아 추가했습니다.

