### PR TITLE
INTERNAL: Prevent immediate reconnect on PROTOCOL_ERROR in sasl mech

### DIFF
--- a/libmemcached/memcached.cc
+++ b/libmemcached/memcached.cc
@@ -160,6 +160,7 @@ static inline bool _memcached_init(memcached_st *self)
   self->callbacks= NULL;
   self->sasl.callbacks= NULL;
   self->sasl.is_allocated= false;
+  self->sasl.in_sasl_mech= false;
 
   self->error_messages= NULL;
 #ifdef REFACTORING_ERROR_PRINT

--- a/libmemcached/response.cc
+++ b/libmemcached/response.cc
@@ -483,6 +483,17 @@ static memcached_return_t textual_read_one_response(memcached_server_write_insta
     }
     else if (memcmp(buffer, "ERROR", 5) == 0)
     {
+      /* If the server doesn't support SASL it will return PROTOCOL_ERROR.
+       * This error may also be returned for other errors, but let's assume
+       * that the server don't support SASL and treat it as success and
+       * let the client fail with the next operation if the error was
+       * caused by another problem....
+       */
+      if (ptr->root->sasl.in_sasl_mech)
+      {
+        return MEMCACHED_NOT_SUPPORTED;
+      }
+
       // Move past the basic error message and whitespace
       char *startptr= buffer + memcached_literal_param_size("ERROR");
       if (startptr[0] == ' ')
@@ -870,8 +881,17 @@ static memcached_return_t binary_read_one_response(memcached_server_write_instan
       rc= MEMCACHED_AUTH_FAILURE;
       break;
 
-    case PROTOCOL_BINARY_RESPONSE_EINVAL:
     case PROTOCOL_BINARY_RESPONSE_UNKNOWN_COMMAND:
+      /* If the server doesn't support SASL it will return PROTOCOL_ERROR.
+       * This error may also be returned for other errors, but let's assume
+       * that the server don't support SASL and treat it as success and
+       * let the client fail with the next operation if the error was
+       * caused by another problem....
+       */
+      rc= ptr->root->sasl.in_sasl_mech ? MEMCACHED_NOT_SUPPORTED : MEMCACHED_PROTOCOL_ERROR;
+      break;
+
+    case PROTOCOL_BINARY_RESPONSE_EINVAL:
     default:
       /* @todo fix the error mappings */
       rc= MEMCACHED_PROTOCOL_ERROR;

--- a/libmemcached/sasl.cc
+++ b/libmemcached/sasl.cc
@@ -226,18 +226,16 @@ memcached_return_t memcached_sasl_authenticate_connection(memcached_server_st *s
    * as authenticated
  */
   char mech[MEMCACHED_MAX_BUFFER];
+  server->root->sasl.in_sasl_mech= true;
   memcached_return_t rc= server->root->flags.binary_protocol
     ? memcached_sasl_mech_binary(server, mech, sizeof(mech))
     : memcached_sasl_mech_ascii(server, mech, sizeof(mech));
+  server->root->sasl.in_sasl_mech= false;
   if (memcached_failed(rc))
   {
-    if (rc == MEMCACHED_PROTOCOL_ERROR || rc == MEMCACHED_NOT_SUPPORTED)
+    if (rc == MEMCACHED_NOT_SUPPORTED)
     {
-      /* If the server doesn't support SASL it will return PROTOCOL_ERROR.
-       * This error may also be returned for other errors, but let's assume
-       * that the server don't support SASL and treat it as success and
-       * let the client fail with the next operation if the error was
-       * caused by another problem....
+      /* If the server doesn't support SASL it will return MEMCACHED_NOT_SUPPORTED.
        */
       rc= MEMCACHED_SUCCESS;
     }

--- a/libmemcached/sasl.h
+++ b/libmemcached/sasl.h
@@ -81,6 +81,7 @@ struct memcached_sasl_st {
    ** supply that.
  */
   bool is_allocated;
+  bool in_sasl_mech;
 };
 
 #endif /* __LIBMEMCACHED_SASL_H__ */


### PR DESCRIPTION
### 🔗 Related Issue

- jam2in/arcus-works#755

### ⌨️ What I did

- 기존에 `ERROR` 응답 수신 시 인증 과정을 생략하려던 의도와 다르게 재연결 + 인증 시도를 반복하던 문제를 해결합니다.
- `in_sasl_mech` 플래그를 두어 sasl mech 명령에 한해 재연결하지 않도록 합니다.
