### PR TITLE
INTERNAL: Subroutine buffer_request check into `memcached_vdo()`

### DIFF
--- a/libmemcached/auto.cc
+++ b/libmemcached/auto.cc
@@ -112,8 +112,7 @@ do_action:
   {
     return rc;
   }
-
-  if (ptr->flags.no_reply)
+  else if (ptr->flags.no_reply)
   {
     return MEMCACHED_SUCCESS;
   }
@@ -218,8 +217,7 @@ do_action:
   {
     return rc;
   }
-
-  if (ptr->flags.no_reply)
+  else if (ptr->flags.no_reply)
   {
     return MEMCACHED_SUCCESS;
   }

--- a/libmemcached/collection.cc
+++ b/libmemcached/collection.cc
@@ -814,11 +814,6 @@ do_action:
   {
     return rc;
   }
-
-  if (ptr->flags.buffer_requests)
-  {
-    return MEMCACHED_BUFFERED;
-  }
   else if (ptr->flags.no_reply)
   {
     return MEMCACHED_SUCCESS;
@@ -1091,11 +1086,6 @@ do_action:
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
-  }
-
-  if (ptr->flags.buffer_requests)
-  {
-    return MEMCACHED_BUFFERED;
   }
   else if (ptr->flags.no_reply or ptr->flags.piped)
   {
@@ -1447,11 +1437,6 @@ do_action:
   {
     return rc;
   }
-
-  if (ptr->flags.buffer_requests)
-  {
-    return MEMCACHED_BUFFERED;
-  }
   else if (ptr->flags.no_reply or ptr->flags.piped)
   {
     return MEMCACHED_SUCCESS;
@@ -1644,11 +1629,6 @@ do_action:
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
-  }
-
-  if (ptr->flags.buffer_requests)
-  {
-    return MEMCACHED_BUFFERED;
   }
   else if (ptr->flags.no_reply)
   {
@@ -1896,7 +1876,7 @@ static memcached_return_t do_coll_get(memcached_st *ptr,
 do_action:
 #endif
   rc= memcached_vdo(instance, vector, veclen, !ptr->flags.buffer_requests);
-  if (rc != MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS or ptr->flags.no_reply or ptr->flags.piped)
   {
     if (mkey_buffer)
     {
@@ -1906,45 +1886,34 @@ do_action:
     return rc;
   }
 
-  if (ptr->flags.buffer_requests)
+  /* Fetch results */
+  result= memcached_coll_fetch_result(ptr, result, &rc);
+#ifdef ENABLE_REPLICATION
+  if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
   {
-    rc= MEMCACHED_BUFFERED;
+    ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
+                   instance->hostname, instance->port, memcached_strerror(ptr, rc)));
+    if (memcached_rgroup_switchover(ptr, instance) == true)
+    {
+      instance= memcached_server_instance_fetch(ptr, server_key);
+      goto do_action;
+    }
   }
-  else if (ptr->flags.no_reply or ptr->flags.piped)
+#endif
+  /* Search for END or something */
+  if (result)
+  {
+    memcached_coll_result_reset(&ptr->collection_result);
+    memcached_coll_fetch_result(ptr, &ptr->collection_result, &rc);
+  }
+  memcached_set_last_response_code(ptr, rc);
+
+  if (rc == MEMCACHED_END             or
+      rc == MEMCACHED_TRIMMED         or
+      rc == MEMCACHED_DELETED         or
+      rc == MEMCACHED_DELETED_DROPPED )
   {
     rc= MEMCACHED_SUCCESS;
-  }
-  else
-  {
-    /* Fetch results */
-    result= memcached_coll_fetch_result(ptr, result, &rc);
-#ifdef ENABLE_REPLICATION
-    if (rc == MEMCACHED_SWITCHOVER or rc == MEMCACHED_REPL_SLAVE)
-    {
-      ZOO_LOG_INFO(("Switchover: hostname=%s port=%d error=%s",
-                    instance->hostname, instance->port, memcached_strerror(ptr, rc)));
-      if (memcached_rgroup_switchover(ptr, instance) == true)
-      {
-        instance= memcached_server_instance_fetch(ptr, server_key);
-        goto do_action;
-      }
-    }
-#endif
-    /* Search for END or something */
-    if (result)
-    {
-      memcached_coll_result_reset(&ptr->collection_result);
-      memcached_coll_fetch_result(ptr, &ptr->collection_result, &rc);
-    }
-    memcached_set_last_response_code(ptr, rc);
-
-    if (rc == MEMCACHED_END             or
-        rc == MEMCACHED_TRIMMED         or
-        rc == MEMCACHED_DELETED         or
-        rc == MEMCACHED_DELETED_DROPPED )
-    {
-      rc= MEMCACHED_SUCCESS;
-    }
   }
 
   if (mkey_buffer)
@@ -2251,11 +2220,6 @@ static memcached_return_t do_bop_find_position(memcached_st *ptr,
   {
     return rc;
   }
-
-  if (ptr->flags.buffer_requests)
-  {
-    return MEMCACHED_BUFFERED;
-  }
   else if (ptr->flags.no_reply or ptr->flags.piped)
   {
     return MEMCACHED_SUCCESS;
@@ -2341,11 +2305,6 @@ static memcached_return_t do_bop_get_by_position(memcached_st *ptr,
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
-  }
-
-  if (ptr->flags.buffer_requests)
-  {
-    return MEMCACHED_BUFFERED;
   }
   else if (ptr->flags.no_reply or ptr->flags.piped)
   {
@@ -2434,11 +2393,6 @@ static memcached_return_t do_bop_find_position_with_get(memcached_st *ptr,
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
-  }
-
-  if (ptr->flags.buffer_requests)
-  {
-    return MEMCACHED_BUFFERED;
   }
   else if (ptr->flags.no_reply or ptr->flags.piped)
   {
@@ -2757,11 +2711,6 @@ static memcached_return_t do_coll_exist(memcached_st *ptr,
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
-  }
-
-  if (ptr->flags.buffer_requests)
-  {
-    return MEMCACHED_BUFFERED;
   }
   else if (ptr->flags.no_reply or ptr->flags.piped)
   {
@@ -3311,11 +3260,6 @@ do_action:
   {
     return rc;
   }
-
-  if (ptr->flags.buffer_requests)
-  {
-    return MEMCACHED_BUFFERED;
-  }
   else if (ptr->flags.no_reply or ptr->flags.piped)
   {
     return MEMCACHED_SUCCESS;
@@ -3444,11 +3388,6 @@ do_action:
   {
     return rc;
   }
-
-  if (ptr->flags.buffer_requests)
-  {
-    return MEMCACHED_BUFFERED;
-  }
   else if (ptr->flags.no_reply or ptr->flags.piped)
   {
     return MEMCACHED_SUCCESS;
@@ -3557,11 +3496,6 @@ static memcached_return_t do_coll_count(memcached_st *ptr,
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
-  }
-
-  if (ptr->flags.buffer_requests)
-  {
-    return MEMCACHED_BUFFERED;
   }
   else if (ptr->flags.no_reply or ptr->flags.piped)
   {

--- a/libmemcached/delete.cc
+++ b/libmemcached/delete.cc
@@ -101,11 +101,6 @@ do_action:
   {
     return rc;
   }
-
-  if (ptr->flags.buffer_requests)
-  {
-    return MEMCACHED_BUFFERED;
-  }
   else if (ptr->flags.no_reply)
   {
     return MEMCACHED_SUCCESS;
@@ -172,7 +167,7 @@ do_action:
   }
 
   memcached_return_t rc= memcached_vdo(instance, vector, 3, !ptr->flags.buffer_requests);
-  if (rc != MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS and rc != MEMCACHED_BUFFERED)
   {
     return rc;
   }
@@ -189,7 +184,8 @@ do_action:
 
       memcached_server_write_instance_st replica;
       replica= memcached_server_instance_fetch(ptr, server_key);
-      if (memcached_vdo(replica, vector, 3, !ptr->flags.buffer_requests) == MEMCACHED_SUCCESS)
+      memcached_return_t rrc= memcached_vdo(replica, vector, 3, !ptr->flags.buffer_requests);
+      if (rrc == MEMCACHED_SUCCESS or rrc == MEMCACHED_BUFFERED)
       {
         memcached_server_response_decrement(replica);
       }

--- a/libmemcached/do.cc
+++ b/libmemcached/do.cc
@@ -121,5 +121,11 @@ memcached_return_t memcached_vdo(memcached_server_write_instance_st ptr,
   {
     memcached_server_response_increment(ptr);
   }
+
+  if (with_flush == false)
+  {
+    rc= MEMCACHED_BUFFERED;
+  }
+
   return rc;
 }

--- a/libmemcached/storage.cc
+++ b/libmemcached/storage.cc
@@ -256,7 +256,7 @@ do_action:
 
   /* write the header */
   memcached_return_t rc= memcached_vdo(server, vector, 4, !buffer_requests);
-  if (rc != MEMCACHED_SUCCESS)
+  if (rc != MEMCACHED_SUCCESS and rc != MEMCACHED_BUFFERED)
   {
     return rc;
   }
@@ -275,8 +275,8 @@ do_action:
         server_key= 0;
 
       instance= memcached_server_instance_fetch(ptr, server_key);
-
-      if (memcached_vdo(instance, vector, 4, false) == MEMCACHED_SUCCESS)
+      memcached_return_t rrc= memcached_vdo(instance, vector, 4, !buffer_requests);
+      if (rrc == MEMCACHED_SUCCESS or rrc == MEMCACHED_BUFFERED)
       {
         memcached_server_response_decrement(instance);
       }
@@ -401,11 +401,6 @@ do_action:
   if (rc != MEMCACHED_SUCCESS)
   {
     return rc;
-  }
-
-  if (buffer_requests)
-  {
-    return MEMCACHED_BUFFERED;
   }
   else if (ptr->flags.no_reply or ptr->flags.multi_store)
   {

--- a/libmemcached/touch.cc
+++ b/libmemcached/touch.cc
@@ -111,11 +111,6 @@ do_action:
   {
     return rc;
   }
-
-  if (ptr->flags.buffer_requests)
-  {
-    return MEMCACHED_BUFFERED;
-  }
   else if (ptr->flags.no_reply)
   {
     return MEMCACHED_SUCCESS;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/naver/arcus-c-client/issues/167

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `memcached_vdo()` 호출부의 buffer_requests 값 검사를 함수 내부로 편입했습니다.

- 기존에는 `memcached_vdo()` 외부에서 `rc == MEMCACHED_SUCCESS && buffer_request`인 경우 MEMCACHED_BUFFERED를 상위 함수로 반환했습니다. 이 로직을 `memcached_vdo()`로 넣음으로써 모듈성을 높였습니다.

> 동일한 논리 구조로 사용 중인 no_reply/piped/multi_store의 경우엔 새로운 return code를 memcached_return_t에 추가하지 않는 한 서브루틴이 불가능해 보입니다. [ref comment](https://github.com/naver/arcus-c-client/issues/167#issuecomment-3520773287)