### PR TITLE
TEST: Upgrade actions version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,12 +14,12 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Arcus C Client Dependency Packages
       run: sudo apt-get install -qq build-essential libtool pandora-build
     - name: Cache Arcus Server Directory
       id: arcus-cache
-      uses: actions/cache@v3.3.2
+      uses: actions/cache@v4
       with:
         path: ~/arcus
         key: ${{runner.os}}-arcus


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 현재 Github Action에서 CI 테스트를 진행하면 아래의 에러가 발생합니다.
```
Error: Missing download info for actions/cache@v3.3.2
```
- actions/cache 쪽에서 변경사항이 있는 것으로 보이며, 업그레이드할 것을 추천하고 있습니다.
  - https://github.com/actions/cache
```readme
⚠️ Important changes

The cache backend service has been rewritten from the ground up for improved performance and reliability. [actions/cache](https://github.com/actions/cache) now integrates with the new cache service (v2) APIs.

The new service will gradually roll out as of February 1st, 2025. The legacy service will also be sunset on the same date. Changes in these release are fully backward compatible.

We are deprecating some versions of this action. We recommend upgrading to version v4 or v3 as soon as possible before February 1st, 2025. (Upgrade instructions below).

If you are using pinned SHAs, please use the SHAs of versions v4.2.0 or v3.4.0

If you do not upgrade, all workflow runs using any of the deprecated [actions/cache](https://github.com/actions/cache) will fail.

Upgrading to the recommended versions will not break your workflows.

Read more about the change & access the migration guide: https://github.com/actions/cache/discussions/1510.
```
### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- actions의 버전을 모두 가장 최신 버전(v4)으로 업그레이드합니다.
