### PR TITLE
CLEANUP: Fix compile error in switch-case

### DIFF
--- a/libmemcached/arcus.cc
+++ b/libmemcached/arcus.cc
@@ -1129,18 +1129,14 @@ static inline void do_arcus_zk_watcher_cachelist(zhandle_t *zh __attribute__((un
                                                  const char *path,
                                                  void *ctx_mc)
 {
-  switch (type)
-  {
-  case ZOO_CHILD_EVENT:
-    ZOO_LOG_INFO(("ZOO_CHILD_EVENT from ZK cache list"));
-    break;
-  case ZOO_NOTWATCHING_EVENT:
-    ZOO_LOG_WARN(("Child watch removed. The znode is %s", path));
-    break;
-  case ZOO_SESSION_EVENT:
-    // Do nothing. Session events are handled by do_arcus_zk_watcher_global.
-    return;
-  default:
+  if (type == ZOO_CHILD_EVENT) {
+      ZOO_LOG_INFO(("ZOO_CHILD_EVENT from ZK cache list"));
+  } else if (type == ZOO_NOWATCHING_EVENT) {
+      ZOO_LOG_WARN(("Child watch removed. The znode is %s", path));
+  } else if (type == ZOO_SESSION_EVENT) {
+      // Do nothing. Session events are handled by do_arcus_zk_watcher_global.
+      return;
+  } else {
     ZOO_LOG_WARN(("Unexpected event gotten by watcher_cachelist. type=%d, path=%s", type, path));
     return;
   }


### PR DESCRIPTION
### 🔗 Related Issue

- #374 

long-running-test를 위한 빌드 중 아래와 같은 에러가 발생하였습니다.
```
libmemcached/arcus.cc: In function 'void do_arcus_zk_watcher_cachelist(zhandle_t*, int, int, const char*, void*)':
libmemcached/arcus.cc:1134:8: error: 'ZOO_CHILD_EVENT' cannot appear in a constant-expression
   case ZOO_CHILD_EVENT:
        ^
libmemcached/arcus.cc:1137:8: error: 'ZOO_NOTWATCHING_EVENT' cannot appear in a constant-expression
   case ZOO_NOTWATCHING_EVENT:
        ^
libmemcached/arcus.cc:1140:8: error: 'ZOO_SESSION_EVENT' cannot appear in a constant-expression
   case ZOO_SESSION_EVENT:
```

### ⌨️ What I did

- switch의 각 case에는 상수만 위치할 수 있는데, ZOO_XXX_EVENT가 변수라서 문제가 생기는 것 같습니다.

```c
#define CREATED_EVENT_DEF 1
#define DELETED_EVENT_DEF 2
#define CHANGED_EVENT_DEF 3
#define CHILD_EVENT_DEF 4
#define SESSION_EVENT_DEF -1
#define NOTWATCHING_EVENT_DEF -2

const int ZOO_CREATED_EVENT = CREATED_EVENT_DEF;
const int ZOO_DELETED_EVENT = DELETED_EVENT_DEF;
const int ZOO_CHANGED_EVENT = CHANGED_EVENT_DEF;
const int ZOO_CHILD_EVENT = CHILD_EVENT_DEF;
const int ZOO_SESSION_EVENT = SESSION_EVENT_DEF;
const int ZOO_NOTWATCHING_EVENT = NOTWATCHING_EVENT_DEF;
```
ZOO_XXX_EVENT는 위와 같이 정의되며, 실제로는 변하지 않는 값입니다.

CI 테스트(ubuntu-latest)와 제가 작업하는 장비(ncp-2c4-001)에서는 문제 발생하지 않았는데,
환경과 무관하게 문제 발생하지 않도록 switch-case 대신 if-else 사용합니다.
