### PR TITLE
INTERNAL: Fix a hidden keyword compile error

### DIFF
--- a/libhashkit/jenkins.cc
+++ b/libhashkit/jenkins.cc
@@ -17,7 +17,7 @@
 #define hashmask(n) (hashsize(n)-1)
 #define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
 
-#define mix(a,b,c) \
+#define JENKINS_MIX(a,b,c) \
 { \
   a -= c;  a ^= rot(c, 4);  c += b; \
   b -= a;  b ^= rot(a, 6);  a += c; \
@@ -27,7 +27,7 @@
   c -= b;  c ^= rot(b, 4);  b += a; \
 }
 
-#define final(a,b,c) \
+#define JENKINS_FINAL(a,b,c) \
 { \
   c ^= b; c -= rot(b,14); \
   a ^= c; a -= rot(c,11); \
@@ -76,7 +76,7 @@ uint32_t hashkit_jenkins(const char *key, size_t length, void *)
       a += k[0];
       b += k[1];
       c += k[2];
-      mix(a,b,c);
+      JENKINS_MIX(a,b,c);
       length -= 12;
       k += 3;
     }
@@ -121,7 +121,7 @@ uint32_t hashkit_jenkins(const char *key, size_t length, void *)
       a += k[0] + (((uint32_t)k[1])<<16);
       b += k[2] + (((uint32_t)k[3])<<16);
       c += k[4] + (((uint32_t)k[5])<<16);
-      mix(a,b,c);
+      JENKINS_MIX(a,b,c);
       length -= 12;
       k += 6;
     }
@@ -180,7 +180,7 @@ uint32_t hashkit_jenkins(const char *key, size_t length, void *)
       c += ((uint32_t)k[9])<<8;
       c += ((uint32_t)k[10])<<16;
       c += ((uint32_t)k[11])<<24;
-      mix(a,b,c);
+      JENKINS_MIX(a,b,c);
       length -= 12;
       k += 12;
     }
@@ -208,6 +208,6 @@ uint32_t hashkit_jenkins(const char *key, size_t length, void *)
   }
 #endif
 
-  final(a,b,c);
+  JENKINS_FINAL(a,b,c);
   return c;
 }


### PR DESCRIPTION
### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- MacOS(clang 16.0.6)에서 발생하는 컴파일 에러를 수정합니다.
- 발생하는 컴파일 에러는 아래와 같습니다.
```js
libhashkit/jenkins.cc:30:9: error: keyword is hidden by macro definition [-Werror,-Wkeyword-macro]
#define final(a,b,c) \
```
- C++에서 final 키워드는 Java와 유사하게 상속을 불가하게 하거나 메서드의 오버라이딩을 막는 용도로 사용됩니다.
- 이를 해결하기 위해 final 매크로를 JENKINS_FINAL로 변경했습니다.
  - 비슷하게 mix 매크로도 JENKINS_MIX로 변경하였습니다.
  - rot 매크로는 일반적으로 사용되는 비트 회전 방식과 유사하여, 이름을 변경하지 않았습니다.