### PR TITLE
FIX: Check dependencies in the prefix path before the default path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -208,7 +208,7 @@ if test "x$enable_zk_integration" = "xyes"; then
     saved_LDFLAGS="$LDFLAGS"
     saved_CPPFLAGS="$CPPFLAGS"
     zk_found=no
-    for zkdir in $tryzookeeperdir "" $prefix /usr/local ; do
+    for zkdir in $tryzookeeperdir $prefix "" /usr/local ; do
       LDFLAGS="$saved_LDFLAGS"
       LIBS="$saved_LIBS -lzookeeper_mt"
 


### PR DESCRIPTION
### 🔗 Related Issue
- naver/arcus-memcached#699

### ⌨️ What I did
- system path보다 prefix 경로에 설치된 의존성을 우선 탐색하도록 합니다.
