### PR TITLE
DOC: Use HTML line break element

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,12 @@ main(int argc, char *argv[])
       false /* do not delete the empty key */,
       &result))
     return -1;
-  
+
   /* Print */
   printf("Retrieved the element. value=%s\n",
     memcached_coll_result_get_value(&result, 0));
   memcached_coll_result_free(&result);
-  
+
   return 0;
 }
 ```
@@ -186,7 +186,7 @@ use --enable-zk-integration when running configure.
                 --with-memcached_engine=/home1/arcus/lib/default_engine.so
     make
     make test
-    
+
     [...]
     PASS: tests/c_sasl_test
     ===================
@@ -207,9 +207,9 @@ https://github.com/naver/arcus-c-client/issues
 In addition to those who had contributed to the original libmemcached, the
 following people at NAVER have contributed to arcus-c-client.
 
-Hoonmin Kim (harebox) <hoonmin.kim@navercorp.com>; <harebox@gmail.com>  
-YeaSol Kim (ngleader) <sol.k@navercorp.com>; <ngleader@gmail.com>  
-HyongYoub Kim <hyongyoub.kim@navercorp.com>  
+Hoonmin Kim (harebox) <hoonmin.kim@navercorp.com>; <harebox@gmail.com> <br>
+YeaSol Kim (ngleader) <sol.k@navercorp.com>; <ngleader@gmail.com> <br>
+HyongYoub Kim <hyongyoub.kim@navercorp.com> <br>
 
 ## License
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- #342

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- README에서 줄바꿈 요소로 줄 마지막에 띄어쓰기 2개를 넣어 활용하고 있습니다.
- 하지만 VS code에서 white space 제거 기능을 키고, README를 수정할 경우 해당 문자(띄어쓰기 2개)까지 제거가 되어 버립니다.
- 줄을 바꿀 때, 띄어쓰기 2개 대신에 HTML 문법인 `<br>`을 활용합니다.