### PR TITLE
INTERNAL: Add a clean-whitespace script file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,5 +104,3 @@ tests/memstat
 tests/sasl
 tests/storage
 unittests/unittests
-devtools/*
-!devtools/maketags.sh

--- a/devtools/clean-whitespace.pl
+++ b/devtools/clean-whitespace.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/perl
+use strict;
+use FindBin qw($Bin);
+
+chdir "$Bin/.." or die;
+my @files = `git ls-files` or die;
+
+foreach my $f (@files) {
+    chomp($f);
+    next if $f =~ /\.png$/;
+    open(my $fh, $f) or die;
+    my $before = do { local $/; <$fh>; };
+    close ($fh);
+    my $after = $before;
+    $after =~ s/\t/    /g;
+    $after =~ s/ +$//mg;
+    $after .= "\n" unless $after =~ /\n$/;
+    next if $after eq $before;
+    open(my $fh, ">$f") or die;
+    print $fh $after;
+    close($fh);
+}


### PR DESCRIPTION
### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- Arcus-C-Client의 파일에서 whitespace를 제거하는 Perl 스크립트를 추가합니다.
  - whitespace를 제거하는 방식은 서버의 clean-whitespace와 동일합니다.
- Git에서 관리하는 파일들에서 whitespace를 제거하도록 했습니다.
  - png(이미지)파일은 제외하도록 했습니다. 
- 이후 whitespace가 제거된 파일을 PR로 올릴 예정입니다.
