### PR TITLE
INTERNAL: Remove unnecessary lines in the version check of get API

### DIFF
--- a/libmemcached/get.cc
+++ b/libmemcached/get.cc
@@ -56,50 +56,41 @@
 
 static inline bool mget_command_is_supported(memcached_st *ptr, memcached_server_write_instance_st instance)
 {
+  if (instance->major_version == UINT8_MAX || instance->minor_version == UINT8_MAX)
+  {
+    return false;
+  }
+
   /* mgets */
   if (ptr->flags.support_cas)
   {
-    if (instance->major_version != UINT8_MAX && instance->minor_version != UINT8_MAX)
+    if (instance->is_enterprise)
     {
-      if (instance->is_enterprise)
-      {
-        /* >= 0.9.0-E */
-        if (instance->major_version > 0 || (instance->major_version == 0 && instance->minor_version >= 9))
-        {
-          return true;
-        }
-      }
-      else
-      {
-        /* >= 1.13.0 */
-        if (instance->major_version > 1 || (instance->major_version == 1 && instance->minor_version >= 13))
-        {
-          return true;
-        }
-      }
+      /* >= 0.9.0-E */
+      if (instance->major_version > 0 || (instance->major_version == 0 && instance->minor_version >= 9))
+        return true;
+    }
+    else
+    {
+      /* >= 1.13.0 */
+      if (instance->major_version > 1 || (instance->major_version == 1 && instance->minor_version >= 13))
+        return true;
     }
   }
   /* mget */
   else
   {
-    if (instance->major_version != UINT8_MAX && instance->minor_version != UINT8_MAX)
+    if (instance->is_enterprise)
     {
-      if (instance->is_enterprise)
-      {
-        /* >= 0.7.0-E */
-        if (instance->major_version > 0 || (instance->major_version == 0 && instance->minor_version >= 7))
-        {
-          return true;
-        }
-      }
-      else
-      {
-        /* >= 1.11.0 */
-        if (instance->major_version > 1 || (instance->major_version == 1 && instance->minor_version >= 11))
-        {
-          return true;
-        }
-      }
+      /* >= 0.7.0-E */
+      if (instance->major_version > 0 || (instance->major_version == 0 && instance->minor_version >= 7))
+        return true;
+    }
+    else
+    {
+      /* >= 1.11.0 */
+      if (instance->major_version > 1 || (instance->major_version == 1 && instance->minor_version >= 11))
+        return true;
     }
   }
   return false;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- jam2in/arcus-works#675

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- mget/mgets 지원 여부를 확인하는 서버 버전 검사 로직에서 불필요한 부분을 제거합니다.
