### PR TITLE
FEATURE: Add ascii sasl authentication

### DIFF
--- a/libmemcached/response.cc
+++ b/libmemcached/response.cc
@@ -237,6 +237,80 @@ static memcached_return_t textual_version_fetch(memcached_server_write_instance_
   return MEMCACHED_SUCCESS;
 }
 
+static memcached_return_t textual_sasl_continue_fetch(memcached_server_write_instance_st ptr,
+                                                      char *buffer, size_t buffer_length,
+                                                      memcached_result_st *result)
+{
+  char *string_ptr;
+  char *next_ptr;
+  char *end_ptr;
+  size_t value_length;
+  size_t to_read;
+  ssize_t read_length= 0;
+
+  string_ptr= buffer;
+  end_ptr= buffer + buffer_length;
+
+  memcached_result_reset(result);
+
+  string_ptr+= 14; /* "SASL_CONTINUE " */
+  if (end_ptr <= string_ptr)
+      return MEMCACHED_PARTIAL_READ;
+
+  for (next_ptr= string_ptr; isdigit(*string_ptr); string_ptr++) {};
+  value_length= (size_t)strtoull(next_ptr, &string_ptr, 10);
+
+  if (end_ptr <= string_ptr)
+      return MEMCACHED_PARTIAL_READ;
+
+  if (*string_ptr == '\r')
+  {
+    /* Skip past the \r\n */
+    string_ptr+= 2;
+  }
+
+  if (end_ptr < string_ptr)
+      return MEMCACHED_PARTIAL_READ;
+
+  /* We add two bytes so that we can walk the \r\n */
+  if (memcached_failed(memcached_string_check(&result->value, value_length +2)))
+  {
+    return memcached_set_error(*ptr, MEMCACHED_MEMORY_ALLOCATION_FAILURE, MEMCACHED_AT);
+  }
+
+  char *value_ptr= memcached_string_value_mutable(&result->value);
+  /*
+    We read the \r\n into the string since not doing so is more
+    cycles then the waster of memory to do so.
+
+    We are null terminating through, which will most likely make
+    some people lazy about using the return length.
+  */
+  to_read= value_length + 2;
+  memcached_return_t rrc= memcached_io_read(ptr, value_ptr, to_read, &read_length);
+  if (memcached_failed(rrc) and rrc == MEMCACHED_IN_PROGRESS)
+  {
+    memcached_quit_server(ptr, true);
+    return memcached_set_error(*ptr, MEMCACHED_IN_PROGRESS, MEMCACHED_AT);
+  }
+  else if (memcached_failed(rrc))
+  {
+    return rrc;
+  }
+
+  if (read_length != (ssize_t)(value_length + 2))
+    return MEMCACHED_PARTIAL_READ;
+
+  /* This next bit blows the API, but this is internal.... */
+  char *char_ptr;
+  char_ptr= memcached_string_value_mutable(&result->value);
+  char_ptr[value_length]= 0;
+  char_ptr[value_length +1]= 0;
+  memcached_string_set_length(&result->value, value_length);
+
+  return MEMCACHED_AUTH_CONTINUE;
+}
+
 #ifdef ENABLE_REPLICATION
 static void textual_switchover_peer_check(memcached_server_write_instance_st instance, char *buffer)
 {
@@ -341,6 +415,20 @@ static memcached_return_t textual_read_one_response(memcached_server_write_insta
     else if (memcmp(buffer, "STORED", 6) == 0)
     {
       return MEMCACHED_STORED;
+    }
+    else if (memcmp(buffer, "SASL_MECH", 9) == 0)
+    {
+      memmove(buffer, buffer + 10, total_read);
+      buffer[total_read - 10 - 2] = '\0';
+      return MEMCACHED_SUCCESS;
+    }
+    else if (memcmp(buffer, "SASL_CONTINUE", 13) == 0)
+    {
+      return textual_sasl_continue_fetch(ptr, buffer, buffer_length, result);
+    }
+    else if (memcmp(buffer, "SASL_OK", 7) == 0)
+    {
+      return MEMCACHED_SUCCESS;
     }
 #ifdef ENABLE_REPLICATION
     else if (memcmp(buffer, "SWITCHOVER", 10) == 0)
@@ -468,6 +556,13 @@ static memcached_return_t textual_read_one_response(memcached_server_write_insta
 
       return memcached_set_error(*ptr, MEMCACHED_CLIENT_ERROR, MEMCACHED_AT,
                                  startptr, size_t(endptr - startptr));
+    }
+    break;
+
+  case 'A':
+    if (memcmp(buffer, "AUTH_ERROR", 10) == 0)
+    {
+      return MEMCACHED_AUTH_FAILURE;
     }
     break;
 

--- a/libmemcached/sasl.cc
+++ b/libmemcached/sasl.cc
@@ -129,8 +129,7 @@ static memcached_return_t memcached_sasl_mech_binary(memcached_server_st *server
   request.message.header.request.magic= PROTOCOL_BINARY_REQ;
   request.message.header.request.opcode= PROTOCOL_BINARY_CMD_SASL_LIST_MECHS;
 
-  if (memcached_io_write(server, request.bytes,
-                         sizeof(request.bytes), 1) != sizeof(request.bytes))
+  if (memcached_io_write(server, request.bytes, sizeof(request.bytes), 1) == -1)
   {
     return MEMCACHED_WRITE_FAILURE;
   }
@@ -166,6 +165,49 @@ static memcached_return_t memcached_sasl_auth_binary(memcached_server_st *server
   return memcached_response(server, NULL, 0, NULL);
 }
 
+static memcached_return_t memcached_sasl_mech_ascii(memcached_server_st *server,
+                                                    char *buffer, size_t buffer_length)
+{
+  if (memcached_io_write(server, "sasl mech\r\n", 11, 1) == -1)
+  {
+    return MEMCACHED_WRITE_FAILURE;
+  }
+  memcached_server_response_increment(server);
+
+  return memcached_response(server, buffer, buffer_length, NULL);
+}
+
+static memcached_return_t memcached_sasl_auth_ascii(memcached_server_st *server, const char *chosenmech,
+                                                    bool is_first, const char *data, unsigned int len)
+{
+  char command[64];
+  unsigned int write_length;
+  if (is_first)
+  {
+    write_length = snprintf(command, sizeof(command), "sasl auth %s %u\r\n", chosenmech, len);
+  }
+  else
+  {
+    write_length = snprintf(command, sizeof(command), "sasl auth %u\r\n", len);
+  }
+
+  struct libmemcached_io_vector_st vector[]=
+  {
+    { write_length, command },
+    { len, data },
+    { 2, "\r\n" }
+  };
+
+  if (memcached_io_writev(server, vector, 3, true) == -1)
+  {
+    return MEMCACHED_WRITE_FAILURE;
+  }
+  memcached_server_response_increment(server);
+
+  char buffer[MEMCACHED_DEFAULT_COMMAND_SIZE + MEMCACHED_MAX_KEY];
+  return memcached_response(server, buffer, sizeof(buffer), NULL);
+}
+
 memcached_return_t memcached_sasl_authenticate_connection(memcached_server_st *server)
 {
   if (LIBMEMCACHED_WITH_SASL_SUPPORT == 0)
@@ -178,18 +220,14 @@ memcached_return_t memcached_sasl_authenticate_connection(memcached_server_st *s
     return MEMCACHED_INVALID_ARGUMENTS;
   }
 
-  /* SANITY CHECK: SASL can only be used with the binary protocol */
-  if (server->root->flags.binary_protocol == false)
-  {
-    return MEMCACHED_PROTOCOL_ERROR;
-  }
-
   /* Try to get the supported mech from the server. Servers without SASL
    * support will return UNKNOWN COMMAND, so we can just treat that
    * as authenticated
  */
   char mech[MEMCACHED_MAX_BUFFER];
-  memcached_return_t rc= memcached_sasl_mech_binary(server, mech, MEMCACHED_MAX_BUFFER);
+  memcached_return_t rc= server->root->flags.binary_protocol
+    ? memcached_sasl_mech_binary(server, mech, sizeof(mech))
+    : memcached_sasl_mech_ascii(server, mech, sizeof(mech));
   if (memcached_failed(rc))
   {
     if (rc == MEMCACHED_PROTOCOL_ERROR)
@@ -257,7 +295,9 @@ memcached_return_t memcached_sasl_authenticate_connection(memcached_server_st *s
                                memcached_string_make_from_cstr(sasl_error_msg));
   }
 
-  rc= memcached_sasl_auth_binary(server, chosenmech, true, data, len);
+  rc= server->root->flags.binary_protocol
+    ? memcached_sasl_auth_binary(server, chosenmech, true, data, len)
+    : memcached_sasl_auth_ascii(server, chosenmech, true, data, len);
   while (rc == MEMCACHED_AUTH_CONTINUE)
   {
     ret= sasl_client_step(conn, memcached_result_value(&server->root->result),
@@ -270,7 +310,9 @@ memcached_return_t memcached_sasl_authenticate_connection(memcached_server_st *s
       break;
     }
 
-    rc= memcached_sasl_auth_binary(server, chosenmech, false, data, len);
+    rc= server->root->flags.binary_protocol
+      ? memcached_sasl_auth_binary(server, chosenmech, false, data, len)
+      : memcached_sasl_auth_ascii(server, chosenmech, false, data, len);
   }
 
   /* Release resources */
@@ -320,12 +362,6 @@ memcached_return_t memcached_set_sasl_auth_data(memcached_st *ptr,
   if (ptr == NULL or username == NULL or password == NULL)
   {
     return MEMCACHED_INVALID_ARGUMENTS;
-  }
-
-  memcached_return_t ret;
-  if (memcached_failed(ret= memcached_behavior_set(ptr, MEMCACHED_BEHAVIOR_BINARY_PROTOCOL, 1)))
-  {
-    return memcached_set_error(*ptr, ret, MEMCACHED_AT, memcached_literal_param("Unable change to binary protocol which is required for SASL."));
   }
 
   memcached_destroy_sasl_auth_data(ptr);


### PR DESCRIPTION
### 🔗 Related Issue

- jam2in/arcus-works#634

### ⌨️ What I did

- ascii protocol에서 sasl 인증 사용할 수 있도록 합니다.
- `textual_sasl_continue_fetch`는 `textual_value_fetch` 참고하여 구현하였습니다.
