### PR TITLE
INTERNAL: Fix the cast-function-type error

### DIFF
--- a/libmemcached/sasl.cc
+++ b/libmemcached/sasl.cc
@@ -43,6 +43,8 @@
 #include <sasl/sasl.h>
 #include <pthread.h>
 
+#define CAST_SASL_CB(cb) reinterpret_cast<int(*)()>(reinterpret_cast<intptr_t>(cb))
+
 void memcached_set_sasl_callbacks(memcached_st *ptr,
                                   const sasl_callback_t *callbacks)
 {
@@ -340,13 +342,13 @@ memcached_return_t memcached_set_sasl_auth_data(memcached_st *ptr,
   secret->data[password_length]= 0;
 
   callbacks[0].id= SASL_CB_USER;
-  callbacks[0].proc= (int (*)())get_username;
+  callbacks[0].proc= CAST_SASL_CB(get_username);
   callbacks[0].context= strncpy(name, username, username_length +1);
   callbacks[1].id= SASL_CB_AUTHNAME;
-  callbacks[1].proc= (int (*)())get_username;
+  callbacks[1].proc= CAST_SASL_CB(get_username);
   callbacks[1].context= name;
   callbacks[2].id= SASL_CB_PASS;
-  callbacks[2].proc= (int (*)())get_password;
+  callbacks[2].proc= CAST_SASL_CB(get_password);
   callbacks[2].context= secret;
   callbacks[3].id= SASL_CB_LIST_END;
 
@@ -405,11 +407,11 @@ memcached_return_t memcached_clone_sasl(memcached_st *clone, const  memcached_st
 
   /* Hopefully we are using our own callback mechanisms.. */
   if (source->sasl.callbacks[0].id == SASL_CB_USER &&
-      source->sasl.callbacks[0].proc ==  (int (*)())get_username &&
+      source->sasl.callbacks[0].proc ==  CAST_SASL_CB(get_username) &&
       source->sasl.callbacks[1].id == SASL_CB_AUTHNAME &&
-      source->sasl.callbacks[1].proc ==  (int (*)())get_username &&
+      source->sasl.callbacks[1].proc ==  CAST_SASL_CB(get_username) &&
       source->sasl.callbacks[2].id == SASL_CB_PASS &&
-      source->sasl.callbacks[2].proc ==  (int (*)())get_password &&
+      source->sasl.callbacks[2].proc ==  CAST_SASL_CB(get_password) &&
       source->sasl.callbacks[3].id == SASL_CB_LIST_END)
   {
     sasl_secret_t *secret= (sasl_secret_t *)source->sasl.callbacks[2].context;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- #356 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- https://github.com/awesomized/libmemcached/commit/4952d9d842e9c13eace3a986bf748001d5d6852d
- libmemcached에서 처리한 방식과 동일하게 처리했습니다.
- reinterpret_cast 는 c++에서 제공하는 타입캐스트 연산자로 Pointer → 일반 자료형, 일반 자료형 → Pointer 형태로 형변환 시  활용됩니다.
