### PR TITLE
FEATURE: Do not send old bop smget command

### DIFF
--- a/libmemcached/collection.h
+++ b/libmemcached/collection.h
@@ -96,7 +96,6 @@ typedef enum {
 
 /* smget mode */
 typedef enum {
-  MEMCACHED_COLL_SMGET_NONE,
   MEMCACHED_COLL_SMGET_DUPLICATE,
   MEMCACHED_COLL_SMGET_UNIQUE
 } memcached_coll_smget_mode_t;

--- a/libmemcached/collection_result.cc
+++ b/libmemcached/collection_result.cc
@@ -244,7 +244,7 @@ static inline void _coll_smget_result_init(memcached_coll_smget_result_st *self,
   self->trimmed_sub_keys= NULL;
   self->offset= 0;
   self->count= 0;
-  self->smgmode= MEMCACHED_COLL_SMGET_NONE;
+  self->smgmode= MEMCACHED_COLL_SMGET_DUPLICATE;
   self->root= memc;
   self->options.is_initialized= true;
   self->options.is_descending= false;

--- a/tests/mem_functions.cc
+++ b/tests/mem_functions.cc
@@ -7878,37 +7878,6 @@ static test_return_t arcus_1_6_btree_smget_more(memcached_st *memc)
   }
   memcached_coll_smget_result_free(&smget_result);
 
-  /* 1-1) do smget in ascending order with offset=2, count=20 */
-  bkey_from = 0;
-  bkey_to = UINT64_MAX;
-  memcached_bop_range_query_init(&smget_query, bkey_from, bkey_to, NULL, 2, 20);
-  memcached_coll_smget_result_create(memc, &smget_result);
-
-  rc = memcached_bop_smget(memc, keys, key_length, 100, &smget_query, &smget_result);
-  test_true_got(rc == MEMCACHED_SUCCESS, memcached_strerror(NULL, rc));
-  test_true_got(memcached_get_last_response_code(memc) == MEMCACHED_END,
-                memcached_strerror(NULL, memcached_get_last_response_code(memc)));
-  test_true(20 == memcached_coll_smget_result_get_count(&smget_result));
-  test_true(0 == memcached_coll_smget_result_get_missed_key_count(&smget_result));
-  if (rc == MEMCACHED_SUCCESS) {
-    uint64_t last_bkey = bkey_from;
-    for (uint32_t i=0; i<memcached_coll_smget_result_get_count(&smget_result); i++) {
-      /* check bkey */
-      bkey = smget_result.sub_keys[i].bkey;
-      test_true(last_bkey <= bkey);
-      last_bkey = bkey;
-      /* compare eflag */
-      eflag = 0;
-      eflag_hex.array = (unsigned char *)&eflag;
-      eflag_hex.length = sizeof(eflag);
-      test_true(memcached_compare_two_hexadecimal(&smget_result.eflags[i], &eflag_hex) == 0);
-      /* compare value */
-      vlen = snprintf(buffer, 63, "value-%llu", (unsigned long long)bkey);
-      test_true(strcmp(buffer, memcached_coll_smget_result_get_value(&smget_result, i)) == 0);
-    }
-  }
-  memcached_coll_smget_result_free(&smget_result);
-
   /* delete btree items */
   for (int i=0; i<100; i++) {
     memcached_delete(memc, keys[i], key_length[i], 0);
@@ -7986,41 +7955,6 @@ static test_return_t arcus_1_6_btree_smget_more(memcached_st *memc)
     for (uint32_t i=0; i<memcached_coll_smget_result_get_count(&smget_result); i++) {
       /* check bkey */
       test_true(memcached_compare_two_hexadecimal(&smget_result.sub_keys[i].bkey_ext, &bkey_hex) <= 0);
-      bkey_hex = smget_result.sub_keys[i].bkey_ext;
-      /* compare eflag */
-      eflag = 0;
-      eflag_hex.array = (unsigned char *)&eflag;
-      eflag_hex.length = sizeof(eflag);
-      test_true(memcached_compare_two_hexadecimal(&smget_result.eflags[i], &eflag_hex) == 0);
-#if 0 /* compare value */
-      vlen = snprintf(buffer, 63, "value-%s", smget_result.sub_keys[i].bkey_ext.array);
-      test_true(strcmp(buffer, memcached_coll_smget_result_get_value(&smget_result, i)) == 0);
-#endif
-    }
-  }
-  memcached_coll_smget_result_free(&smget_result);
-
-  /* 2-3) do smget in ascending order with offset=2, count=20 */
-  bkey_from = (uint64_t)htonl(0);
-  bkey_to = (uint64_t)htonl(UINT32_MAX);
-  memcached_bop_ext_range_query_init(&smget_query,
-                                     (unsigned char *)&bkey_from, sizeof(bkey_from),
-                                     (unsigned char *)&bkey_to, sizeof(bkey_to),
-                                     NULL, 2, 20);
-  memcached_coll_smget_result_create(memc, &smget_result);
-
-  rc = memcached_bop_smget(memc, keys, key_length, 100, &smget_query, &smget_result);
-  test_true_got(rc == MEMCACHED_SUCCESS, memcached_strerror(NULL, rc));
-  test_true_got(memcached_get_last_response_code(memc) == MEMCACHED_END,
-                memcached_strerror(NULL, memcached_get_last_response_code(memc)));
-  test_true(20 == memcached_coll_smget_result_get_count(&smget_result));
-  test_true(0 == memcached_coll_smget_result_get_missed_key_count(&smget_result));
-  if (rc == MEMCACHED_SUCCESS) {
-    bkey_hex.array = (unsigned char *)&bkey_from;
-    bkey_hex.length = sizeof(bkey_from);
-    for (uint32_t i=0; i<memcached_coll_smget_result_get_count(&smget_result); i++) {
-      /* check bkey */
-      test_true(memcached_compare_two_hexadecimal(&smget_result.sub_keys[i].bkey_ext, &bkey_hex) >= 0);
       bkey_hex = smget_result.sub_keys[i].bkey_ext;
       /* compare eflag */
       eflag = 0;
@@ -8329,42 +8263,6 @@ static test_return_t arcus_1_6_btree_smget_duptrim(memcached_st *memc)
     test_true_got(rc == MEMCACHED_SUCCESS || rc == MEMCACHED_BUFFERED, memcached_strerror(NULL, rc));
   }
 
-  /* do smget operation (ascending order): duplicated & trimmed */
-  memcached_bop_range_query_init(&smget_query, 0, 5, NULL, 0, 10);
-  memcached_coll_smget_result_create(memc, &smget_result);
-
-  rc = memcached_bop_smget(memc, keys, key_length, 3, &smget_query, &smget_result);
-  test_true_got(rc == MEMCACHED_OUT_OF_RANGE, memcached_strerror(NULL, rc));
-
-  memcached_coll_smget_result_free(&smget_result);
-
-  /* do smget operation (descending order): duplicated & trimmed */
-  /* count = 10 */
-  memcached_bop_range_query_init(&smget_query, 5, 0, NULL, 0, 10);
-  memcached_coll_smget_result_create(memc, &smget_result);
-
-  rc = memcached_bop_smget(memc, keys, key_length, 3, &smget_query, &smget_result);
-  test_true_got(rc == MEMCACHED_SUCCESS, memcached_strerror(NULL, rc));
-  test_true_got(memcached_get_last_response_code(memc) == MEMCACHED_DUPLICATED_TRIMMED,
-                memcached_strerror(NULL, memcached_get_last_response_code(memc)));
-  test_true(6 == memcached_coll_smget_result_get_count(&smget_result));
-  test_true(0 == memcached_coll_smget_result_get_missed_key_count(&smget_result));
-  if (rc == MEMCACHED_SUCCESS) {
-    uint64_t sorted_bkeys[] = { 3, 3, 4, 4, 5, 5 };
-    for (uint32_t i=0; i<memcached_coll_smget_result_get_count(&smget_result); i++) {
-      test_true(strcmp(memcached_coll_smget_result_get_key(&smget_result, i),
-                       (i%2)==0 ? "test:smget_key_1" : "test:smget_key_0") == 0);
-      test_true(sorted_bkeys[(6-1)-i] == memcached_coll_smget_result_get_bkey(&smget_result, i));
-      /***
-      fprintf(stderr, "key[%s], bkey[%llu], eflag[%s] = %s\n",
-                      (char*)memcached_coll_smget_result_get_key(&smget_result, i),
-                      (unsigned long long)bkey, buffer,
-                      (char*)memcached_coll_smget_result_get_value(&smget_result, i));
-      ***/
-    }
-  }
-  memcached_coll_smget_result_free(&smget_result);
-
   /* do smget operation (descending order): duplicated & trimmed */
   /* range = 5 ~ 0, count = 6 */
   memcached_bop_range_query_init(&smget_query, 5, 0, NULL, 0, 6);
@@ -8437,42 +8335,6 @@ static test_return_t arcus_1_6_btree_smget_duptrim(memcached_st *memc)
     test_true_got(rc == MEMCACHED_SUCCESS || rc == MEMCACHED_BUFFERED, memcached_strerror(NULL, rc));
   }
 
-  /* do smget operation (ascending order): duplicated & trimmed */
-  memcached_bop_range_query_init(&smget_query, 0, 5, NULL, 0, 10);
-  memcached_coll_smget_result_create(memc, &smget_result);
-
-  rc = memcached_bop_smget(memc, keys, key_length, 3, &smget_query, &smget_result);
-  test_true_got(rc == MEMCACHED_OUT_OF_RANGE, memcached_strerror(NULL, rc));
-
-  memcached_coll_smget_result_free(&smget_result);
-
-  /* do smget operation (descending order): duplicated & trimmed */
-  /* count = 10 */
-  memcached_bop_range_query_init(&smget_query, 5, 0, NULL, 0, 10);
-  memcached_coll_smget_result_create(memc, &smget_result);
-
-  rc = memcached_bop_smget(memc, keys, key_length, 3, &smget_query, &smget_result);
-  test_true_got(rc == MEMCACHED_SUCCESS, memcached_strerror(NULL, rc));
-  test_true_got(memcached_get_last_response_code(memc) == MEMCACHED_DUPLICATED_TRIMMED,
-                memcached_strerror(NULL, memcached_get_last_response_code(memc)));
-  test_true(6 == memcached_coll_smget_result_get_count(&smget_result));
-  test_true(0 == memcached_coll_smget_result_get_missed_key_count(&smget_result));
-  if (rc == MEMCACHED_SUCCESS) {
-    uint64_t sorted_bkeys[] = { 3, 3, 4, 4, 5, 5 };
-    for (uint32_t i=0; i<memcached_coll_smget_result_get_count(&smget_result); i++) {
-      test_true(strcmp(memcached_coll_smget_result_get_key(&smget_result, i),
-                       (i%2)==0 ? "test:smget_key_1" : "test:smget_key_0") == 0);
-      test_true(sorted_bkeys[(6-1)-i] == memcached_coll_smget_result_get_bkey(&smget_result, i));
-      /***
-      fprintf(stderr, "key[%s], bkey[%llu] = %s\n",
-                      (char*)memcached_coll_smget_result_get_key(&smget_result, i),
-                      (unsigned long long)memcached_coll_smget_result_get_bkey(&smget_result, i),
-                      (char*)memcached_coll_smget_result_get_value(&smget_result, i));
-      ***/
-    }
-  }
-  memcached_coll_smget_result_free(&smget_result);
-
   /* do smget operation (descending order): duplicated & trimmed */
   /* range = 5 ~ 0, count = 6 */
   memcached_bop_range_query_init(&smget_query, 5, 0, NULL, 0, 6);
@@ -8524,110 +8386,6 @@ static test_return_t arcus_1_6_btree_smget_duptrim(memcached_st *memc)
   for (int i=0; i<10; i++) {
     free((void*)keys[i]);
   }
-  return TEST_SUCCESS;
-}
-
-static test_return_t arcus_1_6_btree_smget_duptrim2(memcached_st *memc)
-{
-  memcached_return_t rc;
-  const char *keys[2] = { "test:smget_key_0", "test:smget_key_1" };
-  size_t key_length[2] = { 16, 16 };
-  uint32_t eflag = 0;
-
-  memcached_coll_create_attrs_st attributes;
-  memcached_coll_create_attrs_init(&attributes, 0, 600, 1000);
-
-  memcached_coll_query_st        smget_query;
-  memcached_coll_smget_result_st smget_result;
-
-  /* create btree items */
-  memcached_coll_create_attrs_set_maxcount(&attributes, 10);
-  for (int i=0; i<10; i++) {
-    rc = memcached_bop_insert(memc, keys[0], key_length[0], i, (unsigned char *)&eflag, sizeof(eflag),
-                              test_literal_param("value"), &attributes);
-    test_true_got(rc == MEMCACHED_SUCCESS || rc == MEMCACHED_BUFFERED, memcached_strerror(NULL, rc));
-  }
-#ifdef IMPROVEMENT_TRIMMED_STATUS
-  for (int i=10; i<30; i++) {
-    rc = memcached_bop_insert(memc, keys[0], key_length[0], i, (unsigned char *)&eflag, sizeof(eflag),
-                              test_literal_param("value"), &attributes);
-    test_true_got(rc == MEMCACHED_SUCCESS || rc == MEMCACHED_BUFFERED, memcached_strerror(NULL, rc));
-  }
-#endif
-  for (int i=0; i<10; i++) {
-    rc = memcached_bop_insert(memc, keys[1], key_length[1], i, (unsigned char *)&eflag, sizeof(eflag),
-                              test_literal_param("value"), &attributes);
-    test_true_got(rc == MEMCACHED_SUCCESS || rc == MEMCACHED_BUFFERED, memcached_strerror(NULL, rc));
-  }
-
-  /* do smget operation (20 ~ 10, offset=0, count=100) */
-  memcached_bop_range_query_init(&smget_query, 20, 10, NULL, 0, 100);
-  memcached_coll_smget_result_create(memc, &smget_result);
-
-  rc = memcached_bop_smget(memc, keys, key_length, 2, &smget_query, &smget_result);
-  test_true_got(rc == MEMCACHED_SUCCESS, memcached_strerror(NULL, rc));
-  test_true_got(memcached_get_last_response_code(memc) == MEMCACHED_TRIMMED, /* response code */
-                memcached_strerror(NULL, memcached_get_last_response_code(memc)));
-  test_true(1 == memcached_coll_smget_result_get_count(&smget_result));
-  test_true(0 == memcached_coll_smget_result_get_missed_key_count(&smget_result));
-  if (rc == MEMCACHED_SUCCESS) {
-    for (uint32_t i=0; i<memcached_coll_smget_result_get_count(&smget_result); i++) {
-      test_true(strcmp(memcached_coll_smget_result_get_key(&smget_result, i), keys[0]) == 0);
-      test_true((20-i) == memcached_coll_smget_result_get_bkey(&smget_result, i));
-    }
-  }
-  memcached_coll_smget_result_free(&smget_result);
-
-  /* do smget operation (20 ~ 10, offset=5, count=100) */
-  memcached_bop_range_query_init(&smget_query, 20, 10, NULL, 5, 100);
-  memcached_coll_smget_result_create(memc, &smget_result);
-
-  rc = memcached_bop_smget(memc, keys, key_length, 2, &smget_query, &smget_result);
-  test_true_got(rc == MEMCACHED_SUCCESS, memcached_strerror(NULL, rc));
-  test_true_got(memcached_get_last_response_code(memc) == MEMCACHED_TRIMMED, /* response code */
-                memcached_strerror(NULL, memcached_get_last_response_code(memc)));
-  test_true(0 == memcached_coll_smget_result_get_count(&smget_result));
-  test_true(0 == memcached_coll_smget_result_get_missed_key_count(&smget_result));
-  memcached_coll_smget_result_free(&smget_result);
-
-  /* do smget operation (22 ~ 20, offset=5, count=100) */
-  memcached_bop_range_query_init(&smget_query, 22, 20, NULL, 5, 100);
-  memcached_coll_smget_result_create(memc, &smget_result);
-
-  rc = memcached_bop_smget(memc, keys, key_length, 2, &smget_query, &smget_result);
-  test_true_got(rc == MEMCACHED_SUCCESS, memcached_strerror(NULL, rc));
-  test_true_got(memcached_get_last_response_code(memc) == MEMCACHED_END, /* response code */
-                memcached_strerror(NULL, memcached_get_last_response_code(memc)));
-  test_true(0 == memcached_coll_smget_result_get_count(&smget_result));
-  test_true(0 == memcached_coll_smget_result_get_missed_key_count(&smget_result));
-  memcached_coll_smget_result_free(&smget_result);
-
-  /* do smget operation (50 ~ 40, offset=0, count=100) */
-  memcached_bop_range_query_init(&smget_query, 50, 40, NULL, 0, 100);
-  memcached_coll_smget_result_create(memc, &smget_result);
-
-  rc = memcached_bop_smget(memc, keys, key_length, 2, &smget_query, &smget_result);
-  test_true_got(rc == MEMCACHED_SUCCESS, memcached_strerror(NULL, rc));
-  test_true_got(memcached_get_last_response_code(memc) == MEMCACHED_END, /* response code */
-                memcached_strerror(NULL, memcached_get_last_response_code(memc)));
-  test_true(0 == memcached_coll_smget_result_get_count(&smget_result));
-  test_true(0 == memcached_coll_smget_result_get_missed_key_count(&smget_result));
-  memcached_coll_smget_result_free(&smget_result);
-
-  /* do smget operation (9 ~ 5, count=100) */
-  memcached_bop_range_query_init(&smget_query, 9, 5, NULL, 0, 100);
-  memcached_coll_smget_result_create(memc, &smget_result);
-
-  rc = memcached_bop_smget(memc, keys, key_length, 2, &smget_query, &smget_result);
-  test_true_got(rc == MEMCACHED_OUT_OF_RANGE, memcached_strerror(NULL, rc));
-
-  memcached_coll_smget_result_free(&smget_result);
-
-  /* delete btree items */
-  for (int i=0; i<2; i++) {
-    memcached_delete(memc, keys[i], key_length[i], 0);
-  }
-
   return TEST_SUCCESS;
 }
 
