### PR TITLE
INTERNAL: Don't change a tab character in .ac/am files

### DIFF
--- a/devtools/clean-whitespace.pl
+++ b/devtools/clean-whitespace.pl
@@ -12,7 +12,7 @@ foreach my $f (@files) {
     my $before = do { local $/; <$fh>; };
     close ($fh);
     my $after = $before;
-    $after =~ s/\t/    /g;
+    $after =~ s/\t/    /g unless $f =~ /\.(ac|am)$/;
     $after =~ s/ +$//mg;
     $after .= "\n" unless $after =~ /\n$/;
     next if $after eq $before;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- #342

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- autotools에서 configure와 Makefile 생성에 사용되는 am과 ac 파일은 tab 문자열을 변경하지 않습니다.
  - Makefile 에서는 space가 아닌 탭 문자로 사용하도록 되어 있습니다.