### PR TITLE
INTERNAL: Add a success case for 'NOT_EXIST' in the exist API

### DIFF
--- a/libmemcached/collection.cc
+++ b/libmemcached/collection.cc
@@ -2889,7 +2889,7 @@ static memcached_return_t do_coll_exist(memcached_st *ptr,
       rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
       memcached_set_last_response_code(ptr, rc);
 
-      if (rc == MEMCACHED_EXIST)
+      if (rc == MEMCACHED_EXIST or rc == MEMCACHED_NOT_EXIST)
       {
         rc= MEMCACHED_SUCCESS;
       }

--- a/tests/mem_functions.cc
+++ b/tests/mem_functions.cc
@@ -7356,11 +7356,15 @@ static test_return_t arcus_1_6_set_exist(memcached_st *memc)
 
   // 3. NOT_EXIST
   rc= memcached_sop_exist(memc, test_literal_param("set:a_set"), test_literal_param("no_value"));
-  test_true_got(rc == MEMCACHED_NOT_EXIST, memcached_strerror(NULL, rc));
+  test_true_got(rc == MEMCACHED_SUCCESS, memcached_strerror(NULL, rc));
+  test_true_got(memcached_get_last_response_code(memc) == MEMCACHED_NOT_EXIST,
+                memcached_strerror(NULL, memcached_get_last_response_code(memc)));
 
   // 4. EXIST
   rc= memcached_sop_exist(memc, test_literal_param("set:a_set"), test_literal_param("value"));
   test_true_got(rc == MEMCACHED_SUCCESS, memcached_strerror(NULL, rc));
+  test_true_got(memcached_get_last_response_code(memc) == MEMCACHED_EXIST,
+                memcached_strerror(NULL, memcached_get_last_response_code(memc)));
 
   return TEST_SUCCESS;
 }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- #321
- #181 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- exist API에서 MEMCACHED_NOT_EXIST를 성공적인 경우로 변경합니다.
- 사용자는 memcached_get_last_response_code API를 통해 존재 여부를 확인할 수 있습니다.