@@ -11916,7 +11674,6 @@ test_st arcus_1_6_collection_tests[] ={
 #endif
   {"arcus_1_6_btree_smget_one_key", true, (test_callback_fn*)arcus_1_6_btree_smget_one_key},
   {"arcus_1_6_btree_smget_duptrim", true, (test_callback_fn*)arcus_1_6_btree_smget_duptrim},
-  {"arcus_1_6_btree_smget_duptrim2", true, (test_callback_fn*)arcus_1_6_btree_smget_duptrim2},
   {"arcus_1_6_btree_count", true, (test_callback_fn*)arcus_1_6_btree_count},
   {"arcus_1_6_list_piped_insert", true, (test_callback_fn*)arcus_1_6_list_piped_insert},
   {"arcus_1_6_list_piped_insert_one", true, (test_callback_fn*)arcus_1_6_list_piped_insert_one},


### PR DESCRIPTION
### 🔗 Related Issue

- jam2in/arcus-works#721

### ⌨️ What I did

old bop smget 연산을 서버로 보내지 않도록 합니다.

- 기존 old smget(`memcached_bop_range_query_init`) 사용 시 동작은 아래와 같이 변경됩니다.
  - offset이 1 이상이면 `MEMCACHED_INVALID_ARGUMENTS` 에러를 반환합니다.
  - offset이 0 이면 new smget의 duplicate 명령으로 변환하여 전송합니다.
  이에 따라, 기존에 `TRIMED`, `DUPLICATED_TRIMMED`, `OUT_OF_RANGE`를 반환했던 경우에는
  (`END` 또는 `DUPLICATED`) + (`missed_key` or `trimmed_key`)로 그 반환값이 달라지게 됩니다.

- 또는, 기존 old smget(`memcached_bop_range_query_init`)을 사용하는 경우에는 모두 `MEMCACHED_DEPRECATED` 반환하고,
new smget(`memcached_bop_smget_query_init`)을 사용하는 경우에만 동작하도록 설정할 수 있습니다.