### PR TITLE
TEST: Do not set CFLAGS when running configure

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,8 +30,8 @@ jobs:
            cd arcus-memcached
            ./deps/install.sh $HOME/arcus
            ./config/autorun.sh
-           CFLAGS="-Wno-error" ./configure --prefix=$HOME/arcus
-           make && make install
+           ./configure --prefix=$HOME/arcus
+           make CFLAGS+="-Wno-error" && make install
     - name: Build Arcus C Client
       run: |
            ./config/autorun.sh


### PR DESCRIPTION
### 🔗 Related Issue

- #369

### ⌨️ What I did

```
gcc -DHAVE_CONFIG_H -I.   -I./include -I/tmp/arcus/include  -fvisibility=hidden -pthread -Wno-error -Wall -Werror -pedantic -Wmissing-prototypes -Wmissing-declarations -Wredundant-decls  -MT memcached-lqdetect.o -MD -MP -MF .deps/memcached-lqdetect.Tpo -c -o memcached-lqdetect.o `test -f 'lqdetect.c' || echo './'`lqdetect.c
mv -f .deps/memcached-lqdetect.Tpo .deps/memcached-lqdetect.Po
gcc -DHAVE_CONFIG_H -I.   -I./include -I/tmp/arcus/include  -fvisibility=hidden -pthread -Wno-error -Wall -Werror -pedantic -Wmissing-prototypes -Wmissing-declarations -Wredundant-decls  -MT memcached-cache.o -MD -MP -MF .deps/memcached-cache.Tpo -c -o memcached-cache.o `test -f 'cache.c' || echo './'`cache.c
mv -f .deps/memcached-cache.Tpo .deps/memcached-cache.Po
/bin/bash ./libtool  --tag=CC   --mode=link gcc -fvisibility=hidden -pthread -Wno-error -Wall -Werror -pedantic -Wmissing-prototypes -Wmissing-declarations -Wredundant-decls  -R '/tmp/arcus/lib'  -L/tmp/arcus/lib  -o memcached memcached-daemon.o memcached-hash.o memcached-memcached.o memcached-stats_prefix.o memcached-thread.o memcached-mc_util.o memcached-topkeys.o memcached-cmdlog.o memcached-lqdetect.o memcached-cache.o       libmcd_util.la -levent -lm
libtool: link: gcc -fvisibility=hidden -Wno-error -Wall -Werror -pedantic -Wmissing-prototypes -Wmissing-declarations -Wredundant-decls -o memcached memcached-daemon.o memcached-hash.o memcached-memcached.o memcached-stats_prefix.o memcached-thread.o memcached-mc_util.o memcached-topkeys.o memcached-cmdlog.o memcached-lqdetect.o memcached-cache.o  -L/tmp/arcus/lib ./.libs/libmcd_util.a /tmp/arcus/lib/libevent.so -lm -pthread -Wl,-rpath -Wl,/tmp/arcus/lib -Wl,-rpath -Wl,/tmp/arcus/lib
/usr/bin/ld: memcached-memcached.o: in function `process_bin_complete_sasl_auth':
memcached.c:(.text+0x1089f): undefined reference to `arcus_sasl_authz'
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:1181: memcached] Error 1
make[2]: Leaving directory '/mnt/disks/namsic-devbox/workspaces/jam2in/arcus-memcached'
make[1]: *** [Makefile:1888: all-recursive] Error 1
make[1]: Leaving directory '/mnt/disks/namsic-devbox/workspaces/jam2in/arcus-memcached'
make: *** [Makefile:865: all] Error 2
```

- 서버 빌드 시 Werror로 인해 make 실패하는 것을 방지합니다.
- configure 시 `CFLAGS="-Wno-error"` 설정하지 않도록 합니다.
