### PR TITLE
INTERNAL: Return an empty string if the value length is 0

### DIFF
--- a/libmemcached/string.cc
+++ b/libmemcached/string.cc
@@ -167,9 +167,6 @@ memcached_return_t memcached_string_append(memcached_string_st *string,
 
 char *memcached_string_c_copy(memcached_string_st *string)
 {
-  if (not memcached_string_length(string))
-    return NULL;
-
   char *c_ptr= static_cast<char *>(libmemcached_malloc(string->root, (memcached_string_length(string)+1) * sizeof(char)));
 
   if (not c_ptr)

--- a/tests/mem_functions.cc
+++ b/tests/mem_functions.cc
@@ -3054,17 +3054,19 @@ static test_return_t user_supplied_bug15(memcached_st *memc)
                                &length, &flags, &rc);
 
     test_compare(MEMCACHED_SUCCESS, rc);
-    test_false(value);
+    test_false(value == NULL);
     test_zero(length);
     test_zero(flags);
+    free(value);
 
     value= memcached_get(memc, test_literal_param("mykey"),
                          &length, &flags, &rc);
 
     test_compare(MEMCACHED_SUCCESS, rc);
-    test_true(value == NULL);
+    test_true(value != NULL);
     test_zero(length);
     test_zero(flags);
+    free(value);
   }
 
   return TEST_SUCCESS;
@@ -3085,9 +3087,10 @@ static test_return_t user_supplied_bug16(memcached_st *memc)
                        &length, &flags, &rc);
 
   test_compare(MEMCACHED_SUCCESS, rc);
-  test_true(value == NULL);
+  test_true(value != NULL);
   test_zero(length);
   test_compare(flags, UINT32_MAX);
+  free(value);
 
   return TEST_SUCCESS;
 }

--- a/tests/memcat.cc
+++ b/tests/memcat.cc
@@ -81,13 +81,17 @@ static test_return_t cat_test(void *)
                memcached_set(memc, test_literal_param("foo"), 0, 0, 0, 0));
 
   memcached_return_t rc;
-  test_null(memcached_get(memc, test_literal_param("foo"), 0, 0, &rc));
+  char *value= memcached_get(memc, test_literal_param("foo"), 0, 0, &rc);
   test_compare(MEMCACHED_SUCCESS, rc);
+  test_true(value != NULL);
+  free(value);
 
   test_true(exec_cmdline(executable, args));
 
-  test_null(memcached_get(memc, test_literal_param("foo"), 0, 0, &rc));
+  value= memcached_get(memc, test_literal_param("foo"), 0, 0, &rc);
   test_compare(MEMCACHED_SUCCESS, rc);
+  test_true(value != NULL);
+  free(value);
 
   memcached_free(memc);
 

--- a/tests/memdump.cc
+++ b/tests/memdump.cc
@@ -94,8 +94,10 @@ static test_return_t FOUND_test(void *)
                memcached_set(memc, test_literal_param("foo2"), 0, 0, 0, 0));
 
   memcached_return_t rc;
-  test_null(memcached_get(memc, test_literal_param("foo"), 0, 0, &rc));
+  char *value= memcached_get(memc, test_literal_param("foo"), 0, 0, &rc);
   test_compare(MEMCACHED_SUCCESS, rc);
+  test_true(value != NULL);
+  free(value);
 
   test_true(exec_cmdline(executable, args));
 

--- a/tests/memexist.cc
+++ b/tests/memexist.cc
@@ -81,13 +81,17 @@ static test_return_t exist_test(void *)
                memcached_set(memc, test_literal_param("foo"), 0, 0, 0, 0));
 
   memcached_return_t rc;
-  test_null(memcached_get(memc, test_literal_param("foo"), 0, 0, &rc));
+  char *value= memcached_get(memc, test_literal_param("foo"), 0, 0, &rc);
   test_compare(MEMCACHED_SUCCESS, rc);
+  test_true(value != NULL);
+  free(value);
 
   test_true(exec_cmdline(executable, args));
 
-  test_null(memcached_get(memc, test_literal_param("foo"), 0, 0, &rc));
+  value= memcached_get(memc, test_literal_param("foo"), 0, 0, &rc);
   test_compare(MEMCACHED_SUCCESS, rc);
+  test_true(value != NULL);
+  free(value);
 
   memcached_free(memc);
 

--- a/tests/memrm.cc
+++ b/tests/memrm.cc
@@ -81,8 +81,10 @@ static test_return_t rm_test(void *)
                memcached_set(memc, test_literal_param("foo"), 0, 0, 0, 0));
 
   memcached_return_t rc;
-  test_null(memcached_get(memc, test_literal_param("foo"), 0, 0, &rc));
+  char *value= memcached_get(memc, test_literal_param("foo"), 0, 0, &rc);
   test_compare(MEMCACHED_SUCCESS, rc);
+  test_true(value != NULL);
+  free(value);
 
   test_true(exec_cmdline(executable, args));
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- #360

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 문자열 복사 과정에서 `value_length`가 0인 경우, `NULL` 대신 빈 문자열(`""`)을 반환하도록 수정되었습니다.
- 이에 맞춰 테스트 코드도 변경되었습니다.
