### PR TITLE
INTERNAL: Pass authentication when receiving NOT_SUPPORTED response

### DIFF
--- a/libmemcached/sasl.cc
+++ b/libmemcached/sasl.cc
@@ -35,6 +35,7 @@
  *
  */
 
+#include "return.h"
 #include <libmemcached/common.h>
 #include <cassert>
 
@@ -230,14 +231,14 @@ memcached_return_t memcached_sasl_authenticate_connection(memcached_server_st *s
     : memcached_sasl_mech_ascii(server, mech, sizeof(mech));
   if (memcached_failed(rc))
   {
-    if (rc == MEMCACHED_PROTOCOL_ERROR)
+    if (rc == MEMCACHED_PROTOCOL_ERROR || rc == MEMCACHED_NOT_SUPPORTED)
     {
       /* If the server doesn't support SASL it will return PROTOCOL_ERROR.
        * This error may also be returned for other errors, but let's assume
        * that the server don't support SASL and treat it as success and
        * let the client fail with the next operation if the error was
        * caused by another problem....
-     */
+       */
       rc= MEMCACHED_SUCCESS;
     }
 


### PR DESCRIPTION
### 🔗 Related Issue

- jam2in/arcus-works#755

### ⌨️ What I did

- NOT_SUPPORTED 응답 수신 시 인증 성공 처리하고 캐시 연산을 전송합니다.
- ERROR 응답 수신 시 실패 처리합니다.
