### PR TITLE
CLEANUP: Clarify error handling of calling func for `memcached_vdo()`

### DIFF
--- a/libmemcached/auto.cc
+++ b/libmemcached/auto.cc
@@ -210,7 +210,8 @@ static memcached_return_t binary_incr_decr(memcached_st *ptr, uint8_t cmd,
 do_action:
 #endif
   memcached_return_t rc= memcached_vdo(instance, vector, 3, true);
-  if (no_reply or rc != MEMCACHED_SUCCESS) {
+  if (no_reply or rc != MEMCACHED_SUCCESS)
+  {
     return rc;
   }
 
@@ -226,6 +227,7 @@ do_action:
     }
   }
 #endif
+
   return rc;
 }
 

--- a/libmemcached/collection.cc
+++ b/libmemcached/collection.cc
@@ -811,36 +811,37 @@ do_action:
 #endif
   /* Send command header */
   rc= memcached_vdo(instance, vector, 4, to_write);
-
   WATCHPOINT_IFERROR(rc);
-
-  if (rc == MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS)
   {
-    if (to_write == false)
-    {
-      rc= MEMCACHED_BUFFERED;
-    }
-    else if (ptr->flags.no_reply)
-    {
-      rc= MEMCACHED_SUCCESS;
-    }
-    else
-    {
-      // expecting OK (MEMCACHED_SUCCESS)
-      char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-      rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+    return rc;
+  }
+
+  if (to_write == false)
+  {
+    rc= MEMCACHED_BUFFERED;
+  }
+  else if (ptr->flags.no_reply)
+  {
+    rc= MEMCACHED_SUCCESS;
+  }
+  else
+  {
+    // expecting OK (MEMCACHED_SUCCESS)
+    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+    rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
 #ifdef ENABLE_REPLICATION
-      if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+    if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+    {
+      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+      if (memcached_rgroup_switchover(ptr, instance) == true)
       {
-        ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                      instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-        if (memcached_rgroup_switchover(ptr, instance) == true) {
-          instance= memcached_server_instance_fetch(ptr, server_key);
-          goto do_action;
-        }
+        instance= memcached_server_instance_fetch(ptr, server_key);
+        goto do_action;
       }
-#endif
     }
+#endif
   }
 
   return rc;
@@ -873,9 +874,10 @@ memcached_return_t memcached_get_attrs(memcached_st *ptr,
 
   /* Request */
   rc= memcached_vdo(instance, vector, 3, true);
-
   if (rc != MEMCACHED_SUCCESS)
+  {
     return rc;
+  }
 
   /* Response */
   char result[MEMCACHED_DEFAULT_COMMAND_SIZE]; // Uninitialized... valgrind would warn about this, but that would be okay.
@@ -1085,38 +1087,39 @@ static memcached_return_t do_coll_create(memcached_st *ptr,
 do_action:
 #endif
   rc= memcached_vdo(instance, vector, 4, to_write);
-
-  if (rc == MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS)
   {
-    if (to_write == false)
+    return rc;
+  }
+
+  if (to_write == false)
+  {
+    rc= MEMCACHED_BUFFERED;
+  }
+  else if (ptr->flags.no_reply || ptr->flags.piped)
+  {
+    rc= MEMCACHED_SUCCESS;
+  }
+  else
+  {
+    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+    rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+#ifdef ENABLE_REPLICATION
+    if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
     {
-      rc= MEMCACHED_BUFFERED;
+      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+      if (memcached_rgroup_switchover(ptr, instance) == true) {
+        instance= memcached_server_instance_fetch(ptr, server_key);
+        goto do_action;
+      }
     }
-    else if (ptr->flags.no_reply || ptr->flags.piped)
+#endif
+    memcached_set_last_response_code(ptr, rc);
+
+    if (rc == MEMCACHED_CREATED)
     {
       rc= MEMCACHED_SUCCESS;
-    }
-    else
-    {
-      char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-      rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
-#ifdef ENABLE_REPLICATION
-      if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
-      {
-        ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                      instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-        if (memcached_rgroup_switchover(ptr, instance) == true) {
-          instance= memcached_server_instance_fetch(ptr, server_key);
-          goto do_action;
-        }
-      }
-#endif
-      memcached_set_last_response_code(ptr, rc);
-
-      if (rc == MEMCACHED_CREATED)
-      {
-        rc= MEMCACHED_SUCCESS;
-      }
     }
   }
 
@@ -1442,43 +1445,44 @@ do_action:
 #endif
   /* Send command header */
   rc= memcached_vdo(instance, vector, 6, to_write);
-
-  if (rc == MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS)
   {
-    if (to_write == false)
+    return rc;
+  }
+
+  if (to_write == false)
+  {
+    rc= MEMCACHED_BUFFERED;
+  }
+  else if (ptr->flags.no_reply or ptr->flags.piped)
+  {
+    rc= MEMCACHED_SUCCESS;
+  }
+  else
+  {
+    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+    rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+#ifdef ENABLE_REPLICATION
+    if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
     {
-      rc= MEMCACHED_BUFFERED;
+      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+      if (memcached_rgroup_switchover(ptr, instance) == true) {
+        instance= memcached_server_instance_fetch(ptr, server_key);
+        goto do_action;
+      }
     }
-    else if (ptr->flags.no_reply or ptr->flags.piped)
+#endif
+    memcached_set_last_response_code(ptr, rc);
+
+    if (rc == MEMCACHED_STORED || rc == MEMCACHED_CREATED_STORED)
     {
       rc= MEMCACHED_SUCCESS;
     }
-    else
+    else if (rc == MEMCACHED_REPLACED && (verb == BOP_UPSERT_OP || verb == MOP_UPSERT_OP))
     {
-      char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-      rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
-#ifdef ENABLE_REPLICATION
-      if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
-      {
-        ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                      instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-        if (memcached_rgroup_switchover(ptr, instance) == true) {
-          instance= memcached_server_instance_fetch(ptr, server_key);
-          goto do_action;
-        }
-      }
-#endif
-      memcached_set_last_response_code(ptr, rc);
-
-      if (rc == MEMCACHED_STORED || rc == MEMCACHED_CREATED_STORED)
-      {
-        rc= MEMCACHED_SUCCESS;
-      }
-      else if (rc == MEMCACHED_REPLACED && (verb == BOP_UPSERT_OP || verb == MOP_UPSERT_OP))
-      {
-        /* mop/bop upsert returns REPLACED if the same bkey element is replaced. */
-        rc= MEMCACHED_SUCCESS;
-      }
+      /* mop/bop upsert returns REPLACED if the same bkey element is replaced. */
+      rc= MEMCACHED_SUCCESS;
     }
   }
 
@@ -1642,39 +1646,40 @@ static memcached_return_t do_coll_delete(memcached_st *ptr,
 do_action:
 #endif
   rc= memcached_vdo(instance, vector, veclen, to_write);
-
-  if (rc == MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS)
   {
-    if (to_write == false)
+    return rc;
+  }
+
+  if (to_write == false)
+  {
+    rc= MEMCACHED_BUFFERED;
+  }
+  else if (ptr->flags.no_reply)
+  {
+    rc= MEMCACHED_SUCCESS;
+  }
+  else
+  {
+    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+    rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+#ifdef ENABLE_REPLICATION
+    if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
     {
-      rc= MEMCACHED_BUFFERED;
+      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+      if (memcached_rgroup_switchover(ptr, instance) == true) {
+        instance= memcached_server_instance_fetch(ptr, server_key);
+        goto do_action;
+      }
     }
-    else if (ptr->flags.no_reply)
+#endif
+    memcached_set_last_response_code(ptr, rc);
+
+    if (rc == MEMCACHED_DELETED or
+        rc == MEMCACHED_DELETED_DROPPED)
     {
       rc= MEMCACHED_SUCCESS;
-    }
-    else
-    {
-      char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-      rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
-#ifdef ENABLE_REPLICATION
-      if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
-      {
-        ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                      instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-        if (memcached_rgroup_switchover(ptr, instance) == true) {
-          instance= memcached_server_instance_fetch(ptr, server_key);
-          goto do_action;
-        }
-      }
-#endif
-      memcached_set_last_response_code(ptr, rc);
-
-      if (rc == MEMCACHED_DELETED or
-          rc == MEMCACHED_DELETED_DROPPED)
-      {
-        rc= MEMCACHED_SUCCESS;
-      }
     }
   }
 
@@ -1899,47 +1904,53 @@ static memcached_return_t do_coll_get(memcached_st *ptr,
 do_action:
 #endif
   rc= memcached_vdo(instance, vector, veclen, to_write);
-
-  if (rc == MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS)
   {
-    if (to_write == false)
+    if (mkey_buffer)
     {
-      rc= MEMCACHED_BUFFERED;
+      libmemcached_free(ptr, mkey_buffer);
+      mkey_buffer= NULL;
     }
-    else if (ptr->flags.no_reply || ptr->flags.piped)
+    return rc;
+  }
+
+  if (to_write == false)
+  {
+    rc= MEMCACHED_BUFFERED;
+  }
+  else if (ptr->flags.no_reply || ptr->flags.piped)
+  {
+    rc= MEMCACHED_SUCCESS;
+  }
+  else
+  {
+    /* Fetch results */
+    result = memcached_coll_fetch_result(ptr, result, &rc);
+#ifdef ENABLE_REPLICATION
+    if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+    {
+      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+      if (memcached_rgroup_switchover(ptr, instance) == true) {
+        instance= memcached_server_instance_fetch(ptr, server_key);
+        goto do_action;
+      }
+    }
+#endif
+    /* Search for END or something */
+    if (result)
+    {
+      memcached_coll_result_reset(&ptr->collection_result);
+      memcached_coll_fetch_result(ptr, &ptr->collection_result, &rc);
+    }
+    memcached_set_last_response_code(ptr, rc);
+
+    if (rc == MEMCACHED_END             or
+        rc == MEMCACHED_TRIMMED         or
+        rc == MEMCACHED_DELETED         or
+        rc == MEMCACHED_DELETED_DROPPED )
     {
       rc= MEMCACHED_SUCCESS;
-    }
-    else
-    {
-      /* Fetch results */
-      result = memcached_coll_fetch_result(ptr, result, &rc);
-#ifdef ENABLE_REPLICATION
-      if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
-      {
-        ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                      instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-        if (memcached_rgroup_switchover(ptr, instance) == true) {
-          instance= memcached_server_instance_fetch(ptr, server_key);
-          goto do_action;
-        }
-      }
-#endif
-      /* Search for END or something */
-      if (result)
-      {
-        memcached_coll_result_reset(&ptr->collection_result);
-        memcached_coll_fetch_result(ptr, &ptr->collection_result, &rc);
-      }
-      memcached_set_last_response_code(ptr, rc);
-
-      if (rc == MEMCACHED_END             or
-          rc == MEMCACHED_TRIMMED         or
-          rc == MEMCACHED_DELETED         or
-          rc == MEMCACHED_DELETED_DROPPED )
-      {
-        rc= MEMCACHED_SUCCESS;
-      }
     }
   }
 
@@ -2245,29 +2256,30 @@ static memcached_return_t do_bop_find_position(memcached_st *ptr,
   memcached_server_write_instance_st instance= memcached_server_instance_fetch(ptr, server_key);
 
   rc = memcached_vdo(instance, vector, 4, to_write);
-
-  if (rc == MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS)
   {
-    if (to_write == false)
-    {
-      rc = MEMCACHED_BUFFERED;
-    }
-    else if (ptr->flags.no_reply || ptr->flags.piped)
-    {
-      rc = MEMCACHED_SUCCESS;
-    }
-    else
-    {
-      char response[MEMCACHED_DEFAULT_COMMAND_SIZE];
-      rc= memcached_coll_response(instance, response, MEMCACHED_DEFAULT_COMMAND_SIZE, &ptr->collection_result);
+    return rc;
+  }
 
-      if (rc == MEMCACHED_POSITION)
-      {
-        *position= ptr->collection_result.btree_position;
-        /* reset btree_position because it is intended for use in bop pwg */
-        ptr->collection_result.btree_position= 0;
-        rc= MEMCACHED_SUCCESS;
-      }
+  if (to_write == false)
+  {
+    rc= MEMCACHED_BUFFERED;
+  }
+  else if (ptr->flags.no_reply || ptr->flags.piped)
+  {
+    rc= MEMCACHED_SUCCESS;
+  }
+  else
+  {
+    char response[MEMCACHED_DEFAULT_COMMAND_SIZE];
+    rc= memcached_coll_response(instance, response, MEMCACHED_DEFAULT_COMMAND_SIZE, &ptr->collection_result);
+
+    if (rc == MEMCACHED_POSITION)
+    {
+      *position= ptr->collection_result.btree_position;
+      /* reset btree_position because it is intended for use in bop pwg */
+      ptr->collection_result.btree_position= 0;
+      rc= MEMCACHED_SUCCESS;
     }
   }
 
@@ -2339,33 +2351,34 @@ static memcached_return_t do_bop_get_by_position(memcached_st *ptr,
   memcached_server_write_instance_st instance= memcached_server_instance_fetch(ptr, server_key);
 
   rc = memcached_vdo(instance, vector, 4, to_write);
-
-  if (rc == MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS)
   {
-    if (to_write == false)
-    {
-      rc = MEMCACHED_BUFFERED;
-    }
-    else if (ptr->flags.no_reply || ptr->flags.piped)
-    {
-      rc = MEMCACHED_SUCCESS;
-    }
-    else
-    {
-      /* Fetch results */
-      result = memcached_coll_fetch_result(ptr, result, &rc);
+    return rc;
+  }
 
-      /* Search for END or something */
-      if (result)
-      {
-        memcached_coll_result_reset(&ptr->collection_result);
-        memcached_coll_fetch_result(ptr, &ptr->collection_result, &rc);
-      }
+  if (to_write == false)
+  {
+    rc= MEMCACHED_BUFFERED;
+  }
+  else if (ptr->flags.no_reply || ptr->flags.piped)
+  {
+    rc= MEMCACHED_SUCCESS;
+  }
+  else
+  {
+    /* Fetch results */
+    result = memcached_coll_fetch_result(ptr, result, &rc);
 
-      if (rc == MEMCACHED_END)
-      {
-        rc= MEMCACHED_SUCCESS;
-      }
+    /* Search for END or something */
+    if (result)
+    {
+      memcached_coll_result_reset(&ptr->collection_result);
+      memcached_coll_fetch_result(ptr, &ptr->collection_result, &rc);
+    }
+
+    if (rc == MEMCACHED_END)
+    {
+      rc= MEMCACHED_SUCCESS;
     }
   }
 
@@ -2435,33 +2448,34 @@ static memcached_return_t do_bop_find_position_with_get(memcached_st *ptr,
   memcached_server_write_instance_st instance= memcached_server_instance_fetch(ptr, server_key);
 
   rc = memcached_vdo(instance, vector, 4, to_write);
-
-  if (rc == MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS)
   {
-    if (to_write == false)
-    {
-      rc = MEMCACHED_BUFFERED;
-    }
-    else if (ptr->flags.no_reply || ptr->flags.piped)
-    {
-      rc = MEMCACHED_SUCCESS;
-    }
-    else
-    {
-      /* Fetch results */
-      result = memcached_coll_fetch_result(ptr, result, &rc);
+    return rc;
+  }
 
-      /* Search for END or something */
-      if (result)
-      {
-        memcached_coll_result_reset(&ptr->collection_result);
-        memcached_coll_fetch_result(ptr, &ptr->collection_result, &rc);
-      }
+  if (to_write == false)
+  {
+    rc= MEMCACHED_BUFFERED;
+  }
+  else if (ptr->flags.no_reply || ptr->flags.piped)
+  {
+    rc= MEMCACHED_SUCCESS;
+  }
+  else
+  {
+    /* Fetch results */
+    result= memcached_coll_fetch_result(ptr, result, &rc);
 
-      if (rc == MEMCACHED_END)
-      {
-        rc= MEMCACHED_SUCCESS;
-      }
+    /* Search for END or something */
+    if (result)
+    {
+      memcached_coll_result_reset(&ptr->collection_result);
+      memcached_coll_fetch_result(ptr, &ptr->collection_result, &rc);
+    }
+
+    if (rc == MEMCACHED_END)
+    {
+      rc= MEMCACHED_SUCCESS;
     }
   }
 
@@ -2761,27 +2775,28 @@ static memcached_return_t do_coll_exist(memcached_st *ptr,
   memcached_server_write_instance_st instance= memcached_server_instance_fetch(ptr, server_key);
 
   rc= memcached_vdo(instance, vector, 5, to_write);
-
-  if (rc == MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS)
   {
-    if (to_write == false)
-    {
-      rc= MEMCACHED_BUFFERED;
-    }
-    else if (ptr->flags.no_reply)
+    return rc;
+  }
+
+  if (to_write == false)
+  {
+    rc= MEMCACHED_BUFFERED;
+  }
+  else if (ptr->flags.no_reply)
+  {
+    rc= MEMCACHED_SUCCESS;
+  }
+  else
+  {
+    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+    rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+    memcached_set_last_response_code(ptr, rc);
+
+    if (rc == MEMCACHED_EXIST or rc == MEMCACHED_NOT_EXIST)
     {
       rc= MEMCACHED_SUCCESS;
-    }
-    else
-    {
-      char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-      rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
-      memcached_set_last_response_code(ptr, rc);
-
-      if (rc == MEMCACHED_EXIST or rc == MEMCACHED_NOT_EXIST)
-      {
-        rc= MEMCACHED_SUCCESS;
-      }
     }
   }
 
@@ -3317,38 +3332,39 @@ static memcached_return_t do_coll_update(memcached_st *ptr,
 do_action:
 #endif
   rc= memcached_vdo(instance, vector, veclen, to_write);
-
-  if (rc == MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS)
   {
-    if (to_write == false)
+    return rc;
+  }
+
+  if (to_write == false)
+  {
+    rc= MEMCACHED_BUFFERED;
+  }
+  else if (ptr->flags.no_reply || ptr->flags.piped)
+  {
+    rc= MEMCACHED_SUCCESS;
+  }
+  else
+  {
+    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+    rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+#ifdef ENABLE_REPLICATION
+    if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
     {
-      rc= MEMCACHED_BUFFERED;
+      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+      if (memcached_rgroup_switchover(ptr, instance) == true) {
+        instance= memcached_server_instance_fetch(ptr, server_key);
+        goto do_action;
+      }
     }
-    else if (ptr->flags.no_reply || ptr->flags.piped)
+#endif
+    memcached_set_last_response_code(ptr, rc);
+
+    if (rc == MEMCACHED_UPDATED)
     {
       rc= MEMCACHED_SUCCESS;
-    }
-    else
-    {
-      char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-      rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
-#ifdef ENABLE_REPLICATION
-      if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
-      {
-        ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                      instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-        if (memcached_rgroup_switchover(ptr, instance) == true) {
-          instance= memcached_server_instance_fetch(ptr, server_key);
-          goto do_action;
-        }
-      }
-#endif
-      memcached_set_last_response_code(ptr, rc);
-
-      if (rc == MEMCACHED_UPDATED)
-      {
-        rc= MEMCACHED_SUCCESS;
-      }
     }
   }
 
@@ -3451,46 +3467,47 @@ static memcached_return_t do_coll_arithmetic(memcached_st *ptr,
 do_action:
 #endif
   rc= memcached_vdo(instance, vector, 4, to_write);
-
-  if (rc == MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS)
   {
-    if (to_write == false)
+    return rc;
+  }
+
+  if (to_write == false)
+  {
+    rc= MEMCACHED_BUFFERED;
+  }
+  else if (ptr->flags.no_reply || ptr->flags.piped)
+  {
+    rc= MEMCACHED_SUCCESS;
+  }
+  else
+  {
+    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+    rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+#ifdef ENABLE_REPLICATION
+    if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
     {
-      rc= MEMCACHED_BUFFERED;
+      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+      if (memcached_rgroup_switchover(ptr, instance) == true) {
+        instance= memcached_server_instance_fetch(ptr, server_key);
+        goto do_action;
+      }
     }
-    else if (ptr->flags.no_reply || ptr->flags.piped)
+#endif
+    if (rc == MEMCACHED_NOTFOUND or
+        rc == MEMCACHED_NOTFOUND_ELEMENT or
+        rc == MEMCACHED_CLIENT_ERROR or
+        rc == MEMCACHED_TYPE_MISMATCH or
+        rc == MEMCACHED_BKEY_MISMATCH or
+        rc == MEMCACHED_SERVER_ERROR)
     {
-      rc= MEMCACHED_SUCCESS;
+      *value= 0;
+      return rc;
     }
     else
     {
-      char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-      rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
-#ifdef ENABLE_REPLICATION
-      if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
-      {
-        ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                      instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-        if (memcached_rgroup_switchover(ptr, instance) == true) {
-          instance= memcached_server_instance_fetch(ptr, server_key);
-          goto do_action;
-        }
-      }
-#endif
-      if (rc == MEMCACHED_NOTFOUND
-          || rc == MEMCACHED_NOTFOUND_ELEMENT
-          || rc == MEMCACHED_CLIENT_ERROR
-          || rc == MEMCACHED_TYPE_MISMATCH
-          || rc == MEMCACHED_BKEY_MISMATCH
-          || rc == MEMCACHED_SERVER_ERROR)
-      {
-        *value= 0;
-        return rc;
-      }
-      else
-      {
-        *value= strtoull(result, (char **)NULL, 10);
-      }
+      *value= strtoull(result, (char **)NULL, 10);
     }
   }
 
@@ -3567,29 +3584,30 @@ static memcached_return_t do_coll_count(memcached_st *ptr,
   memcached_server_write_instance_st instance= memcached_server_instance_fetch(ptr, server_key);
 
   rc= memcached_vdo(instance, vector, 4, to_write);
-
-  if (rc == MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS)
   {
-    if (to_write == false)
-    {
-      rc= MEMCACHED_BUFFERED;
-    }
-    else if (ptr->flags.no_reply || ptr->flags.piped)
-    {
-      rc= MEMCACHED_SUCCESS;
-    }
-    else
-    {
-      char response[MEMCACHED_DEFAULT_COMMAND_SIZE];
-      rc= memcached_coll_response(instance, response, MEMCACHED_DEFAULT_COMMAND_SIZE, &ptr->collection_result);
+    return rc;
+  }
 
-      if (rc == MEMCACHED_COUNT)
-      {
-        *count= ptr->collection_result.collection_count;
-        /* reset collection because it is used in memcached_coll_result_reset(collection_result.cc)*/
-        ptr->collection_result.collection_count= 0;
-        rc= MEMCACHED_SUCCESS;
-      }
+  if (to_write == false)
+  {
+    rc= MEMCACHED_BUFFERED;
+  }
+  else if (ptr->flags.no_reply || ptr->flags.piped)
+  {
+    rc= MEMCACHED_SUCCESS;
+  }
+  else
+  {
+    char response[MEMCACHED_DEFAULT_COMMAND_SIZE];
+    rc= memcached_coll_response(instance, response, MEMCACHED_DEFAULT_COMMAND_SIZE, &ptr->collection_result);
+
+    if (rc == MEMCACHED_COUNT)
+    {
+      *count= ptr->collection_result.collection_count;
+      /* reset collection because it is used in memcached_coll_result_reset(collection_result.cc)*/
+      ptr->collection_result.collection_count= 0;
+      rc= MEMCACHED_SUCCESS;
     }
   }
 

--- a/libmemcached/delete.cc
+++ b/libmemcached/delete.cc
@@ -100,34 +100,35 @@ do_action:
 
   /* Send command header */
   memcached_return_t rc= memcached_vdo(instance, vector, 5, to_write);
-
-  if (rc == MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS)
   {
-    if (to_write == false)
-    {
-      rc= MEMCACHED_BUFFERED;
-    }
-    else if (no_reply == false)
-    {
-      char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-      rc= memcached_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+    return rc;
+  }
 
-      if (rc == MEMCACHED_DELETED)
-      {
-        rc= MEMCACHED_SUCCESS;
-      }
-#ifdef ENABLE_REPLICATION
-      else if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
-      {
-        ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                      instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-        if (memcached_rgroup_switchover(ptr, instance) == true) {
-          instance= memcached_server_instance_fetch(ptr, server_key);
-          goto do_action;
-        }
-      }
-#endif
+  if (to_write == false)
+  {
+    rc= MEMCACHED_BUFFERED;
+  }
+  else if (no_reply == false)
+  {
+    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+    rc= memcached_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+
+    if (rc == MEMCACHED_DELETED)
+    {
+      rc= MEMCACHED_SUCCESS;
     }
+#ifdef ENABLE_REPLICATION
+    else if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+    {
+      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+      if (memcached_rgroup_switchover(ptr, instance) == true) {
+        instance= memcached_server_instance_fetch(ptr, server_key);
+        goto do_action;
+      }
+    }
+#endif
   }
 
   return rc;
@@ -180,7 +181,8 @@ do_action:
   }
 
   memcached_return_t rc= memcached_vdo(instance, vector, 3, to_write);
-  if (rc != MEMCACHED_SUCCESS) {
+  if (rc != MEMCACHED_SUCCESS)
+  {
     return rc;
   }
 

--- a/libmemcached/exist.cc
+++ b/libmemcached/exist.cc
@@ -85,30 +85,33 @@ static memcached_return_t ascii_exist(memcached_st *memc,
 
   uint32_t server_key= memcached_generate_hash_with_redistribution(memc, group_key, group_key_length);
   memcached_server_write_instance_st instance= memcached_server_instance_fetch(memc, server_key);
+  memcached_return_t rc;
 
   /* Send command header */
 #ifdef LIBMEMCACHED_WITH_ZK_INTEGRATION
-  memcached_return_t rc=  memcached_vdo(instance, vector, 4, true);
+  rc= memcached_vdo(instance, vector, 4, true);
 #else
-  memcached_return_t rc=  memcached_vdo(instance, vector, 8, true);
+  rc= memcached_vdo(instance, vector, 8, true);
 #endif
-  if (rc == MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS)
   {
-    char buffer[MEMCACHED_DEFAULT_COMMAND_SIZE];
-#ifdef LIBMEMCACHED_WITH_ZK_INTEGRATION
-    while ((rc= memcached_coll_response(instance, buffer, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL)) == MEMCACHED_ATTR);
-    if (rc == MEMCACHED_END)
-      rc= MEMCACHED_SUCCESS;
-#else
-    rc= memcached_response(instance, buffer, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
-
-    if (rc == MEMCACHED_NOTSTORED)
-      rc= MEMCACHED_SUCCESS;
-
-    if (rc == MEMCACHED_STORED)
-      rc= MEMCACHED_NOTFOUND;
-#endif
+    return rc;
   }
+
+  char buffer[MEMCACHED_DEFAULT_COMMAND_SIZE];
+#ifdef LIBMEMCACHED_WITH_ZK_INTEGRATION
+  while ((rc= memcached_coll_response(instance, buffer, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL)) == MEMCACHED_ATTR);
+  if (rc == MEMCACHED_END)
+    rc= MEMCACHED_SUCCESS;
+#else
+  rc= memcached_response(instance, buffer, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+
+  if (rc == MEMCACHED_NOTSTORED)
+    rc= MEMCACHED_SUCCESS;
+
+  if (rc == MEMCACHED_STORED)
+    rc= MEMCACHED_NOTFOUND;
+#endif
 
   return rc;
 }
@@ -146,7 +149,8 @@ static memcached_return_t binary_exist(memcached_st *memc,
 
   /* write the header */
   memcached_return_t rc= memcached_vdo(instance, vector, 3, true);
-  if (rc != MEMCACHED_SUCCESS) {
+  if (rc != MEMCACHED_SUCCESS)
+  {
     return rc;
   }
 

--- a/libmemcached/get.cc
+++ b/libmemcached/get.cc
@@ -190,9 +190,11 @@ static memcached_return_t ascii_get_by_key(memcached_st *ptr,
   };
 
   rc= memcached_vdo(instance, vector, 4, true);
-  if (rc != MEMCACHED_SUCCESS) {
+  if (rc != MEMCACHED_SUCCESS)
+  {
     memcached_set_error(*ptr, rc, MEMCACHED_AT);
   }
+
   return rc;
 }
 

--- a/libmemcached/stats.cc
+++ b/libmemcached/stats.cc
@@ -330,6 +330,7 @@ static memcached_return_t binary_stats_fetch(memcached_stat_st *memc_stat,
                                              struct local_context *check)
 {
   char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+  memcached_return_t rc;
   protocol_binary_request_stats request= {}; // = {.bytes= {0}};
   request.message.header.request.magic= PROTOCOL_BINARY_REQ;
   request.message.header.request.opcode= PROTOCOL_BINARY_CMD_STAT;
@@ -347,23 +348,23 @@ static memcached_return_t binary_stats_fetch(memcached_stat_st *memc_stat,
       { len, args }
     };
 
-    memcached_return_t rc = memcached_vdo(instance, vector, 2, true);
-    if (rc != MEMCACHED_SUCCESS) {
-      return rc;
-    }
+    rc= memcached_vdo(instance, vector, 2, true);
   }
   else
   {
-    memcached_return_t rc = memcached_do(instance, request.bytes, sizeof(request.bytes), true);
-    if (rc != MEMCACHED_SUCCESS) {
-      return rc;
-    }
+    rc= memcached_do(instance, request.bytes, sizeof(request.bytes), true);
+  }
+
+  if (rc != MEMCACHED_SUCCESS)
+  {
+    return rc;
   }
 
   memcached_server_response_decrement(instance);
+
   do
   {
-    memcached_return_t rc= memcached_response(instance, result, sizeof(result), NULL);
+    rc= memcached_response(instance, result, sizeof(result), NULL);
 
     if (rc == MEMCACHED_END)
       break;

--- a/libmemcached/storage.cc
+++ b/libmemcached/storage.cc
@@ -260,7 +260,8 @@ do_action:
 
   /* write the header */
   memcached_return_t rc= memcached_vdo(server, vector, 4, flush);
-  if (rc != MEMCACHED_SUCCESS) {
+  if (rc != MEMCACHED_SUCCESS)
+  {
     return rc;
   }
 
@@ -279,7 +280,8 @@ do_action:
 
       instance= memcached_server_instance_fetch(ptr, server_key);
 
-      if (memcached_vdo(instance, vector, 4, false) == MEMCACHED_SUCCESS) {
+      if (memcached_vdo(instance, vector, 4, false) == MEMCACHED_SUCCESS)
+      {
         memcached_server_response_decrement(instance);
       }
     }
@@ -287,26 +289,28 @@ do_action:
 
   if (flush == false)
   {
-    return MEMCACHED_BUFFERED;
+    rc= MEMCACHED_BUFFERED;
   }
-
-  if (noreply or ptr->flags.multi_store)
+  else if (noreply or ptr->flags.multi_store)
   {
-    return MEMCACHED_SUCCESS;
+    rc= MEMCACHED_SUCCESS;
   }
-
-  rc= memcached_response(server, NULL, 0, NULL);
+  else
+  {
+    rc= memcached_response(server, NULL, 0, NULL);
 #ifdef ENABLE_REPLICATION
-  if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
-  {
-    ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                  server->hostname, server->port, memcached_strerror(ptr, rc)));
-    if (memcached_rgroup_switchover(ptr, server) == true) {
-      server= memcached_server_instance_fetch(ptr, server_key);
-      goto do_action;
+    if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+    {
+      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                    server->hostname, server->port, memcached_strerror(ptr, rc)));
+      if (memcached_rgroup_switchover(ptr, server) == true) {
+        server= memcached_server_instance_fetch(ptr, server_key);
+        goto do_action;
+      }
     }
-  }
 #endif
+  }
+
   return rc;
 }
 
@@ -407,38 +411,38 @@ do_action:
 
   /* Send command header */
   memcached_return_t rc= memcached_vdo(instance, vector, 11, to_write);
-
-  if (rc == MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS)
   {
-    if (ptr->flags.no_reply or ptr->flags.multi_store)
-    {
-      rc= (to_write == false) ? MEMCACHED_BUFFERED : MEMCACHED_SUCCESS;
-    }
-    else if (to_write == false)
-    {
-      rc= MEMCACHED_BUFFERED;
-    }
-    else
-    {
-      char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-      rc= memcached_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+    return rc;
+  }
 
-      if (rc == MEMCACHED_STORED)
-      {
-        rc= MEMCACHED_SUCCESS;
-      }
-#ifdef ENABLE_REPLICATION
-      else if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
-      {
-        ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                      instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-        if (memcached_rgroup_switchover(ptr, instance) == true) {
-          instance= memcached_server_instance_fetch(ptr, server_key);
-          goto do_action;
-        }
-      }
-#endif
+  if (to_write == false)
+  {
+    rc= MEMCACHED_BUFFERED;
+  }
+  else if (ptr->flags.no_reply or ptr->flags.multi_store)
+  {
+    rc= MEMCACHED_SUCCESS;
+  }
+  else
+  {
+    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+    rc= memcached_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+    if (rc == MEMCACHED_STORED)
+    {
+      rc= MEMCACHED_SUCCESS;
     }
+#ifdef ENABLE_REPLICATION
+    else if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+    {
+      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+      if (memcached_rgroup_switchover(ptr, instance) == true) {
+        instance= memcached_server_instance_fetch(ptr, server_key);
+        goto do_action;
+      }
+    }
+#endif
   }
 
   return rc;

--- a/libmemcached/touch.cc
+++ b/libmemcached/touch.cc
@@ -110,29 +110,30 @@ do_action:
   }
 
   memcached_return_t rc= memcached_vdo(instance, vector, 6, to_write);
-
-  if (rc == MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS)
   {
-    if (to_write == false)
-    {
-      rc= MEMCACHED_BUFFERED;
-    }
-    else if (no_reply == false)
-    {
-      char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-      rc= memcached_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+    return rc;
+  }
+
+  if (to_write == false)
+  {
+    rc= MEMCACHED_BUFFERED;
+  }
+  else if (no_reply == false)
+  {
+    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+    rc= memcached_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
 #ifdef ENABLE_REPLICATION
-      if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
-      {
-        ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                      instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-        if (memcached_rgroup_switchover(ptr, instance) == true) {
-          instance= memcached_server_instance_fetch(ptr, server_key);
-          goto do_action;
-        }
+    if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+    {
+      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+      if (memcached_rgroup_switchover(ptr, instance) == true) {
+        instance= memcached_server_instance_fetch(ptr, server_key);
+        goto do_action;
       }
-#endif
     }
+#endif
   }
 
   return rc;

--- a/libmemcached/version.cc
+++ b/libmemcached/version.cc
@@ -66,11 +66,11 @@ static inline memcached_return_t memcached_version_textual(memcached_st *ptr)
   };
 
   uint32_t success= 0;
-  bool errors_happened= false;
+  memcached_return_t rc= MEMCACHED_SUCCESS;
+
   for (uint32_t x= 0; x < memcached_server_count(ptr); x++)
   {
-    memcached_server_st *instance=
-      memcached_server_instance_fetch(ptr, x);
+    memcached_server_st *instance= memcached_server_instance_fetch(ptr, x);
 
     /* Optimization, we only fetch version once. */
     if (instance->major_version != UINT8_MAX)
@@ -81,7 +81,7 @@ static inline memcached_return_t memcached_version_textual(memcached_st *ptr)
     memcached_return_t rrc= memcached_vdo(instance, vector, 1, true);
     if (rrc != MEMCACHED_SUCCESS)
     {
-      errors_happened= true;
+      rc= MEMCACHED_SOME_ERRORS;
       (void)memcached_set_error(*instance, rrc, MEMCACHED_AT);
       continue;
     }
@@ -98,12 +98,12 @@ static inline memcached_return_t memcached_version_textual(memcached_st *ptr)
       memcached_return_t rrc= memcached_response(instance, buffer, sizeof(buffer), NULL);
       if (rrc != MEMCACHED_SUCCESS)
       {
-        errors_happened= true;
+        rc= MEMCACHED_SOME_ERRORS;
       }
     }
   }
 
-  return errors_happened ? MEMCACHED_SOME_ERRORS : MEMCACHED_SUCCESS;
+  return rc;
 }
 
 static inline memcached_return_t memcached_version_binary(memcached_st *ptr)
@@ -119,11 +119,11 @@ static inline memcached_return_t memcached_version_binary(memcached_st *ptr)
   };
 
   uint32_t success= 0;
-  bool errors_happened= false;
+  memcached_return_t rc= MEMCACHED_SUCCESS;
+
   for (uint32_t x= 0; x < memcached_server_count(ptr); x++)
   {
-    memcached_server_st *instance=
-      memcached_server_instance_fetch(ptr, x);
+    memcached_server_st *instance= memcached_server_instance_fetch(ptr, x);
 
     /* Optimization, we only fetch version once. */
     if (instance->major_version != UINT8_MAX)
@@ -134,7 +134,7 @@ static inline memcached_return_t memcached_version_binary(memcached_st *ptr)
     memcached_return_t rrc= memcached_vdo(instance, vector, 1, true);
     if (rrc != MEMCACHED_SUCCESS)
     {
-      errors_happened= true;
+      rc= MEMCACHED_SOME_ERRORS;
       (void)memcached_set_error(*instance, rrc, MEMCACHED_AT);
       continue;
     }
@@ -151,12 +151,12 @@ static inline memcached_return_t memcached_version_binary(memcached_st *ptr)
       memcached_return_t rrc= memcached_response(instance, buffer, sizeof(buffer), NULL);
       if (rrc != MEMCACHED_SUCCESS)
       {
-        errors_happened= true;
+        rc= MEMCACHED_SOME_ERRORS;
       }
     }
   }
 
-  return errors_happened ? MEMCACHED_SOME_ERRORS : MEMCACHED_SUCCESS;
+  return rc;
 }
 
 static inline memcached_return_t version_ascii_instance(memcached_server_st *instance)


### PR DESCRIPTION
### 🔗 Related Issue
- https://github.com/naver/arcus-c-client/issues/167

### ⌨️ What I did
`memcached_vdo()` 호출부에서 
- 복잡한 중첩 조건문을 간단하게 수정했습니다.
- 불필요한 상태 변수를 제거했습니다.
- 조건문 내부 로직을 일관된 indent로 수정했습니다.

=> 현재 가독성은 조금 떨어지더라도 통일성을 맞춰놓은 부분이 있습니다. 추후 커밋에서 분리할 수 있는 로직을 쉽게 파악하기 위해서입니다.
