### PR TITLE
INTERNAL: Extract hostname validation logic

### DIFF
--- a/libmemcached/hosts.cc
+++ b/libmemcached/hosts.cc
@@ -639,6 +639,12 @@ static memcached_return_t server_add(memcached_st *ptr,
     return memcached_set_error(*ptr, MEMCACHED_INVALID_HOST_PROTOCOL, MEMCACHED_AT);
   }
 
+  if (memcached_is_valid_servername(hostname) == false)
+  {
+    return memcached_set_error(*ptr, MEMCACHED_INVALID_ARGUMENTS, MEMCACHED_AT,
+                               memcached_literal_param("Invalid hostname provided"));
+  }
+
   memcached_server_st *new_host_list;
   new_host_list= static_cast<memcached_server_st*>(libmemcached_realloc(ptr, memcached_server_list(ptr),
                                                    sizeof(memcached_server_st) * (ptr->number_of_hosts + 1)));
@@ -712,6 +718,11 @@ memcached_return_t memcached_server_push_with_count(memcached_st *ptr,
     WATCHPOINT_ASSERT(instance);
 
     memcached_string_t hostname= { memcached_string_make_from_cstr(list[x].hostname) };
+    if (memcached_is_valid_servername(hostname) == false) {
+      return memcached_set_error(*ptr, MEMCACHED_INVALID_ARGUMENTS, MEMCACHED_AT,
+                                 memcached_literal_param("Invalid hostname provided"));
+    }
+
     if (__server_create_with(ptr, instance,
                              hostname,
                              list[x].port, list[x].weight, list[x].type) == NULL)
@@ -778,6 +789,10 @@ memcached_return_t memcached_server_push_with_serverinfo(memcached_st *ptr,
       WATCHPOINT_ASSERT(instance);
 
       memcached_string_t hostname= { memcached_string_make_from_cstr(serverinfo[x].hostname) };
+      if (memcached_is_valid_servername(hostname) == false) {
+        return memcached_set_error(*ptr, MEMCACHED_INVALID_ARGUMENTS, MEMCACHED_AT,
+                                   memcached_literal_param("Invalid hostname provided"));
+      }
       if (__server_create_with(ptr, instance, hostname, serverinfo[x].port, 0,
                               serverinfo[x].port ? MEMCACHED_CONNECTION_TCP : MEMCACHED_CONNECTION_UNIX_SOCKET) == NULL)
       {
@@ -815,11 +830,6 @@ memcached_return_t memcached_server_add_unix_socket_with_weight(memcached_st *pt
   }
 
   memcached_string_t _filename= { memcached_string_make_from_cstr(filename) };
-  if (memcached_is_valid_servername(_filename) == false)
-  {
-    memcached_set_error(*ptr, MEMCACHED_INVALID_ARGUMENTS, MEMCACHED_AT,
-                        memcached_literal_param("Invalid filename for socket provided"));
-  }
 
   return server_add(ptr, _filename, 0, weight, MEMCACHED_CONNECTION_UNIX_SOCKET);
 }
@@ -852,11 +862,6 @@ memcached_return_t memcached_server_add_udp_with_weight(memcached_st *ptr,
   }
 
   memcached_string_t _hostname= { memcached_string_make_from_cstr(hostname) };
-  if (memcached_is_valid_servername(_hostname) == false)
-  {
-    memcached_set_error(*ptr, MEMCACHED_INVALID_ARGUMENTS, MEMCACHED_AT,
-                        memcached_literal_param("Invalid hostname provided"));
-  }
 
   return server_add(ptr, _hostname, port, weight, MEMCACHED_CONNECTION_UDP);
 }
@@ -891,12 +896,6 @@ memcached_return_t memcached_server_add_with_weight(memcached_st *ptr,
   }
 
   memcached_string_t _hostname= { hostname, hostname_length };
-
-  if (memcached_is_valid_servername(_hostname) == false)
-  {
-    return memcached_set_error(*ptr, MEMCACHED_INVALID_ARGUMENTS, MEMCACHED_AT,
-                               memcached_literal_param("Invalid hostname provided"));
-  }
 
   return server_add(ptr, _hostname, port, weight,
                     _hostname.c_str[0] == '/' ? MEMCACHED_CONNECTION_UNIX_SOCKET

--- a/libmemcached/rgroup.cc
+++ b/libmemcached/rgroup.cc
@@ -190,6 +190,11 @@ do_rgroup_server_insert(memcached_rgroup_st *rgroup, int sindex,
 
   /* create a new memcached server */
   memcached_string_t _hostname= { memcached_string_make_from_cstr(hostname) };
+  if (memcached_is_valid_servername(_hostname) == false) {
+    memcached_set_error(*rgroup->root, MEMCACHED_INVALID_ARGUMENTS, MEMCACHED_AT,
+                        memcached_literal_param("Invalid hostname provided"));
+    return;
+  }
   server= do_rgroup_server_alloc(rgroup->root);
   assert(server != NULL);
   server= __server_create_with(rgroup->root, server, _hostname, port, 0,
@@ -252,6 +257,11 @@ do_rgroup_server_replace(memcached_rgroup_st *rgroup, int sindex,
 
   /* create a new memcached server */
   memcached_string_t _hostname= { memcached_string_make_from_cstr(hostname) };
+  if (memcached_is_valid_servername(_hostname) == false) {
+    memcached_set_error(*rgroup->root, MEMCACHED_INVALID_ARGUMENTS, MEMCACHED_AT,
+                        memcached_literal_param("Invalid hostname provided"));
+    return;
+  }
   new_server= do_rgroup_server_alloc(rgroup->root);
   assert(new_server != NULL);
   new_server= __server_create_with(rgroup->root, new_server, _hostname, port, 0,

--- a/libmemcached/server.cc
+++ b/libmemcached/server.cc
@@ -134,12 +134,6 @@ memcached_server_st *__server_create_with(memcached_st *memc,
                                           uint32_t weight,
                                           const memcached_connection_t type)
 {
-  if (memcached_is_valid_servername(hostname) == false)
-  {
-    memcached_set_error(*memc, MEMCACHED_INVALID_ARGUMENTS, MEMCACHED_AT, memcached_literal_param("Invalid hostname provided"));
-    return NULL;
-  }
-
   self= _server_create(self, memc);
 
   if (not self)
@@ -208,6 +202,12 @@ memcached_server_st *memcached_server_clone(memcached_server_st *destination,
   }
 
   memcached_string_t hostname= { memcached_string_make_from_cstr(source->hostname) };
+  if (memcached_is_valid_servername(hostname) == false)
+  {
+    memcached_set_error(*source, MEMCACHED_INVALID_ARGUMENTS, MEMCACHED_AT,
+                        memcached_literal_param("Invalid hostname provided"));
+    return NULL;
+  }
   destination= __server_create_with(source->root, destination,
                                     hostname,
                                     source->port, source->weight,

--- a/libmemcached/server_list.cc
+++ b/libmemcached/server_list.cc
@@ -60,6 +60,13 @@ memcached_server_list_append_with_weight(memcached_server_list_st ptr,
     port= MEMCACHED_DEFAULT_PORT;
   }
 
+  memcached_string_t _hostname= { memcached_string_make_from_cstr(hostname) };
+  if (memcached_is_valid_servername(_hostname) == false) {
+    memcached_set_error(*ptr, MEMCACHED_INVALID_ARGUMENTS, MEMCACHED_AT,
+                        memcached_literal_param("Invalid hostname provided"));
+    return NULL;
+  }
+
   /* Increment count for hosts */
   count= 1;
   if (ptr != NULL) {
@@ -72,8 +79,6 @@ memcached_server_list_append_with_weight(memcached_server_list_st ptr,
     return NULL;
   }
 
-  memcached_string_t _hostname= { memcached_string_make_from_cstr(hostname) };
-  /* @todo Check return type */
   if (not __server_create_with(NULL, &new_host_list[count-1], _hostname, port, weight,
                                port ? MEMCACHED_CONNECTION_TCP : MEMCACHED_CONNECTION_UNIX_SOCKET))
   {


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- jam2in/arcus-works#717

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- __server_create_with 내부의 hostname 유효성 검사를 외부에서 호출하도록 변경합니다.
