### PR TITLE
DOC: Use a list instead of line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,9 @@ https://github.com/naver/arcus-c-client/issues
 In addition to those who had contributed to the original libmemcached, the
 following people at NAVER have contributed to arcus-c-client.
 
-Hoonmin Kim (harebox) <hoonmin.kim@navercorp.com>; <harebox@gmail.com> <br>
-YeaSol Kim (ngleader) <sol.k@navercorp.com>; <ngleader@gmail.com> <br>
-HyongYoub Kim <hyongyoub.kim@navercorp.com> <br>
+- Hoonmin Kim (harebox) <hoonmin.kim@navercorp.com>; <harebox@gmail.com>
+- YeaSol Kim (ngleader) <sol.k@navercorp.com>; <ngleader@gmail.com>
+- HyongYoub Kim <hyongyoub.kim@navercorp.com>
 
 ## License
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- #343

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- HTML 줄바꿈 대신에 Markdown의 리스트를 활용합니다.

```markdown
In addition to those who had contributed to the original libmemcached, the following people at NAVER have contributed to arcus-c-client.

- Hoonmin Kim (harebox) [hoonmin.kim@navercorp.com](mailto:hoonmin.kim@navercorp.com); [harebox@gmail.com](mailto:harebox@gmail.com)
- YeaSol Kim (ngleader) [sol.k@navercorp.com](mailto:sol.k@navercorp.com); [ngleader@gmail.com](mailto:ngleader@gmail.com)
- HyongYoub Kim [hyongyoub.kim@navercorp.com](mailto:hyongyoub.kim@navercorp.com)
```
