### PR TITLE
INTERNAL: Fix a compile error in Ubuntu 24.04

### DIFF
--- a/libmemcached/server_list.cc
+++ b/libmemcached/server_list.cc
@@ -77,7 +77,7 @@ memcached_server_list_append_with_weight(memcached_server_list_st ptr,
   if (not __server_create_with(NULL, &new_host_list[count-1], _hostname, port, weight,
                                port ? MEMCACHED_CONNECTION_TCP : MEMCACHED_CONNECTION_UNIX_SOCKET))
   {
-    *error= memcached_set_errno(*ptr, MEMCACHED_MEMORY_ALLOCATION_FAILURE, MEMCACHED_AT);
+    *error= memcached_set_errno(*new_host_list, MEMCACHED_MEMORY_ALLOCATION_FAILURE, MEMCACHED_AT);
     return NULL;
   }
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- #368 
- [jam2in/arcus-works#717](https://github.com/naver/arcus-c-client/pull/368#issuecomment-2834149556)

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- Ubuntu 24.04에서 발생하는 에러를 수정합니다.
```js
libmemcached/server_list.cc:80:32: error: pointer 'ptr' may be used after 'void* realloc(void*, size_t)' [-Werror=use-after-free]
   80 |     *error= memcached_set_errno(*ptr, MEMCACHED_MEMORY_ALLOCATION_FAILURE, MEMCACHED_AT);
      |             ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libmemcached/server_list.cc:69:61: note: call to 'void* realloc(void*, size_t)' here
   69 |   new_host_list= (memcached_server_write_instance_st)realloc(ptr, sizeof(memcached_server_st) * count);
      |            
```
- __server_create_with 에서 NULL이 반환되는 경우는 invalid hostname, malloc failure로
  미리 hostname validation 검사 및 realloc을 통한 공간 확보가 확정된 상황에서는 반환되지 않습니다.
