### PR TITLE
FIX: Use `__linux__` instead of `TARGET_OS_LINUX` to check if the current OS is Linux.

### DIFF
--- a/libmemcached/connect.cc
+++ b/libmemcached/connect.cc
@@ -82,7 +82,7 @@ static memcached_return_t connect_poll(memcached_server_st *server)
     default: // A real error occurred and we need to completely bail
       switch (get_socket_errno())
       {
-#ifdef TARGET_OS_LINUX
+#ifdef __linux__
       case ERESTART:
 #endif
       case EINTR:

--- a/libmemcached/io.cc
+++ b/libmemcached/io.cc
@@ -125,7 +125,7 @@ static bool repack_input_buffer(memcached_server_write_instance_st ptr)
 #ifdef USE_EAGAIN
           case EAGAIN:
 #endif
-#ifdef TARGET_OS_LINUX
+#ifdef __linux__
           case ERESTART:
 #endif
             break; // No IO is fine, we can just move on
@@ -266,7 +266,7 @@ static memcached_return_t io_wait(memcached_server_write_instance_st ptr,
       WATCHPOINT_ERRNO(get_socket_errno());
       switch (get_socket_errno())
       {
-#ifdef TARGET_OS_LINUX
+#ifdef __linux__
       case ERESTART:
 #endif
       case EINTR:
@@ -476,7 +476,7 @@ static memcached_return_t _io_fill(memcached_server_write_instance_st ptr)
 #ifdef USE_EAGAIN
       case EAGAIN:
 #endif
-#ifdef TARGET_OS_LINUX
+#ifdef __linux__
       case ERESTART:
 #endif
         if (memcached_success(io_wait(ptr, MEM_READ)))
@@ -603,7 +603,7 @@ memcached_return_t memcached_io_slurp(memcached_server_write_instance_st ptr)
 #ifdef USE_EAGAIN
       case EAGAIN:
 #endif
-#ifdef TARGET_OS_LINUX
+#ifdef __linux__
       case ERESTART:
 #endif
         if (memcached_success(io_wait(ptr, MEM_READ)))

--- a/libmemcached/memcached.h
+++ b/libmemcached/memcached.h
@@ -105,7 +105,7 @@
 #include <libmemcached/version.h>
 #include <libmemcached/sasl.h>
 #ifdef LIBMEMCACHED_WITH_ZK_INTEGRATION
-#ifdef TARGET_OS_LINUX
+#ifdef __linux__
 #include <linux/limits.h>
 #endif
 #ifndef PATH_MAX


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `TARGET_OS_LINUX`는 configure 과정에서 정의하는 변수입니다.
- `__linux__`는 Linux 머신에 설치된 GCC가 정의하는 변수이고, 이를 사용하는 것이 더 일반적입니다.
  - https://stackoverflow.com/a/4605893
  - https://github.com/cpredef/predef/blob/374dfcc5581db7c968e794f05129a996acd033b2/OperatingSystems.md#linux-kernel