### PR TITLE
INTERNAL: Rename update_filter to eflag_update

### DIFF
--- a/libmemcached/collection.cc
+++ b/libmemcached/collection.cc
@@ -4989,11 +4989,11 @@ memcached_return_t memcached_coll_eflag_filter_set_bitwise(memcached_coll_eflag_
   return MEMCACHED_SUCCESS;
 }
 
-/* memcached_coll_update_filter_st */
+/* memcached_coll_eflag_update_st */
 
-memcached_return_t memcached_coll_update_filter_init(memcached_coll_update_filter_st *ptr,
-                                                     const unsigned char *fvalue,
-                                                     const size_t fvalue_length)
+memcached_return_t memcached_coll_eflag_update_init(memcached_coll_eflag_update_st *ptr,
+                                                    const unsigned char *fvalue,
+                                                    const size_t fvalue_length)
 {
   if (not ptr)
   {
@@ -5015,9 +5015,9 @@ memcached_return_t memcached_coll_update_filter_init(memcached_coll_update_filte
   return MEMCACHED_SUCCESS;
 }
 
-memcached_return_t memcached_coll_update_filter_set_bitwise(memcached_coll_update_filter_st *ptr,
-                                                            const size_t fwhere,
-                                                            memcached_coll_bitwise_t bitwise_op)
+memcached_return_t memcached_coll_eflag_update_set_bitwise(memcached_coll_eflag_update_st *ptr,
+                                                           const size_t fwhere,
+                                                           memcached_coll_bitwise_t bitwise_op)
 {
   if (not ptr)
   {
@@ -5035,6 +5035,22 @@ memcached_return_t memcached_coll_update_filter_set_bitwise(memcached_coll_updat
   ptr->bitwise.op = bitwise_op;
 
   return MEMCACHED_SUCCESS;
+}
+
+// DEPRECATED
+memcached_return_t memcached_coll_update_filter_init(memcached_coll_update_filter_st *ptr,
+                                                     const unsigned char *fvalue,
+                                                     const size_t fvalue_length)
+{
+  return memcached_coll_eflag_update_init(ptr, fvalue, fvalue_length);
+}
+
+// DEPRECATED
+memcached_return_t memcached_coll_update_filter_set_bitwise(memcached_coll_update_filter_st *ptr,
+                                                            const size_t fwhere,
+                                                            memcached_coll_bitwise_t bitwise_op)
+{
+  return memcached_coll_eflag_update_set_bitwise(ptr, fwhere, bitwise_op);
 }
 
 size_t memcached_hexadecimal_to_str(memcached_hexadecimal_st *ptr,

--- a/libmemcached/collection.h
+++ b/libmemcached/collection.h
@@ -721,7 +721,7 @@ memcached_return_t memcached_coll_eflag_filter_set_bitwise(memcached_coll_eflag_
  * B+tree eflag filter used for certain update commands.
  * This is just for convenience.
  */
-struct memcached_coll_update_filter_st {
+struct memcached_coll_eflag_update_st {
   size_t fwhere;
   size_t flength;
 
@@ -749,9 +749,9 @@ struct memcached_coll_update_filter_st {
  * @param fvalue_length  value length (number of bytes).
  */
 LIBMEMCACHED_API
-memcached_return_t memcached_coll_update_filter_init(memcached_coll_update_filter_st *ptr,
-                                                     const unsigned char *fvalue,
-                                                     const size_t fvalue_length);
+memcached_return_t memcached_coll_eflag_update_init(memcached_coll_eflag_update_st *ptr,
+                                                    const unsigned char *fvalue,
+                                                    const size_t fvalue_length);
 
 /**
  * Initialize the b+tree eflag filter used for update commands.
@@ -760,6 +760,18 @@ memcached_return_t memcached_coll_update_filter_init(memcached_coll_update_filte
  * @param fwhere  eflag offset.
  * @param bitwise_op  bitwise operator.
  */
+LIBMEMCACHED_API
+memcached_return_t memcached_coll_eflag_update_set_bitwise(memcached_coll_eflag_update_st *ptr,
+                                                           const size_t fwhere,
+                                                           memcached_coll_bitwise_t bitwise_op);
+
+// DEPRECATED
+LIBMEMCACHED_API
+memcached_return_t memcached_coll_update_filter_init(memcached_coll_update_filter_st *ptr,
+                                                     const unsigned char *fvalue,
+                                                     const size_t fvalue_length);
+
+// DEPRECATED
 LIBMEMCACHED_API
 memcached_return_t memcached_coll_update_filter_set_bitwise(memcached_coll_update_filter_st *ptr,
                                                             const size_t fwhere,

--- a/libmemcached/types.h
+++ b/libmemcached/types.h
@@ -92,7 +92,8 @@ typedef struct memcached_coll_query_st memcached_bop_query_st;
 typedef struct memcached_hexadecimal_st memcached_hexadecimal_st;
 typedef struct memcached_mkey_st memcached_mkey_st;
 typedef struct memcached_coll_eflag_filter_st memcached_coll_eflag_filter_st;
-typedef struct memcached_coll_update_filter_st memcached_coll_update_filter_st;
+typedef struct memcached_coll_eflag_update_st memcached_coll_eflag_update_st;
+typedef struct memcached_coll_eflag_update_st memcached_coll_update_filter_st;
 typedef struct memcached_coll_smget_result_st memcached_coll_smget_result_st;
 
 #ifdef __cplusplus


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- #327

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- update_filter를 deprecated 시키고, eflag_update로 변경합니다.
