### PR TITLE
INTERNAL: Exclude m4 files from clean-whitespace

### DIFF
--- a/devtools/clean-whitespace.pl
+++ b/devtools/clean-whitespace.pl
@@ -7,7 +7,7 @@ my @files = `git ls-files` or die;
 
 foreach my $f (@files) {
     chomp($f);
-    next if $f =~ /\.png$/;
+    next if $f =~ /\.(png|m4)$/;
     open(my $fh, $f) or die;
     my $before = do { local $/; <$fh>; };
     close ($fh);


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- #344

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- whitespace 제거 스크립트에서 m4 파일을 제외합니다.
