### PR TITLE
FIX: Add missing line continuation in Makefile.am

### DIFF
--- a/libmemcached/include.am
+++ b/libmemcached/include.am
@@ -82,7 +82,7 @@ nobase_include_HEADERS+= \
 			 libmemcached/storage.h \
 			 libmemcached/strerror.h \
 			 libmemcached/string.h \
-			 libmemcached/touch.h
+			 libmemcached/touch.h \
 			 libmemcached/types.h \
 			 libmemcached/verbosity.h \
 			 libmemcached/version.h \


### PR DESCRIPTION
### 🔗 Related Issue

- #386 

### ⌨️ What I did

- 헤더 목록 나열 시 `\` 누락되어 있던 문제 수정합니다.
