### PR TITLE
FIX: Correct invalid check logic for servername

### DIFF
--- a/libmemcached/server.hpp
+++ b/libmemcached/server.hpp
@@ -62,9 +62,9 @@
 
 #include <cassert>
 
-static inline bool memcached_is_valid_servername(const memcached_string_t& arg)
+static inline bool memcached_is_valid_servername(const memcached_string_t &arg)
 {
-  return arg.size > 0 or arg.size < NI_MAXHOST;
+  return (arg.c_str != NULL or arg.size == 0) and arg.size < MEMCACHED_NI_MAXHOST;
 }
 
 static inline void memcached_mark_server_as_clean(memcached_server_write_instance_st server)


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- jam2in/arcus-works#717
- https://github.com/awesomized/libmemcached/commit/4d91f4de5a20d137435d0141f0dab9e9951d5eb4

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- memcached_is_valid_servername에서 잘못된 비교 연산을 수정합니다.
- 최신 libmemcached 와 동일하게 수정합니다.
- `NI_MAXHOST` 는 시스템 환경에 따라 정의가 되지 않을 수 있으며, 이에 따라 libmemcached 내부에서 `MEMCACHED_NI_MAXHOST`를 사용하도록 정의하고 있습니다.
```c
#ifdef NI_MAXHOST
#define MEMCACHED_NI_MAXHOST NI_MAXHOST
#else
#define MEMCACHED_NI_MAXHOST 1025
#endif
```
