### PR TITLE
FEATURE: Add gat API

### DIFF
--- a/libmemcached/get.cc
+++ b/libmemcached/get.cc
@@ -198,6 +198,76 @@ static memcached_return_t ascii_get_by_key(memcached_st *ptr,
   return rc;
 }
 
+static memcached_return_t ascii_gat_by_key(memcached_st *ptr,
+                                           const char *key,
+                                           const size_t key_length,
+                                           time_t expiration)
+{
+  memcached_return_t rc;
+  memcached_server_write_instance_st instance;
+  uint32_t server_key= memcached_generate_hash_with_redistribution(ptr, key, key_length);
+
+  instance= memcached_server_instance_fetch(ptr, server_key);
+
+  const char *command= (ptr->flags.support_cas ? "gats " : "gat ");
+
+  char expiration_buffer[MEMCACHED_MAXIMUM_INTEGER_DISPLAY_LENGTH + 1 + 1];
+  int expiration_buffer_length= snprintf(expiration_buffer, sizeof(expiration_buffer), "%lld ",
+                                         (long long)expiration);
+  if (size_t(expiration_buffer_length) >= sizeof(expiration_buffer) or expiration_buffer_length < 0)
+  {
+    return memcached_set_error(*ptr, MEMCACHED_MEMORY_ALLOCATION_FAILURE, MEMCACHED_AT,
+                               memcached_literal_param("snprintf(MEMCACHED_MAXIMUM_INTEGER_DISPLAY_LENGTH)"));
+  }
+
+  struct libmemcached_io_vector_st vector[]=
+  {
+    { strlen(command), command },
+    { (size_t)expiration_buffer_length, expiration_buffer },
+    { memcached_array_size(ptr->_namespace), memcached_array_string(ptr->_namespace) },
+    { key_length, key },
+    { 2, "\r\n" }
+  };
+
+#ifdef ENABLE_REPLICATION
+do_action:
+#endif
+
+  rc= memcached_vdo(instance, vector, 5, true);
+  if (rc != MEMCACHED_SUCCESS)
+  {
+    return rc;
+  }
+
+  char buffer[MEMCACHED_DEFAULT_COMMAND_SIZE + MEMCACHED_MAX_KEY];
+  rc= memcached_response(instance, buffer, sizeof(buffer), NULL);
+  if (rc == MEMCACHED_SUCCESS)
+  {
+    rc= memcached_response(instance, buffer, sizeof(buffer), NULL);
+    if (rc == MEMCACHED_END)
+    {
+      rc= MEMCACHED_SUCCESS;
+    }
+  }
+  else if (rc == MEMCACHED_END)
+  {
+    rc= MEMCACHED_NOTFOUND;
+  }
+#ifdef ENABLE_REPLICATION
+  else if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+  {
+    ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                  instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+    if (memcached_rgroup_switchover(ptr, instance) == true)
+    {
+      instance= memcached_server_instance_fetch(ptr, server_key);
+      goto do_action;
+    }
+  }
+#endif
+  return rc;
+}
+
 static memcached_return_t simple_binary_mget(memcached_st *ptr,
                                              uint32_t master_server_key,
                                              bool is_group_key_set,
@@ -624,6 +694,72 @@ char *memcached_get(memcached_st *ptr, const char *key,
 {
   return memcached_get_by_key(ptr, NULL, 0, key, key_length, value_length,
                               flags, error);
+}
+
+static char *memcached_gat_by_key(memcached_st *ptr,
+                                  const char *key, size_t key_length,
+                                  time_t expiration,
+                                  size_t *value_length,
+                                  uint32_t *flags,
+                                  memcached_return_t *error)
+{
+  arcus_server_check_for_update(ptr);
+
+  if (value_length)
+    *value_length= 0;
+
+  if (flags)
+    *flags= 0;
+
+  memcached_return_t unused;
+  if (error == NULL)
+    error= &unused;
+
+  *error= before_get_query(ptr, NULL, 0, (const char * const *)&key, &key_length, 1);
+  if (memcached_failed(*error))
+  {
+    if (memcached_has_current_error(*ptr)) // Find the most accurate error
+    {
+      *error= memcached_last_error(ptr);
+    }
+    return NULL;
+  }
+
+  /* Request the key */
+  if (ptr->flags.binary_protocol)
+  {
+    *error= MEMCACHED_NOT_SUPPORTED;
+  }
+  else
+  {
+    *error= ascii_gat_by_key(ptr, key, key_length, expiration);
+  }
+
+  if (*error != MEMCACHED_SUCCESS)
+  {
+    return NULL;
+  }
+
+  char *value= memcached_string_take_value(&ptr->result.value);
+  if (value_length)
+  {
+    *value_length= memcached_string_length(&ptr->result.value);
+  }
+  if (flags)
+  {
+    *flags= ptr->result.item_flags;
+  }
+
+  return value;
+}
+
+char *memcached_gat(memcached_st *ptr, const char *key,
+                    size_t key_length, time_t expiration,
+                    size_t *value_length, uint32_t *flags,
+                    memcached_return_t *error)
+{
+  return memcached_gat_by_key(ptr, key, key_length, expiration,
+                              value_length, flags, error);
 }
 
 memcached_return_t memcached_mget_by_key(memcached_st *ptr,

--- a/libmemcached/get.h
+++ b/libmemcached/get.h
@@ -52,6 +52,14 @@ char *memcached_get(memcached_st *ptr,
                     memcached_return_t *error);
 
 LIBMEMCACHED_API
+char *memcached_gat(memcached_st *ptr,
+                    const char *key, size_t key_length,
+                    time_t expiration,
+                    size_t *value_length,
+                    uint32_t *flags,
+                    memcached_return_t *error);
+
+LIBMEMCACHED_API
 memcached_return_t memcached_mget(memcached_st *ptr,
                                   const char * const *keys,
                                   const size_t *key_length,

--- a/tests/mem_functions.cc
+++ b/tests/mem_functions.cc
@@ -862,6 +862,50 @@ static test_return_t touch_test(memcached_st *memc)
   return TEST_SUCCESS;
 }
 
+static test_return_t gat_test(memcached_st *memc)
+{
+  memcached_return_t rc;
+  const char *key= "foo";
+  const char *value= "when we sanitize";
+  char *string;
+  size_t string_length;
+  uint32_t flags;
+
+  if (memc->flags.binary_protocol) {
+    return TEST_SUCCESS;
+  }
+
+  uint64_t query_id= memcached_query_id(memc);
+  rc= memcached_set(memc, key, strlen(key),
+                    value, strlen(value),
+                    (time_t)0, (uint32_t)0);
+  test_true(rc == MEMCACHED_SUCCESS || rc == MEMCACHED_BUFFERED);
+  test_compare(query_id +1, memcached_query_id(memc));
+
+  query_id= memcached_query_id(memc);
+  test_true(query_id);
+
+  string= memcached_gat(memc, key, strlen(key), time(NULL) - 2,
+                        &string_length, &flags, &rc);
+  test_compare(query_id +1, memcached_query_id(memc));
+
+  test_compare_got(MEMCACHED_SUCCESS, rc, memcached_strerror(NULL, rc));
+  test_true(string);
+  test_compare(strlen(value), string_length);
+  test_memcmp(value, string, string_length);
+
+  free(string);
+
+  string= memcached_gat(memc, key, strlen(key), (time_t)0,
+                        &string_length, &flags, &rc);
+
+  test_compare_got(MEMCACHED_NOTFOUND, rc, memcached_strerror(NULL, rc));
+  test_false(string_length);
+  test_false(string);
+
+  return TEST_SUCCESS;
+}
+
 static memcached_return_t  server_function(const memcached_st *ptr,
                                            const memcached_server_st *server,
                                            void *context)
@@ -6217,6 +6261,7 @@ test_st tests[] ={
   {"replace", true, (test_callback_fn*)replace_test },
   {"delete", true, (test_callback_fn*)delete_test },
   {"touch", true, (test_callback_fn*)touch_test },
+  {"gat", true, (test_callback_fn*)gat_test },
   {"get", true, (test_callback_fn*)get_test },
   {"get2", false, (test_callback_fn*)get_test2 },
   {"get3", false, (test_callback_fn*)get_test3 },


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
-

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- gat API를 추가했습니다.
- 대부분의 로직은 기존 memcached_get에서 가져왔습니다.
- memcached_get의 로직을 그대로 사용했지만, 해당 부분은 한번 검토해볼 필요가 있을 것 같습니다.
  - 아래 사항들은 추후 별도 이슈로 등록하여 검토할 예정입니다.
    - 다른 API의 group_key 유효성 검사
    - 일부 로직에 대한 리팩토링 필요성
      - get_key_failure 처리 방식
      - value_fetch 관련 처리 방식
