### PR TITLE
INTERNAL: Refactor memcached_key_test code

### DIFF
--- a/libmemcached/auto.cc
+++ b/libmemcached/auto.cc
@@ -68,11 +68,6 @@ static memcached_return_t text_incr_decr(memcached_st *ptr,
 {
   arcus_server_check_for_update(ptr);
 
-  if (memcached_failed(memcached_key_test(*ptr, (const char **)&key, &key_length, 1)))
-  {
-    return memcached_set_error(*ptr, MEMCACHED_BAD_KEY_PROVIDED, MEMCACHED_AT);
-  }
-
   char offset_buffer[MEMCACHED_MAXIMUM_INTEGER_DISPLAY_LENGTH + 1 + 1]; // 1 for space, 1 for null termination
   int offset_buffer_length= snprintf(offset_buffer, sizeof(offset_buffer), " %" PRIu64, offset);
   if (size_t(offset_buffer_length) >= sizeof(offset_buffer) or offset_buffer_length < 0)
@@ -266,7 +261,7 @@ memcached_return_t memcached_increment_by_key(memcached_st *ptr,
     return rc;
   }
 
-  if (memcached_failed(rc= memcached_validate_key_length(key_length, ptr->flags.binary_protocol)))
+  if (memcached_failed(rc= memcached_key_test(*ptr, (const char **)&key, &key_length, 1)))
   {
     return rc;
   }
@@ -306,7 +301,7 @@ memcached_return_t memcached_decrement_by_key(memcached_st *ptr,
     return rc;
   }
 
-  if (memcached_failed(rc= memcached_validate_key_length(key_length, ptr->flags.binary_protocol)))
+  if (memcached_failed(rc= memcached_key_test(*ptr, (const char **)&key, &key_length, 1)))
   {
     return rc;
   }
@@ -368,7 +363,7 @@ memcached_return_t memcached_increment_with_initial_by_key(memcached_st *ptr,
     return rc;
   }
 
-  if (memcached_failed(rc= memcached_validate_key_length(key_length, ptr->flags.binary_protocol)))
+  if (memcached_failed(rc= memcached_key_test(*ptr, (const char **)&key, &key_length, 1)))
   {
     return rc;
   }
@@ -430,7 +425,7 @@ memcached_return_t memcached_decrement_with_initial_by_key(memcached_st *ptr,
     return rc;
   }
 
-  if (memcached_failed(rc= memcached_validate_key_length(key_length, ptr->flags.binary_protocol)))
+  if (memcached_failed(rc= memcached_key_test(*ptr, (const char **)&key, &key_length, 1)))
   {
     return rc;
   }

--- a/libmemcached/common.h
+++ b/libmemcached/common.h
@@ -185,32 +185,6 @@ memcached_return_t memcached_key_test(const memcached_st& memc,
 LIBMEMCACHED_LOCAL
 memcached_return_t memcached_purge(memcached_server_write_instance_st ptr);
 
-
-static inline memcached_return_t memcached_validate_key_length(size_t key_length, bool binary)
-{
-  if (key_length == 0)
-  {
-    return MEMCACHED_BAD_KEY_PROVIDED;
-  }
-
-  if (binary)
-  {
-    if (key_length > 0xffff)
-    {
-      return MEMCACHED_BAD_KEY_PROVIDED;
-    }
-  }
-  else
-  {
-    if (key_length >= MEMCACHED_MAX_KEY)
-    {
-      return MEMCACHED_BAD_KEY_PROVIDED;
-    }
-  }
-
-  return MEMCACHED_SUCCESS;
-}
-
 #ifdef __cplusplus
 }
 #endif

--- a/libmemcached/delete.cc
+++ b/libmemcached/delete.cc
@@ -252,11 +252,6 @@ memcached_return_t memcached_delete_by_key(memcached_st *ptr,
     return rc;
   }
 
-  if (memcached_failed(rc= memcached_validate_key_length(key_length, ptr->flags.binary_protocol)))
-  {
-    return rc;
-  }
-
   if (memcached_failed(rc= memcached_key_test(*ptr, (const char **)&key, &key_length, 1)))
   {
     return rc;

--- a/libmemcached/exist.cc
+++ b/libmemcached/exist.cc
@@ -179,11 +179,6 @@ memcached_return_t memcached_exist_by_key(memcached_st *memc,
     return rc;
   }
 
-  if (memcached_failed(rc= memcached_validate_key_length(key_length, memc->flags.binary_protocol)))
-  {
-    return rc;
-  }
-
   if (memcached_failed(rc= memcached_key_test(*memc, (const char **)&key, &key_length, 1)))
   {
     return rc;

--- a/libmemcached/get.cc
+++ b/libmemcached/get.cc
@@ -244,19 +244,6 @@ static memcached_return_t simple_binary_mget(memcached_st *ptr,
     else
       request.message.header.request.opcode= PROTOCOL_BINARY_CMD_GETK;
 
-    memcached_return_t vk;
-    vk= memcached_validate_key_length(key_length[x],
-                                      ptr->flags.binary_protocol);
-    unlikely (vk != MEMCACHED_SUCCESS)
-    {
-      if (x > 0)
-      {
-        memcached_io_reset(instance);
-      }
-
-      return vk;
-    }
-
     request.message.header.request.keylen= htons((uint16_t)(key_length[x] + memcached_array_size(ptr->_namespace)));
     request.message.header.request.datatype= PROTOCOL_BINARY_RAW_BYTES;
     request.message.header.request.bodylen= htonl((uint32_t)( key_length[x] + memcached_array_size(ptr->_namespace)));

--- a/libmemcached/key.cc
+++ b/libmemcached/key.cc
@@ -37,30 +37,59 @@
 
 #include <libmemcached/common.h>
 
+static inline memcached_return_t memcached_validate_key_length(size_t key_length, bool binary)
+{
+  if (key_length == 0)
+  {
+    return MEMCACHED_BAD_KEY_PROVIDED;
+  }
+
+  if (binary)
+  {
+    if (key_length > 0xffff)
+    {
+      return MEMCACHED_BAD_KEY_PROVIDED;
+    }
+  }
+  else
+  {
+    if (key_length >= MEMCACHED_MAX_KEY)
+    {
+      return MEMCACHED_BAD_KEY_PROVIDED;
+    }
+  }
+
+  return MEMCACHED_SUCCESS;
+}
+
 memcached_return_t memcached_key_test(const memcached_st &memc,
                                       const char * const *keys,
                                       const size_t *key_length,
                                       const size_t number_of_keys)
 {
-  if (not memc.flags.verify_key)
-    return MEMCACHED_SUCCESS;
-
-  if (memc.flags.binary_protocol)
-    return MEMCACHED_SUCCESS;
-
-  for (uint32_t x= 0; x < number_of_keys; x++)
+  if (number_of_keys == 0 || keys == NULL || key_length == NULL)
   {
-    memcached_return_t rc= memcached_validate_key_length(*(key_length + x), false);
-    if (memcached_failed(rc))
+    return MEMCACHED_INVALID_ARGUMENTS;
+  }
+
+  memcached_return_t rc;
+  const bool is_binary= memc.flags.binary_protocol;
+  for (size_t x= 0; x < number_of_keys; x++)
+  {
+    rc= memcached_validate_key_length(key_length[x], is_binary);
+    if (rc != MEMCACHED_SUCCESS)
     {
       return rc;
     }
 
-    for (size_t y= 0; y < *(key_length + x); y++)
+    if (memc.flags.verify_key && is_binary == false)
     {
-      if ((isgraph(keys[x][y])) == 0)
+      for (size_t y= 0; y < key_length[x]; y++)
       {
-        return MEMCACHED_BAD_KEY_PROVIDED;
+        if ((isgraph(keys[x][y])) == 0)
+        {
+          return MEMCACHED_BAD_KEY_PROVIDED;
+        }
       }
     }
   }

--- a/libmemcached/namespace.cc
+++ b/libmemcached/namespace.cc
@@ -53,12 +53,13 @@ memcached_return_t memcached_set_namespace(memcached_st *self, const char *key, 
   }
   else if (key and key_length)
   {
+    memcached_return_t rc;
     bool orig= self->flags.verify_key;
     self->flags.verify_key= true;
-    if (memcached_failed(memcached_key_test(*self, (const char **)&key, &key_length, 1)))
+    if (memcached_failed(rc= memcached_key_test(*self, (const char **)&key, &key_length, 1)))
     {
       self->flags.verify_key= orig;
-      return memcached_set_error(*self, MEMCACHED_BAD_KEY_PROVIDED, MEMCACHED_AT);
+      return memcached_set_error(*self, rc, MEMCACHED_AT);
     }
     self->flags.verify_key= orig;
 

--- a/libmemcached/server.cc
+++ b/libmemcached/server.cc
@@ -292,15 +292,9 @@ memcached_server_instance_st memcached_server_by_key(const memcached_st *ptr,
     return NULL;
   }
 
-  if (memcached_failed(rc= memcached_validate_key_length(key_length, ptr->flags.binary_protocol)))
+  if (memcached_failed(rc= memcached_key_test(*ptr, (const char **)&key, &key_length, 1)))
   {
     *error= rc;
-    return NULL;
-  }
-
-  if (memcached_failed((memcached_key_test(*ptr, (const char **)&key, &key_length, 1))))
-  {
-    *error= MEMCACHED_BAD_KEY_PROVIDED;
     return NULL;
   }
 

--- a/libmemcached/stats.cc
+++ b/libmemcached/stats.cc
@@ -338,11 +338,6 @@ static memcached_return_t binary_stats_fetch(memcached_stat_st *memc_stat,
   if (args)
   {
     size_t len= strlen(args);
-
-    memcached_return_t rc= memcached_validate_key_length(len, true);
-    unlikely (rc != MEMCACHED_SUCCESS)
-      return rc;
-
     request.message.header.request.keylen= htons((uint16_t)len);
     request.message.header.request.bodylen= htonl((uint32_t) len);
 
@@ -352,7 +347,7 @@ static memcached_return_t binary_stats_fetch(memcached_stat_st *memc_stat,
       { len, args }
     };
 
-    rc = memcached_vdo(instance, vector, 2, true);
+    memcached_return_t rc = memcached_vdo(instance, vector, 2, true);
     if (rc != MEMCACHED_SUCCESS) {
       return rc;
     }

--- a/libmemcached/storage.cc
+++ b/libmemcached/storage.cc
@@ -461,14 +461,9 @@ static inline memcached_return_t memcached_send(memcached_st *ptr,
     return rc;
   }
 
-  if (memcached_failed(rc= memcached_validate_key_length(key_length, ptr->flags.binary_protocol)))
+  if (memcached_failed(rc= memcached_key_test(*ptr, (const char **)&key, &key_length, 1)))
   {
     return rc;
-  }
-
-  if (memcached_failed(memcached_key_test(*ptr, (const char **)&key, &key_length, 1)))
-  {
-    return MEMCACHED_BAD_KEY_PROVIDED;
   }
 
   uint32_t server_key= memcached_generate_hash_with_redistribution(ptr, group_key, group_key_length);
@@ -543,8 +538,7 @@ static memcached_return_t memcached_send_multi(memcached_st *ptr,
       failure_occurred= true;
       results[i]= MEMCACHED_INVALID_ARGUMENTS;
     }
-    else if (memcached_failed(rc= memcached_validate_key_length(req[i].key_length, ptr->flags.binary_protocol)) or
-             memcached_failed(rc= memcached_key_test(*ptr, &(req[i].key), &(req[i].key_length), 1)))
+    else if (memcached_failed(rc= memcached_key_test(*ptr, &(req[i].key), &(req[i].key_length), 1)))
     {
       failure_occurred= true;
       results[i]= rc;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- jam2in/arcus-works#753

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- memcached_validate_key_length()를 별도로 호출하지 않고, 해당 로직을 memcached_key_test() 내부에 통합하였습니다.
- libmemcached의 구현을 참고했으며, 구조적 차이로 인해 전체 코드를 그대로 적용하지는 않았습니다.
  - [key.cc](https://github.com/awesomized/libmemcached/blob/86608cf9542fa65bc11430421a26b3d80371c430/src/libmemcached/key.cc#L43) 
