### PR TITLE
INTERNAL: Improve readability of branching logic for `no_reply` and `to_write`

### DIFF
--- a/libmemcached/auto.cc
+++ b/libmemcached/auto.cc
@@ -108,9 +108,14 @@ do_action:
 #endif
   /* Send command header */
   memcached_return_t rc= memcached_vdo(instance, vector, 7, true);
-  if (ptr->flags.no_reply or rc != MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
+  }
+
+  if (ptr->flags.no_reply)
+  {
+    return MEMCACHED_SUCCESS;
   }
 
   char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
@@ -170,14 +175,12 @@ static memcached_return_t binary_incr_decr(memcached_st *ptr, uint8_t cmd,
                                            uint32_t expiration,
                                            uint64_t *value)
 {
-  bool no_reply= ptr->flags.no_reply;
-
   arcus_server_check_for_update(ptr);
 
   if (memcached_server_count(ptr) == 0)
     return memcached_set_error(*ptr, MEMCACHED_NO_SERVERS, MEMCACHED_AT);
 
-  if (no_reply)
+  if (ptr->flags.no_reply)
   {
     if(cmd == PROTOCOL_BINARY_CMD_DECREMENT)
       cmd= PROTOCOL_BINARY_CMD_DECREMENTQ;
@@ -211,9 +214,14 @@ static memcached_return_t binary_incr_decr(memcached_st *ptr, uint8_t cmd,
 do_action:
 #endif
   memcached_return_t rc= memcached_vdo(instance, vector, 3, true);
-  if (no_reply or rc != MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
+  }
+
+  if (ptr->flags.no_reply)
+  {
+    return MEMCACHED_SUCCESS;
   }
 
   rc= memcached_response(instance, (char*)value, sizeof(*value), NULL);

--- a/libmemcached/collection.cc
+++ b/libmemcached/collection.cc
@@ -792,8 +792,6 @@ memcached_return_t memcached_set_attrs(memcached_st *ptr,
                                memcached_literal_param("snprintf(MEMCACHED_DEFAULT_COMMAND_SIZE)"));
   }
 
-  bool to_write= not ptr->flags.buffer_requests;
-
   struct libmemcached_io_vector_st vector[]=
   {
     { command_length, command },
@@ -810,39 +808,37 @@ memcached_return_t memcached_set_attrs(memcached_st *ptr,
 do_action:
 #endif
   /* Send command header */
-  rc= memcached_vdo(instance, vector, 4, to_write);
+  rc= memcached_vdo(instance, vector, 4, !ptr->flags.buffer_requests);
   WATCHPOINT_IFERROR(rc);
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
   }
 
-  if (to_write == false)
+  if (ptr->flags.buffer_requests)
   {
-    rc= MEMCACHED_BUFFERED;
+    return MEMCACHED_BUFFERED;
   }
   else if (ptr->flags.no_reply)
   {
-    rc= MEMCACHED_SUCCESS;
+    return MEMCACHED_SUCCESS;
   }
-  else
-  {
-    // expecting OK (MEMCACHED_SUCCESS)
-    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-    rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+
+  // expecting OK (MEMCACHED_SUCCESS)
+  char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+  rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
 #ifdef ENABLE_REPLICATION
-    if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+  if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+  {
+    ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                  instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+    if (memcached_rgroup_switchover(ptr, instance) == true)
     {
-      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-      if (memcached_rgroup_switchover(ptr, instance) == true)
-      {
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
-      }
+      instance= memcached_server_instance_fetch(ptr, server_key);
+      goto do_action;
     }
-#endif
   }
+#endif
 
   return rc;
 }
@@ -1076,8 +1072,6 @@ static memcached_return_t do_coll_create(memcached_st *ptr,
   }
 
   /* Request */
-  bool to_write= not ptr->flags.buffer_requests;
-
   struct libmemcached_io_vector_st vector[]=
   {
     { command_length, command },
@@ -1093,42 +1087,40 @@ static memcached_return_t do_coll_create(memcached_st *ptr,
 #ifdef ENABLE_REPLICATION
 do_action:
 #endif
-  rc= memcached_vdo(instance, vector, 4, to_write);
+  rc= memcached_vdo(instance, vector, 4, !ptr->flags.buffer_requests);
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
   }
 
-  if (to_write == false)
+  if (ptr->flags.buffer_requests)
   {
-    rc= MEMCACHED_BUFFERED;
+    return MEMCACHED_BUFFERED;
   }
-  else if (ptr->flags.no_reply || ptr->flags.piped)
+  else if (ptr->flags.no_reply or ptr->flags.piped)
+  {
+    return MEMCACHED_SUCCESS;
+  }
+
+  char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+  rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+#ifdef ENABLE_REPLICATION
+  if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+  {
+    ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                  instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+    if (memcached_rgroup_switchover(ptr, instance) == true)
+    {
+      instance= memcached_server_instance_fetch(ptr, server_key);
+      goto do_action;
+    }
+  }
+#endif
+  memcached_set_last_response_code(ptr, rc);
+
+  if (rc == MEMCACHED_CREATED)
   {
     rc= MEMCACHED_SUCCESS;
-  }
-  else
-  {
-    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-    rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
-#ifdef ENABLE_REPLICATION
-    if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
-    {
-      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-      if (memcached_rgroup_switchover(ptr, instance) == true)
-      {
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
-      }
-    }
-#endif
-    memcached_set_last_response_code(ptr, rc);
-
-    if (rc == MEMCACHED_CREATED)
-    {
-      rc= MEMCACHED_SUCCESS;
-    }
   }
 
   return rc;
@@ -1257,9 +1249,9 @@ static memcached_return_t internal_coll_piped_insert(memcached_st *ptr,
     { query->value_length, query->value },
     { 2, "\r\n" }
   };
-  bool to_write= true; /* do not buffer requests internally. */
 
-  rc= memcached_vdo(instance, vector, 7, to_write);
+  /* do not buffer requests internally. */
+  rc= memcached_vdo(instance, vector, 7, true);
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
@@ -1330,9 +1322,9 @@ static memcached_return_t internal_coll_piped_exist(memcached_st *ptr,
     { value_length, value },
     { 2, "\r\n" }
   };
-  bool to_write= true; /* do not buffer requests internally. */
 
-  rc= memcached_vdo(instance, vector, 6, to_write);
+  /* do not buffer requests internally. */
+  rc= memcached_vdo(instance, vector, 6, true);
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
@@ -1432,8 +1424,6 @@ static memcached_return_t do_coll_insert(memcached_st *ptr,
                                memcached_literal_param("snprintf(MEMCACHED_DEFAULT_COMMAND_SIZE)"));
   }
 
-  bool to_write= not ptr->flags.buffer_requests;
-
   struct libmemcached_io_vector_st vector[]=
   {
     { command_length, command },
@@ -1452,47 +1442,45 @@ static memcached_return_t do_coll_insert(memcached_st *ptr,
 do_action:
 #endif
   /* Send command header */
-  rc= memcached_vdo(instance, vector, 6, to_write);
+  rc= memcached_vdo(instance, vector, 6, !ptr->flags.buffer_requests);
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
   }
 
-  if (to_write == false)
+  if (ptr->flags.buffer_requests)
   {
-    rc= MEMCACHED_BUFFERED;
+    return MEMCACHED_BUFFERED;
   }
   else if (ptr->flags.no_reply or ptr->flags.piped)
   {
+    return MEMCACHED_SUCCESS;
+  }
+
+  char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+  rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+#ifdef ENABLE_REPLICATION
+  if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+  {
+    ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                  instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+    if (memcached_rgroup_switchover(ptr, instance) == true)
+    {
+      instance= memcached_server_instance_fetch(ptr, server_key);
+      goto do_action;
+    }
+  }
+#endif
+  memcached_set_last_response_code(ptr, rc);
+
+  if (rc == MEMCACHED_STORED || rc == MEMCACHED_CREATED_STORED)
+  {
     rc= MEMCACHED_SUCCESS;
   }
-  else
+  else if (rc == MEMCACHED_REPLACED && (verb == BOP_UPSERT_OP || verb == MOP_UPSERT_OP))
   {
-    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-    rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
-#ifdef ENABLE_REPLICATION
-    if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
-    {
-      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-      if (memcached_rgroup_switchover(ptr, instance) == true)
-      {
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
-      }
-    }
-#endif
-    memcached_set_last_response_code(ptr, rc);
-
-    if (rc == MEMCACHED_STORED || rc == MEMCACHED_CREATED_STORED)
-    {
-      rc= MEMCACHED_SUCCESS;
-    }
-    else if (rc == MEMCACHED_REPLACED && (verb == BOP_UPSERT_OP || verb == MOP_UPSERT_OP))
-    {
-      /* mop/bop upsert returns REPLACED if the same bkey element is replaced. */
-      rc= MEMCACHED_SUCCESS;
-    }
+    /* mop/bop upsert returns REPLACED if the same bkey element is replaced. */
+    rc= MEMCACHED_SUCCESS;
   }
 
   return rc;
@@ -1610,8 +1598,6 @@ static memcached_return_t do_coll_delete(memcached_st *ptr,
   }
 
   /* Request */
-  bool to_write= not ptr->flags.buffer_requests;
-
   struct libmemcached_io_vector_st vector[6];
   size_t veclen;
 
@@ -1654,43 +1640,41 @@ static memcached_return_t do_coll_delete(memcached_st *ptr,
 #ifdef ENABLE_REPLICATION
 do_action:
 #endif
-  rc= memcached_vdo(instance, vector, veclen, to_write);
+  rc= memcached_vdo(instance, vector, veclen, !ptr->flags.buffer_requests);
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
   }
 
-  if (to_write == false)
+  if (ptr->flags.buffer_requests)
   {
-    rc= MEMCACHED_BUFFERED;
+    return MEMCACHED_BUFFERED;
   }
   else if (ptr->flags.no_reply)
   {
-    rc= MEMCACHED_SUCCESS;
+    return MEMCACHED_SUCCESS;
   }
-  else
-  {
-    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-    rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
-#ifdef ENABLE_REPLICATION
-    if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
-    {
-      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-      if (memcached_rgroup_switchover(ptr, instance) == true)
-      {
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
-      }
-    }
-#endif
-    memcached_set_last_response_code(ptr, rc);
 
-    if (rc == MEMCACHED_DELETED or
-        rc == MEMCACHED_DELETED_DROPPED)
+  char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+  rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+#ifdef ENABLE_REPLICATION
+  if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+  {
+    ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                  instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+    if (memcached_rgroup_switchover(ptr, instance) == true)
     {
-      rc= MEMCACHED_SUCCESS;
+      instance= memcached_server_instance_fetch(ptr, server_key);
+      goto do_action;
     }
+  }
+#endif
+  memcached_set_last_response_code(ptr, rc);
+
+  if (rc == MEMCACHED_DELETED or
+      rc == MEMCACHED_DELETED_DROPPED)
+  {
+    rc= MEMCACHED_SUCCESS;
   }
 
   return rc;
@@ -1877,8 +1861,6 @@ static memcached_return_t do_coll_get(memcached_st *ptr,
   }
 
   /* Request */
-  bool to_write= not ptr->flags.buffer_requests;
-
   struct libmemcached_io_vector_st vector[6];
   size_t veclen;
 
@@ -1913,7 +1895,7 @@ static memcached_return_t do_coll_get(memcached_st *ptr,
 #ifdef ENABLE_REPLICATION
 do_action:
 #endif
-  rc= memcached_vdo(instance, vector, veclen, to_write);
+  rc= memcached_vdo(instance, vector, veclen, !ptr->flags.buffer_requests);
   if (rc != MEMCACHED_SUCCESS)
   {
     if (mkey_buffer)
@@ -1924,11 +1906,11 @@ do_action:
     return rc;
   }
 
-  if (to_write == false)
+  if (ptr->flags.buffer_requests)
   {
     rc= MEMCACHED_BUFFERED;
   }
-  else if (ptr->flags.no_reply || ptr->flags.piped)
+  else if (ptr->flags.no_reply or ptr->flags.piped)
   {
     rc= MEMCACHED_SUCCESS;
   }
@@ -2252,8 +2234,6 @@ static memcached_return_t do_bop_find_position(memcached_st *ptr,
   }
 
   /* Request */
-  bool to_write= not ptr->flags.buffer_requests;
-
   struct libmemcached_io_vector_st vector[] =
   {
     { command_length, command },
@@ -2266,32 +2246,30 @@ static memcached_return_t do_bop_find_position(memcached_st *ptr,
   uint32_t server_key= memcached_generate_hash_with_redistribution(ptr, key, key_length);
   memcached_server_write_instance_st instance= memcached_server_instance_fetch(ptr, server_key);
 
-  rc= memcached_vdo(instance, vector, 4, to_write);
+  rc= memcached_vdo(instance, vector, 4, !ptr->flags.buffer_requests);
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
   }
 
-  if (to_write == false)
+  if (ptr->flags.buffer_requests)
   {
-    rc= MEMCACHED_BUFFERED;
+    return MEMCACHED_BUFFERED;
   }
-  else if (ptr->flags.no_reply || ptr->flags.piped)
+  else if (ptr->flags.no_reply or ptr->flags.piped)
   {
-    rc= MEMCACHED_SUCCESS;
+    return MEMCACHED_SUCCESS;
   }
-  else
-  {
-    char response[MEMCACHED_DEFAULT_COMMAND_SIZE];
-    rc= memcached_coll_response(instance, response, MEMCACHED_DEFAULT_COMMAND_SIZE, &ptr->collection_result);
 
-    if (rc == MEMCACHED_POSITION)
-    {
-      *position= ptr->collection_result.btree_position;
-      /* reset btree_position because it is intended for use in bop pwg */
-      ptr->collection_result.btree_position= 0;
-      rc= MEMCACHED_SUCCESS;
-    }
+  char response[MEMCACHED_DEFAULT_COMMAND_SIZE];
+  rc= memcached_coll_response(instance, response, MEMCACHED_DEFAULT_COMMAND_SIZE, &ptr->collection_result);
+
+  if (rc == MEMCACHED_POSITION)
+  {
+    *position= ptr->collection_result.btree_position;
+    /* reset btree_position because it is intended for use in bop pwg */
+    ptr->collection_result.btree_position= 0;
+    rc= MEMCACHED_SUCCESS;
   }
 
   return rc;
@@ -2347,8 +2325,6 @@ static memcached_return_t do_bop_get_by_position(memcached_st *ptr,
   }
 
   /* Request */
-  bool to_write= not ptr->flags.buffer_requests;
-
   struct libmemcached_io_vector_st vector[]=
   {
     { command_length, command },
@@ -2361,36 +2337,34 @@ static memcached_return_t do_bop_get_by_position(memcached_st *ptr,
   uint32_t server_key= memcached_generate_hash_with_redistribution(ptr, key, key_length);
   memcached_server_write_instance_st instance= memcached_server_instance_fetch(ptr, server_key);
 
-  rc= memcached_vdo(instance, vector, 4, to_write);
+  rc= memcached_vdo(instance, vector, 4, !ptr->flags.buffer_requests);
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
   }
 
-  if (to_write == false)
+  if (ptr->flags.buffer_requests)
   {
-    rc= MEMCACHED_BUFFERED;
+    return MEMCACHED_BUFFERED;
   }
-  else if (ptr->flags.no_reply || ptr->flags.piped)
+  else if (ptr->flags.no_reply or ptr->flags.piped)
+  {
+    return MEMCACHED_SUCCESS;
+  }
+
+  /* Fetch results */
+  result= memcached_coll_fetch_result(ptr, result, &rc);
+
+  /* Search for END or something */
+  if (result)
+  {
+    memcached_coll_result_reset(&ptr->collection_result);
+    memcached_coll_fetch_result(ptr, &ptr->collection_result, &rc);
+  }
+
+  if (rc == MEMCACHED_END)
   {
     rc= MEMCACHED_SUCCESS;
-  }
-  else
-  {
-    /* Fetch results */
-    result= memcached_coll_fetch_result(ptr, result, &rc);
-
-    /* Search for END or something */
-    if (result)
-    {
-      memcached_coll_result_reset(&ptr->collection_result);
-      memcached_coll_fetch_result(ptr, &ptr->collection_result, &rc);
-    }
-
-    if (rc == MEMCACHED_END)
-    {
-      rc= MEMCACHED_SUCCESS;
-    }
   }
 
   return rc;
@@ -2444,8 +2418,6 @@ static memcached_return_t do_bop_find_position_with_get(memcached_st *ptr,
   }
 
   /* Request */
-  bool to_write= not ptr->flags.buffer_requests;
-
   struct libmemcached_io_vector_st vector[] =
   {
     { command_length, command },
@@ -2458,36 +2430,34 @@ static memcached_return_t do_bop_find_position_with_get(memcached_st *ptr,
   uint32_t server_key= memcached_generate_hash_with_redistribution(ptr, key, key_length);
   memcached_server_write_instance_st instance= memcached_server_instance_fetch(ptr, server_key);
 
-  rc= memcached_vdo(instance, vector, 4, to_write);
+  rc= memcached_vdo(instance, vector, 4, !ptr->flags.buffer_requests);
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
   }
 
-  if (to_write == false)
+  if (ptr->flags.buffer_requests)
   {
-    rc= MEMCACHED_BUFFERED;
+    return MEMCACHED_BUFFERED;
   }
-  else if (ptr->flags.no_reply || ptr->flags.piped)
+  else if (ptr->flags.no_reply or ptr->flags.piped)
+  {
+    return MEMCACHED_SUCCESS;
+  }
+
+  /* Fetch results */
+  result= memcached_coll_fetch_result(ptr, result, &rc);
+
+  /* Search for END or something */
+  if (result)
+  {
+    memcached_coll_result_reset(&ptr->collection_result);
+    memcached_coll_fetch_result(ptr, &ptr->collection_result, &rc);
+  }
+
+  if (rc == MEMCACHED_END)
   {
     rc= MEMCACHED_SUCCESS;
-  }
-  else
-  {
-    /* Fetch results */
-    result= memcached_coll_fetch_result(ptr, result, &rc);
-
-    /* Search for END or something */
-    if (result)
-    {
-      memcached_coll_result_reset(&ptr->collection_result);
-      memcached_coll_fetch_result(ptr, &ptr->collection_result, &rc);
-    }
-
-    if (rc == MEMCACHED_END)
-    {
-      rc= MEMCACHED_SUCCESS;
-    }
   }
 
   return rc;
@@ -2770,8 +2740,6 @@ static memcached_return_t do_coll_exist(memcached_st *ptr,
   }
 
   /* Request */
-  bool to_write= not ptr->flags.buffer_requests;
-
   struct libmemcached_io_vector_st vector[]=
   {
     { command_length, command },
@@ -2785,30 +2753,28 @@ static memcached_return_t do_coll_exist(memcached_st *ptr,
   uint32_t server_key= memcached_generate_hash_with_redistribution(ptr, key, key_length);
   memcached_server_write_instance_st instance= memcached_server_instance_fetch(ptr, server_key);
 
-  rc= memcached_vdo(instance, vector, 5, to_write);
+  rc= memcached_vdo(instance, vector, 5, !ptr->flags.buffer_requests);
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
   }
 
-  if (to_write == false)
+  if (ptr->flags.buffer_requests)
   {
-    rc= MEMCACHED_BUFFERED;
+    return MEMCACHED_BUFFERED;
   }
-  else if (ptr->flags.no_reply)
+  else if (ptr->flags.no_reply or ptr->flags.piped)
+  {
+    return MEMCACHED_SUCCESS;
+  }
+
+  char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+  rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+  memcached_set_last_response_code(ptr, rc);
+
+  if (rc == MEMCACHED_EXIST or rc == MEMCACHED_NOT_EXIST)
   {
     rc= MEMCACHED_SUCCESS;
-  }
-  else
-  {
-    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-    rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
-    memcached_set_last_response_code(ptr, rc);
-
-    if (rc == MEMCACHED_EXIST or rc == MEMCACHED_NOT_EXIST)
-    {
-      rc= MEMCACHED_SUCCESS;
-    }
   }
 
   return rc;
@@ -3309,8 +3275,6 @@ static memcached_return_t do_coll_update(memcached_st *ptr,
   }
 
   /* Request */
-  bool to_write= not ptr->flags.buffer_requests;
-
   struct libmemcached_io_vector_st vector[6];
   size_t veclen;
 
@@ -3342,42 +3306,40 @@ static memcached_return_t do_coll_update(memcached_st *ptr,
 #ifdef ENABLE_REPLICATION
 do_action:
 #endif
-  rc= memcached_vdo(instance, vector, veclen, to_write);
+  rc= memcached_vdo(instance, vector, veclen, !ptr->flags.buffer_requests);
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
   }
 
-  if (to_write == false)
+  if (ptr->flags.buffer_requests)
   {
-    rc= MEMCACHED_BUFFERED;
+    return MEMCACHED_BUFFERED;
   }
-  else if (ptr->flags.no_reply || ptr->flags.piped)
+  else if (ptr->flags.no_reply or ptr->flags.piped)
+  {
+    return MEMCACHED_SUCCESS;
+  }
+
+  char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+  rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+#ifdef ENABLE_REPLICATION
+  if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+  {
+    ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                  instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+    if (memcached_rgroup_switchover(ptr, instance) == true)
+    {
+      instance= memcached_server_instance_fetch(ptr, server_key);
+      goto do_action;
+    }
+  }
+#endif
+  memcached_set_last_response_code(ptr, rc);
+
+  if (rc == MEMCACHED_UPDATED)
   {
     rc= MEMCACHED_SUCCESS;
-  }
-  else
-  {
-    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-    rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
-#ifdef ENABLE_REPLICATION
-    if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
-    {
-      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-      if (memcached_rgroup_switchover(ptr, instance) == true)
-      {
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
-      }
-    }
-#endif
-    memcached_set_last_response_code(ptr, rc);
-
-    if (rc == MEMCACHED_UPDATED)
-    {
-      rc= MEMCACHED_SUCCESS;
-    }
   }
 
   return rc;
@@ -3460,7 +3422,6 @@ static memcached_return_t do_coll_arithmetic(memcached_st *ptr,
   }
 
   /* Request */
-  bool to_write= not ptr->flags.buffer_requests;
 
   /* update without value */
   struct libmemcached_io_vector_st vector[]=
@@ -3478,50 +3439,48 @@ static memcached_return_t do_coll_arithmetic(memcached_st *ptr,
 #ifdef ENABLE_REPLICATION
 do_action:
 #endif
-  rc= memcached_vdo(instance, vector, 4, to_write);
+  rc= memcached_vdo(instance, vector, 4, !ptr->flags.buffer_requests);
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
   }
 
-  if (to_write == false)
+  if (ptr->flags.buffer_requests)
   {
-    rc= MEMCACHED_BUFFERED;
+    return MEMCACHED_BUFFERED;
   }
-  else if (ptr->flags.no_reply || ptr->flags.piped)
+  else if (ptr->flags.no_reply or ptr->flags.piped)
   {
-    rc= MEMCACHED_SUCCESS;
+    return MEMCACHED_SUCCESS;
+  }
+
+  char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+  rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+#ifdef ENABLE_REPLICATION
+  if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+  {
+    ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                  instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+    if (memcached_rgroup_switchover(ptr, instance) == true)
+    {
+      instance= memcached_server_instance_fetch(ptr, server_key);
+      goto do_action;
+    }
+  }
+#endif
+  if (rc == MEMCACHED_NOTFOUND or
+      rc == MEMCACHED_NOTFOUND_ELEMENT or
+      rc == MEMCACHED_CLIENT_ERROR or
+      rc == MEMCACHED_TYPE_MISMATCH or
+      rc == MEMCACHED_BKEY_MISMATCH or
+      rc == MEMCACHED_SERVER_ERROR)
+  {
+    *value= 0;
+    return rc;
   }
   else
   {
-    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-    rc= memcached_coll_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
-#ifdef ENABLE_REPLICATION
-    if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
-    {
-      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-      if (memcached_rgroup_switchover(ptr, instance) == true)
-      {
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
-      }
-    }
-#endif
-    if (rc == MEMCACHED_NOTFOUND or
-        rc == MEMCACHED_NOTFOUND_ELEMENT or
-        rc == MEMCACHED_CLIENT_ERROR or
-        rc == MEMCACHED_TYPE_MISMATCH or
-        rc == MEMCACHED_BKEY_MISMATCH or
-        rc == MEMCACHED_SERVER_ERROR)
-    {
-      *value= 0;
-      return rc;
-    }
-    else
-    {
-      *value= strtoull(result, (char **)NULL, 10);
-    }
+    *value= strtoull(result, (char **)NULL, 10);
   }
 
   return rc;
@@ -3582,8 +3541,6 @@ static memcached_return_t do_coll_count(memcached_st *ptr,
   }
 
   /* Request */
-  bool to_write= not ptr->flags.buffer_requests;
-
   struct libmemcached_io_vector_st vector[]=
   {
     { command_length, command },
@@ -3596,32 +3553,30 @@ static memcached_return_t do_coll_count(memcached_st *ptr,
   uint32_t server_key= memcached_generate_hash_with_redistribution(ptr, key, key_length);
   memcached_server_write_instance_st instance= memcached_server_instance_fetch(ptr, server_key);
 
-  rc= memcached_vdo(instance, vector, 4, to_write);
+  rc= memcached_vdo(instance, vector, 4, !ptr->flags.buffer_requests);
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
   }
 
-  if (to_write == false)
+  if (ptr->flags.buffer_requests)
   {
-    rc= MEMCACHED_BUFFERED;
+    return MEMCACHED_BUFFERED;
   }
-  else if (ptr->flags.no_reply || ptr->flags.piped)
+  else if (ptr->flags.no_reply or ptr->flags.piped)
   {
-    rc= MEMCACHED_SUCCESS;
+    return MEMCACHED_SUCCESS;
   }
-  else
-  {
-    char response[MEMCACHED_DEFAULT_COMMAND_SIZE];
-    rc= memcached_coll_response(instance, response, MEMCACHED_DEFAULT_COMMAND_SIZE, &ptr->collection_result);
 
-    if (rc == MEMCACHED_COUNT)
-    {
-      *count= ptr->collection_result.collection_count;
-      /* reset collection because it is used in memcached_coll_result_reset(collection_result.cc)*/
-      ptr->collection_result.collection_count= 0;
-      rc= MEMCACHED_SUCCESS;
-    }
+  char response[MEMCACHED_DEFAULT_COMMAND_SIZE];
+  rc= memcached_coll_response(instance, response, MEMCACHED_DEFAULT_COMMAND_SIZE, &ptr->collection_result);
+
+  if (rc == MEMCACHED_COUNT)
+  {
+    *count= ptr->collection_result.collection_count;
+    /* reset collection because it is used in memcached_coll_result_reset(collection_result.cc)*/
+    ptr->collection_result.collection_count= 0;
+    rc= MEMCACHED_SUCCESS;
   }
 
   return rc;

--- a/libmemcached/delete.cc
+++ b/libmemcached/delete.cc
@@ -61,15 +61,12 @@ static inline memcached_return_t ascii_delete(memcached_st *ptr,
                                               const char *key,
                                               const size_t key_length)
 {
-  bool to_write= (ptr->flags.buffer_requests) ? false : true;
-  bool no_reply= (ptr->flags.no_reply);
-
   struct libmemcached_io_vector_st vector[]=
   {
     { 7, "delete " },
     { memcached_array_size(ptr->_namespace), memcached_array_string(ptr->_namespace) },
     { key_length, key },
-    { (no_reply ? memcached_literal_param_size(" noreply") : 0), " noreply" },
+    { (ptr->flags.no_reply ? memcached_literal_param_size(" noreply") : 0), " noreply" },
     { 2, "\r\n" }
   };
 
@@ -79,7 +76,7 @@ static inline memcached_return_t ascii_delete(memcached_st *ptr,
 #ifdef ENABLE_REPLICATION
 do_action:
 #endif
-  if (ptr->flags.use_udp && to_write == false)
+  if (ptr->flags.use_udp && ptr->flags.buffer_requests)
   {
     size_t cmd_size= 0;
     for (uint32_t x= 0; x < 5; x++)
@@ -99,38 +96,40 @@ do_action:
   }
 
   /* Send command header */
-  memcached_return_t rc= memcached_vdo(instance, vector, 5, to_write);
+  memcached_return_t rc= memcached_vdo(instance, vector, 5, !ptr->flags.buffer_requests);
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
   }
 
-  if (to_write == false)
+  if (ptr->flags.buffer_requests)
   {
-    rc= MEMCACHED_BUFFERED;
+    return MEMCACHED_BUFFERED;
   }
-  else if (no_reply == false)
+  else if (ptr->flags.no_reply)
   {
-    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-    rc= memcached_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+    return MEMCACHED_SUCCESS;
+  }
 
-    if (rc == MEMCACHED_DELETED)
-    {
-      rc= MEMCACHED_SUCCESS;
-    }
-#ifdef ENABLE_REPLICATION
-    else if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
-    {
-      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-      if (memcached_rgroup_switchover(ptr, instance) == true)
-      {
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
-      }
-    }
-#endif
+  char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+  rc= memcached_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+
+  if (rc == MEMCACHED_DELETED)
+  {
+    rc= MEMCACHED_SUCCESS;
   }
+#ifdef ENABLE_REPLICATION
+  else if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+  {
+    ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                  instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+    if (memcached_rgroup_switchover(ptr, instance) == true)
+    {
+      instance= memcached_server_instance_fetch(ptr, server_key);
+      goto do_action;
+    }
+  }
+#endif
 
   return rc;
 }
@@ -141,12 +140,10 @@ static inline memcached_return_t binary_delete(memcached_st *ptr,
                                                const char *key,
                                                size_t key_length)
 {
-  bool to_write= (ptr->flags.buffer_requests) ? false : true;
-  bool no_reply= (ptr->flags.no_reply);
-
   protocol_binary_request_delete request= {};
   request.message.header.request.magic= PROTOCOL_BINARY_REQ;
-  request.message.header.request.opcode= no_reply ? PROTOCOL_BINARY_CMD_DELETEQ : PROTOCOL_BINARY_CMD_DELETE;
+  request.message.header.request.opcode= ptr->flags.no_reply ?
+                                         PROTOCOL_BINARY_CMD_DELETEQ : PROTOCOL_BINARY_CMD_DELETE;
   request.message.header.request.keylen= htons((uint16_t)(key_length + memcached_array_size(ptr->_namespace)));
   request.message.header.request.datatype= PROTOCOL_BINARY_RAW_BYTES;
   request.message.header.request.bodylen= htonl((uint32_t)(key_length + memcached_array_size(ptr->_namespace)));
@@ -164,7 +161,7 @@ static inline memcached_return_t binary_delete(memcached_st *ptr,
 #ifdef ENABLE_REPLICATION
 do_action:
 #endif
-  if (ptr->flags.use_udp && ! to_write)
+  if (ptr->flags.use_udp && ptr->flags.buffer_requests)
   {
     size_t cmd_size= sizeof(request.bytes) + key_length;
     if (cmd_size > MAX_UDP_DATAGRAM_LENGTH - UDP_DATAGRAM_HEADER_LENGTH)
@@ -174,7 +171,7 @@ do_action:
       memcached_io_write(instance, NULL, 0, true);
   }
 
-  memcached_return_t rc= memcached_vdo(instance, vector, 3, to_write);
+  memcached_return_t rc= memcached_vdo(instance, vector, 3, !ptr->flags.buffer_requests);
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
@@ -192,38 +189,40 @@ do_action:
 
       memcached_server_write_instance_st replica;
       replica= memcached_server_instance_fetch(ptr, server_key);
-      if (memcached_vdo(replica, vector, 3, to_write) == MEMCACHED_SUCCESS)
+      if (memcached_vdo(replica, vector, 3, !ptr->flags.buffer_requests) == MEMCACHED_SUCCESS)
       {
         memcached_server_response_decrement(replica);
       }
     }
   }
 
-  if (to_write == false)
+  if (ptr->flags.buffer_requests)
   {
-    rc= MEMCACHED_BUFFERED;
+    return MEMCACHED_BUFFERED;
   }
-  else if (no_reply == false)
+  else if (ptr->flags.no_reply)
   {
-    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-    rc= memcached_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
-    if (rc == MEMCACHED_DELETED)
-    {
-      rc= MEMCACHED_SUCCESS;
-    }
+    return MEMCACHED_SUCCESS;
+  }
+
+  char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+  rc= memcached_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+  if (rc == MEMCACHED_DELETED)
+  {
+    rc= MEMCACHED_SUCCESS;
+  }
 #ifdef ENABLE_REPLICATION
-    else if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+  else if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+  {
+    ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                  instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+    if (memcached_rgroup_switchover(ptr, instance) == true)
     {
-      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-      if (memcached_rgroup_switchover(ptr, instance) == true)
-      {
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
-      }
+      instance= memcached_server_instance_fetch(ptr, server_key);
+      goto do_action;
     }
-#endif
   }
+#endif
 
   return rc;
 }

--- a/libmemcached/storage.cc
+++ b/libmemcached/storage.cc
@@ -198,14 +198,11 @@ static memcached_return_t memcached_send_binary(memcached_st *ptr,
                                                 uint64_t cas,
                                                 memcached_storage_action_t verb)
 {
-  bool flush= (ptr->flags.buffer_requests && verb == SET_OP) ? false : true;
-  bool noreply= ptr->flags.no_reply;
-
   protocol_binary_request_set request= {};
   size_t send_length= sizeof(request.bytes);
 
   request.message.header.request.magic= PROTOCOL_BINARY_REQ;
-  request.message.header.request.opcode= get_com_code(verb, noreply);
+  request.message.header.request.opcode= get_com_code(verb, ptr->flags.no_reply);
   request.message.header.request.keylen= htons((uint16_t)(key_length + memcached_array_size(ptr->_namespace)));
   request.message.header.request.datatype= PROTOCOL_BINARY_RAW_BYTES;
   if (verb == APPEND_OP || verb == PREPEND_OP)
@@ -241,7 +238,9 @@ do_action:
   WATCHPOINT_SET(server->io_wait_count.read= 0);
   WATCHPOINT_SET(server->io_wait_count.write= 0);
 
-  if (ptr->flags.use_udp && !flush)
+  bool buffer_requests= (ptr->flags.buffer_requests && verb == SET_OP) ? true : false;
+
+  if (ptr->flags.use_udp && buffer_requests)
   {
     size_t cmd_size= send_length + key_length + value_length;
 
@@ -256,7 +255,7 @@ do_action:
   }
 
   /* write the header */
-  memcached_return_t rc= memcached_vdo(server, vector, 4, flush);
+  memcached_return_t rc= memcached_vdo(server, vector, 4, !buffer_requests);
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
@@ -284,30 +283,28 @@ do_action:
     }
   }
 
-  if (flush == false)
+  if (buffer_requests)
   {
-    rc= MEMCACHED_BUFFERED;
+    return MEMCACHED_BUFFERED;
   }
-  else if (noreply or ptr->flags.multi_store)
+  else if (ptr->flags.no_reply or ptr->flags.multi_store)
   {
-    rc= MEMCACHED_SUCCESS;
+    return MEMCACHED_SUCCESS;
   }
-  else
-  {
-    rc= memcached_response(server, NULL, 0, NULL);
+
+  rc= memcached_response(server, NULL, 0, NULL);
 #ifdef ENABLE_REPLICATION
-    if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+  if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+  {
+    ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                  server->hostname, server->port, memcached_strerror(ptr, rc)));
+    if (memcached_rgroup_switchover(ptr, server) == true)
     {
-      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                    server->hostname, server->port, memcached_strerror(ptr, rc)));
-      if (memcached_rgroup_switchover(ptr, server) == true)
-      {
-        server= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
-      }
+      server= memcached_server_instance_fetch(ptr, server_key);
+      goto do_action;
     }
-#endif
   }
+#endif
 
   return rc;
 }
@@ -374,7 +371,7 @@ static memcached_return_t memcached_send_ascii(memcached_st *ptr,
     { 2, "\r\n" }
   };
 
-  bool to_write= (ptr->flags.buffer_requests && verb == SET_OP) ? false : true;
+  bool buffer_requests= (ptr->flags.buffer_requests && verb == SET_OP) ? true : false;
 
   memcached_server_write_instance_st instance= memcached_server_instance_fetch(ptr, server_key);;
 
@@ -400,41 +397,39 @@ do_action:
   }
 
   /* Send command header */
-  memcached_return_t rc= memcached_vdo(instance, vector, 11, to_write);
+  memcached_return_t rc= memcached_vdo(instance, vector, 11, !buffer_requests);
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
   }
 
-  if (to_write == false)
+  if (buffer_requests)
   {
-    rc= MEMCACHED_BUFFERED;
+    return MEMCACHED_BUFFERED;
   }
   else if (ptr->flags.no_reply or ptr->flags.multi_store)
   {
+    return MEMCACHED_SUCCESS;
+  }
+
+  char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+  rc= memcached_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+  if (rc == MEMCACHED_STORED)
+  {
     rc= MEMCACHED_SUCCESS;
   }
-  else
-  {
-    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-    rc= memcached_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
-    if (rc == MEMCACHED_STORED)
-    {
-      rc= MEMCACHED_SUCCESS;
-    }
 #ifdef ENABLE_REPLICATION
-    else if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+  else if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+  {
+    ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                  instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+    if (memcached_rgroup_switchover(ptr, instance) == true)
     {
-      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-      if (memcached_rgroup_switchover(ptr, instance) == true)
-      {
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
-      }
+      instance= memcached_server_instance_fetch(ptr, server_key);
+      goto do_action;
     }
-#endif
   }
+#endif
 
   return rc;
 }

--- a/libmemcached/touch.cc
+++ b/libmemcached/touch.cc
@@ -61,9 +61,6 @@ static memcached_return_t ascii_touch(memcached_st *ptr,
                                       size_t key_length,
                                       time_t expiration)
 {
-  bool to_write= (ptr->flags.buffer_requests) ? false : true;
-  bool no_reply= (ptr->flags.no_reply);
-
   char expiration_buffer[MEMCACHED_MAXIMUM_INTEGER_DISPLAY_LENGTH + 1 + 1];
   int expiration_buffer_length= snprintf(expiration_buffer, sizeof(expiration_buffer), " %lld",
                                           (long long) expiration);
@@ -80,7 +77,7 @@ static memcached_return_t ascii_touch(memcached_st *ptr,
     { memcached_array_size(ptr->_namespace), memcached_array_string(ptr->_namespace) },
     { key_length, key },
     { (size_t)expiration_buffer_length, expiration_buffer },
-    { (no_reply ? memcached_literal_param_size(" noreply") : 0), " noreply" },
+    { (ptr->flags.no_reply ? memcached_literal_param_size(" noreply") : 0), " noreply" },
     { 2, "\r\n" }
   };
 
@@ -90,7 +87,7 @@ static memcached_return_t ascii_touch(memcached_st *ptr,
 #ifdef ENABLE_REPLICATION
 do_action:
 #endif
-  if (ptr->flags.use_udp && to_write == false)
+  if (ptr->flags.use_udp && ptr->flags.buffer_requests)
   {
     size_t cmd_size= 0;
     for (uint32_t x= 0; x < 6; x++)
@@ -109,33 +106,35 @@ do_action:
     }
   }
 
-  memcached_return_t rc= memcached_vdo(instance, vector, 6, to_write);
+  memcached_return_t rc= memcached_vdo(instance, vector, 6, !ptr->flags.buffer_requests);
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
   }
 
-  if (to_write == false)
+  if (ptr->flags.buffer_requests)
   {
-    rc= MEMCACHED_BUFFERED;
+    return MEMCACHED_BUFFERED;
   }
-  else if (no_reply == false)
+  else if (ptr->flags.no_reply)
   {
-    char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
-    rc= memcached_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
+    return MEMCACHED_SUCCESS;
+  }
+
+  char result[MEMCACHED_DEFAULT_COMMAND_SIZE];
+  rc= memcached_response(instance, result, MEMCACHED_DEFAULT_COMMAND_SIZE, NULL);
 #ifdef ENABLE_REPLICATION
-    if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+  if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
+  {
+    ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                  instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+    if (memcached_rgroup_switchover(ptr, instance) == true)
     {
-      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-      if (memcached_rgroup_switchover(ptr, instance) == true)
-      {
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
-      }
+      instance= memcached_server_instance_fetch(ptr, server_key);
+      goto do_action;
     }
-#endif
   }
+#endif
 
   return rc;
 }


### PR DESCRIPTION
### 🔗 Related Issue
- https://github.com/naver/arcus-c-client/issues/167

### ⌨️ What I did
- to_write 변수를 삭제하고 ptr->flags.buffer_requests를 직접 사용하게 했습니다. 기존에는 `to_write= not ptr->flags.buffer_requests;`로 할당하고, 사용 시에는 `to_write == false`를 비교해 이중 부정이 되며 가독성이 다소 떨어졌기 때문입니다.

- noreply 변수를 삭제하고 ptr->flags.no_reply를 직접 사용하게 통일했습니다.

-  buffer_request, no_reply인 경우 rc값 변경 대신 early return 하도록 통일했습니다. 단, 기존 방식이 더 적합한 경우 기존 방식을 채택했습니다.

