### PR TITLE
CLEANUP: Unlock mutex before return if sasl startup fails

### DIFF
--- a/libmemcached/sasl.cc
+++ b/libmemcached/sasl.cc
@@ -193,6 +193,7 @@ memcached_return_t memcached_sasl_authenticate_connection(memcached_server_st *s
   if (sasl_startup_state != SASL_OK)
   {
     const char *sasl_error_msg= sasl_errstring(sasl_startup_state, NULL, NULL);
+    (void)pthread_mutex_unlock(&sasl_startup_state_LOCK);
     return memcached_set_error(*server, MEMCACHED_AUTH_PROBLEM, MEMCACHED_AT,
                                memcached_string_make_from_cstr(sasl_error_msg));
   }


### PR DESCRIPTION
### 🔗 Related Issue

- #382 

### ⌨️ What I did

- sasl_startup 중 에러 발생했을 때 lock을 놓지 않고 반환하던 문제를 수정합니다.
