### PR TITLE
DOC: Fix an incorrect description of expiration in the delete API

### DIFF
--- a/docs/03-key-value-API.md
+++ b/docs/03-key-value-API.md
@@ -141,5 +141,5 @@ memcached_delete(memcached_st *ptr,
 ```
 
 주어진 key를 삭제한다.
-expiration 값이 0 이상으로 지정되면 key는 expiration 초 이후에 삭제된다.
+expiration은 현재 지원하지 않으며, 0을 값으로 주어야 한다.
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- jam2in/arcus-works#607

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 문서 내 delete API의 잘못된 내용을 수정합니다.
- 추후에는 expiration을 가변 인자로 변경하는 것도 고려해볼 수 있을 것 같습니다.
