### PR TITLE
FIX: Read response for `BINARY_CMD_SASL_LIST_MECHS`

### DIFF
--- a/libmemcached/response.cc
+++ b/libmemcached/response.cc
@@ -582,6 +582,16 @@ static memcached_return_t binary_read_one_response(memcached_server_write_instan
       break;
 
     case PROTOCOL_BINARY_CMD_SASL_LIST_MECHS:
+      {
+        if (header.response.keylen || bodylen + 1 > buffer_length) {
+          return MEMCACHED_UNKNOWN_READ_FAILURE;
+        } else {
+          if ((rc = memcached_safe_read(ptr, buffer, bodylen)) != MEMCACHED_SUCCESS) {
+            return MEMCACHED_UNKNOWN_READ_FAILURE;
+          }
+        }
+      }
+      break;
     case PROTOCOL_BINARY_CMD_VERSION:
       {
         char version_buffer[32];


### PR DESCRIPTION
### ⌨️ What I did
- `binary_read_one_response`에서 `PROTOCOL_BINARY_CMD_SASL_LIST_MECHS`에 대한 로직을 구현합니다.
- https://github.com/awesomized/libmemcached/commit/6852ee197af0a3887c458a6d1bac58764b1d691b 와 동일한 구현입니다.
