### PR TITLE
INTERNAL: Refactor a memcached_fetch function

### DIFF
--- a/libmemcached/fetch.cc
+++ b/libmemcached/fetch.cc
@@ -63,72 +63,26 @@ char *memcached_fetch(memcached_st *ptr, char *key, size_t *key_length,
   if (not error)
     error= &unused;
 
-
-  unlikely (ptr->flags.use_udp)
-  {
-    if (value_length)
-      *value_length= 0;
-
-    if (key_length)
-      *key_length= 0;
-
-    if (flags)
-      *flags= 0;
-
-    if (key)
-      *key= 0;
-
-    *error= MEMCACHED_NOT_SUPPORTED;
-    return NULL;
-  }
-
   result_buffer= memcached_fetch_result(ptr, result_buffer, error);
-  if (result_buffer == NULL or memcached_failed(*error))
+  if (result_buffer == NULL)
   {
-    WATCHPOINT_ASSERT(result_buffer == NULL);
-    if (value_length)
-      *value_length= 0;
-
-    if (key_length)
-      *key_length= 0;
-
-    if (flags)
-      *flags= 0;
-
-    if (key)
-      *key= 0;
+    if (key)          *key= 0;
+    if (key_length)   *key_length= 0;
+    if (value_length) *value_length= 0;
+    if (flags)        *flags= 0;
 
     return NULL;
-  }
-
-  if (value_length)
-  {
-    *value_length= memcached_string_length(&result_buffer->value);
   }
 
   if (key)
   {
-    if (result_buffer->key_length >= MEMCACHED_MAX_KEY)
-    {
-      *error= MEMCACHED_KEY_TOO_BIG;
-      if (value_length)
-        *value_length= 0;
-
-      if (key_length)
-        *key_length= 0;
-
-      if (flags)
-        *flags= 0;
-
-      if (key)
-        *key= 0;
-
-      return NULL;
-    }
     strncpy(key, result_buffer->item_key, result_buffer->key_length); // For the binary protocol we will cut off the key :(
     if (key_length)
       *key_length= result_buffer->key_length;
   }
+
+  if (value_length)
+    *value_length= memcached_string_length(&result_buffer->value);
 
   if (flags)
     *flags= result_buffer->item_flags;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- #334

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- memcached_fetch 함수가 리팩토링되었습니다.
- use_udp 부분을 확인한 결과, 필요하지 않아서 제거했습니다.
- `if (result_buffer == NULL || memcached_failed(*error))` 조건문에서 `memcached_failed`를 제거했습니다.
  - memcached_fetch_result에서 error 값이 memcached_success가 아닌 경우, 항상 NULL을 반환하도록 되어 있습니다.
- libmemcached를 확인한 결과, 별다른 변경 사항은 없는 것으로 보입니다.
  - [libmemcached/src/libmemcached/fetch.cc](https://github.com/awesomized/libmemcached/blob/b32a7148f30b60020a28d68e4462894af5151d3a/src/libmemcached/fetch.cc#L18-L108)

