### PR TITLE
INTERNAL: Set MEMCACHED_MAX_KEY to the key length, not the memory size

### DIFF
--- a/arcus/multi_process.c
+++ b/arcus/multi_process.c
@@ -183,7 +183,7 @@ static inline void process_child(memcached_st *proxy_mc)
 
       rc = memcached_mget(mc, keys, lengths, 20);
 
-      char key[MEMCACHED_MAX_KEY];
+      char key[MEMCACHED_MAX_KEY + 1];
       size_t key_length;
 
       for (i=0; i<20; i++)
@@ -215,7 +215,7 @@ static inline void process_child(memcached_st *proxy_mc)
 
       rc = memcached_mget(mc, keys, lengths, 5);
 
-      char key[MEMCACHED_MAX_KEY];
+      char key[MEMCACHED_MAX_KEY + 1];
       size_t key_length;
 
       for (i=0; i<5; i++)

--- a/docs/03-key-value-API.md
+++ b/docs/03-key-value-API.md
@@ -187,7 +187,7 @@ int arcus_kv_mget(memcached_st *memc)
   assert(rc == MEMCACHED_SUCCESS || rc == MEMCACHED_SOME_ERRORS);
   while (true)
   {
-    char key[MEMCACHED_MAX_KEY];
+    char key[MEMCACHED_MAX_KEY + 1];
     size_t key_length;
     size_t value_length;
 

--- a/libmemcached/collection_result.h
+++ b/libmemcached/collection_result.h
@@ -29,7 +29,7 @@
  * Result structure for collection operations.
  */
 struct memcached_coll_result_st {
-  char item_key[MEMCACHED_MAX_KEY];
+  char item_key[MEMCACHED_MAX_KEY + 1];
   size_t key_length;
 
   memcached_coll_type_t type;

--- a/libmemcached/common.h
+++ b/libmemcached/common.h
@@ -202,7 +202,7 @@ static inline memcached_return_t memcached_validate_key_length(size_t key_length
   }
   else
   {
-    if (key_length >= MEMCACHED_MAX_KEY)
+    if (key_length > MEMCACHED_MAX_KEY)
     {
       return MEMCACHED_BAD_KEY_PROVIDED;
     }

--- a/libmemcached/constants.h
+++ b/libmemcached/constants.h
@@ -69,7 +69,7 @@
 
 /* Public defines */
 #define MEMCACHED_DEFAULT_PORT 11211
-#define MEMCACHED_MAX_KEY 4001 /* (4000 + 1) We add one to have it null terminated */
+#define MEMCACHED_MAX_KEY 4000
 #define MEMCACHED_MAX_BUFFER 8196
 #define MEMCACHED_MAX_HOST_SORT_LENGTH 86 /* Used for Ketama */
 #define MEMCACHED_POINTS_PER_SERVER 160

--- a/libmemcached/fetch.cc
+++ b/libmemcached/fetch.cc
@@ -179,7 +179,7 @@ memcached_result_st *memcached_fetch_result(memcached_st *ptr,
   bool connection_failures= false;
   while ((server= memcached_io_get_readable_server(ptr)))
   {
-    char buffer[MEMCACHED_DEFAULT_COMMAND_SIZE + MEMCACHED_MAX_KEY];
+    char buffer[MEMCACHED_DEFAULT_COMMAND_SIZE + MEMCACHED_MAX_KEY + 1];
     *error= memcached_response(server, buffer, sizeof(buffer), result);
 
     if (*error == MEMCACHED_IN_PROGRESS)
@@ -336,7 +336,7 @@ memcached_coll_fetch_result(memcached_st *ptr,
   memcached_server_st *server;
   while ((server= memcached_io_get_readable_server(ptr)))
   {
-    char buffer[MEMCACHED_DEFAULT_COMMAND_SIZE + MEMCACHED_MAX_KEY];
+    char buffer[MEMCACHED_DEFAULT_COMMAND_SIZE + MEMCACHED_MAX_KEY + 1];
     *error= memcached_coll_response(server, buffer, sizeof(buffer), result);
 
     if (*error == MEMCACHED_IN_PROGRESS)

--- a/libmemcached/hash.cc
+++ b/libmemcached/hash.cc
@@ -114,9 +114,9 @@ static inline uint32_t _generate_hash_wrapper(const memcached_st *ptr, const cha
   if (ptr->flags.hash_with_namespace)
   {
     size_t temp_length= memcached_array_size(ptr->_namespace) + key_length;
-    char temp[MEMCACHED_MAX_KEY];
+    char temp[MEMCACHED_MAX_KEY + 1];
 
-    if (temp_length > MEMCACHED_MAX_KEY -1)
+    if (temp_length > MEMCACHED_MAX_KEY)
       return 0;
 
     strncpy(temp, memcached_array_string(ptr->_namespace), memcached_array_size(ptr->_namespace));

--- a/libmemcached/result.h
+++ b/libmemcached/result.h
@@ -46,7 +46,7 @@ struct memcached_result_st {
   memcached_st *root;
   memcached_string_st value;
   uint64_t count;
-  char item_key[MEMCACHED_MAX_KEY];
+  char item_key[MEMCACHED_MAX_KEY + 1];
   struct {
     bool is_allocated:1;
     bool is_initialized:1;

--- a/tests/mem_functions.cc
+++ b/tests/mem_functions.cc
@@ -920,8 +920,8 @@ static test_return_t bad_key_test(memcached_st *memc)
                  memcached_callback_set(memc_clone, MEMCACHED_CALLBACK_NAMESPACE, NULL));
 
     std::vector <char> longkey;
-    longkey.insert(longkey.end(), MEMCACHED_MAX_KEY, 'a');
-    test_compare(longkey.size(), size_t(MEMCACHED_MAX_KEY));
+    longkey.insert(longkey.end(), MEMCACHED_MAX_KEY + 1, 'a');
+    test_compare(longkey.size(), size_t(MEMCACHED_MAX_KEY + 1));
     {
       size_t string_length;
       // We subtract 1
@@ -1301,7 +1301,7 @@ static test_return_t mget_end(memcached_st *memc)
   // retrieve both via mget
   test_compare(MEMCACHED_SUCCESS, memcached_mget(memc, keys, lengths, test_array_length(keys)));
 
-  char key[MEMCACHED_MAX_KEY];
+  char key[MEMCACHED_MAX_KEY + 1];
   size_t key_length;
 
   // this should get both
@@ -1867,7 +1867,7 @@ static test_return_t mget_test(memcached_st *memc)
   const char *keys[]= {"fudge", "son", "food"};
   size_t key_length[]= {5, 3, 4};
 
-  char return_key[MEMCACHED_MAX_KEY];
+  char return_key[MEMCACHED_MAX_KEY + 1];
   size_t return_key_length;
   char *return_value;
   size_t return_value_length;
@@ -1927,7 +1927,7 @@ static test_return_t mget_longkey_test(memcached_st *memc)
     memset(keys[x], x + '0', key_length[x]);
   }
 
-  char return_key[MEMCACHED_MAX_KEY];
+  char return_key[MEMCACHED_MAX_KEY + 1];
   size_t return_key_length;
   char *return_value;
   size_t return_value_length;
@@ -2378,7 +2378,7 @@ static test_return_t MEMCACHED_BEHAVIOR_TCP_KEEPIDLE_test(memcached_st *memc)
 static test_return_t fetch_all_results(memcached_st *memc, unsigned int &keys_returned, const memcached_return_t expect)
 {
   memcached_return_t rc;
-  char return_key[MEMCACHED_MAX_KEY];
+  char return_key[MEMCACHED_MAX_KEY + 1];
   size_t return_key_length;
   char *return_value;
   size_t return_value_length;
@@ -2576,7 +2576,7 @@ static test_return_t user_supplied_bug4(memcached_st *memc)
 
   {
     char *return_value;
-    char return_key[MEMCACHED_MAX_KEY];
+    char return_key[MEMCACHED_MAX_KEY + 1];
     memcached_return_t rc;
     size_t return_key_length;
     size_t return_value_length;
@@ -2655,7 +2655,7 @@ static test_return_t user_supplied_bug6(memcached_st *memc)
 {
   const char *keys[]= {"036790384900", "036790384902", "036790384904", "036790384906"};
   size_t key_length[]=  {strlen("036790384900"), strlen("036790384902"), strlen("036790384904"), strlen("036790384906")};
-  char return_key[MEMCACHED_MAX_KEY];
+  char return_key[MEMCACHED_MAX_KEY + 1];
   size_t return_key_length;
   char *value;
   size_t value_length;
@@ -2755,7 +2755,7 @@ static test_return_t user_supplied_bug7(memcached_st *memc)
 {
   const char *keys= "036790384900";
   size_t key_length=  strlen(keys);
-  char return_key[MEMCACHED_MAX_KEY];
+  char return_key[MEMCACHED_MAX_KEY + 1];
   size_t return_key_length;
   char *value;
   size_t value_length;
@@ -2801,7 +2801,7 @@ static test_return_t user_supplied_bug9(memcached_st *memc)
   uint32_t flags;
   unsigned count= 0;
 
-  char return_key[MEMCACHED_MAX_KEY];
+  char return_key[MEMCACHED_MAX_KEY + 1];
   size_t return_key_length;
   char *return_value;
   size_t return_value_length;
@@ -3226,7 +3226,7 @@ static test_return_t _user_supplied_bug21(memcached_st* memc, size_t key_count)
 
   memcached_return_t rc;
   uint32_t flags;
-  char return_key[MEMCACHED_MAX_KEY];
+  char return_key[MEMCACHED_MAX_KEY + 1];
   size_t return_key_length;
   char *return_value;
   size_t return_value_length;
@@ -5816,7 +5816,7 @@ static test_return_t regression_bug_490486(memcached_st *memc)
     test_compare(MEMCACHED_SUCCESS, rc);
 
     char* the_value= NULL;
-    char the_key[MEMCACHED_MAX_KEY];
+    char the_key[MEMCACHED_MAX_KEY + 1];
     size_t the_key_length;
     size_t the_value_length;
     uint32_t the_flags;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- #339 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- MEMCACHED_MAX_KEY 에서 NULL 문자를 제외하고, 오직 MAX_KEY 길이정보만 갖도록 변경합니다.
  - 4001 -> 4000
