### PR TITLE
DOC: Fix `MEMCACHED_DEFAULT_TIMEOUT` value

### DIFF
--- a/docs/02-arcus-c-client.md
+++ b/docs/02-arcus-c-client.md
@@ -307,7 +307,7 @@ mc = memcached_create(NULL);
 memcached_behavior_set(mc, MEMCACHED_BEHAVIOR_POLL_TIMEOUT, (uint64_t)timeout);
 ```
 
-timeout 시간은 밀리초(ms) 단위이며, 기본 값은 MEMCACHED_DEFAULT_TIMEOUT (500ms) 이다.
+timeout 시간은 밀리초(ms) 단위이며, 기본 값은 MEMCACHED_DEFAULT_TIMEOUT (700ms) 이다.
 
 ### 캐시 노드에 대한 CONNECTION TIMEOUT 지정
 


### PR DESCRIPTION
### ⌨️ What I did

- 잘못 표기된 default timeout 값을 수정합니다.
- `MEMCACHED_DEFAULT_TIMEOUT` 값은 1.7.3 버전부터 700ms였습니다.
- https://github.com/naver/arcus-c-client/commit/6fb2fa50890c3320d9566a9ed24d89f2b1ff4d2c 에서 변경할 때 문서는 함께 수정하지 않아 잘못된 값이 지금까지 남아있었습니다.