### PR TITLE
INTERNAL: Increase the cursor_active even in non-successful situations

### DIFF
--- a/libmemcached/response.cc
+++ b/libmemcached/response.cc
@@ -255,12 +255,12 @@ static void textual_switchover_peer_check(memcached_server_write_instance_st ins
   if (str_length < buf_length) {
     /* OK */
     memcpy(instance->switchover_peer, startptr, str_length);
-    instance->switchover_peer[str_length]= '\0'; 
+    instance->switchover_peer[str_length]= '\0';
     instance->switchover_sidx= -1; /* undefined */
   } else {
     /* something is wrong */
     memcpy(instance->switchover_peer, startptr, buf_length-1);
-    instance->switchover_peer[buf_length-1]= '\0'; 
+    instance->switchover_peer[buf_length-1]= '\0';
     instance->switchover_sidx= 1; /* set first slave */
   }
 }
@@ -1563,13 +1563,9 @@ static memcached_return_t textual_read_one_coll_response(memcached_server_write_
   case 'V':
     if (memcmp(buffer, "VALUE", 5) == 0)
     {
-      rc= textual_coll_value_fetch(ptr, buffer, result);
-      if (rc == MEMCACHED_SUCCESS)
-      {
-        /* We add back in one to search for END or next VALUE */
-        memcached_server_response_increment(ptr);
-      }
-      return rc;
+      /* We add back in one to search for END or next VALUE */
+      memcached_server_response_increment(ptr);
+      return textual_coll_value_fetch(ptr, buffer, result);
     }
     break;
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- jam2in/arcus-works#652

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 서버로부터 받은 response 코드에서 VALUE 라인을 파싱할 때, 성공/실패 상관없이 무조건 cursor_active를 증가하도록 변경합니다.
  - 서버에서 보내는 response 코드는 VALUE 라인이 응답의 마지막이 되는 경우가 없으며, END 라인을 보내어 마지막을 알려줍니다.
  - `NOTFOUND` / `OUT_OF_RANGE` 가 아닌 `PROTOCOL_ERROR`, `MEMCACHED_PARTIAL_READ` 에러가 발생하는 경우, reconnect가 되어 문제는 없을 것으로 보입니다.
