### PR TITLE
INTERNAL: Add sasluser to client_list

### DIFF
--- a/libmemcached/arcus.cc
+++ b/libmemcached/arcus.cc
@@ -559,7 +559,7 @@ static inline int do_arcus_cluster_validation_check(memcached_st *mc, arcus_st *
   return -1;
 }
 
-static inline int do_add_client_info(arcus_st *arcus)
+static inline int do_add_client_info(arcus_st *arcus, memcached_st *mc)
 {
   int result;
   char path[512];
@@ -578,7 +578,8 @@ static inline int do_add_client_info(arcus_st *arcus)
 
   /* create the ephemeral znode
    * "/arcus or arcus_repl/client_list/{service_code}/
-   *  {client hostname}_{ip address}_{pool count}_c_{client version}_{YYYYMMDDHHIISS}_{zk session id}"
+   *  {client hostname}_{ip address}_{pool count}_c_{client version}_{YYYYMMDDHHIISS}_{zk session id}
+   *  [_sasluser={username}]"
    * it means administrator has to create the {service_code} node before using.
    */
   char* client_info_znode = (char*)ARCUS_ZK_CLIENT_INFO_NODE;
@@ -587,15 +588,24 @@ static inline int do_add_client_info(arcus_st *arcus)
     client_info_znode = (char*)ARCUS_REPL_ZK_CLIENT_INFO_NODE;
   }
 #endif
-  snprintf(path, sizeof(path), "%s/%s/%.*s_%s_%u_c_%s_%d%02d%02d%02d%02d%02d_%llx",
-                              client_info_znode,
-                              arcus->zk.svc_code,
-                              50, hostname,
-                              (host == NULL ? "NULL" : inet_ntoa(*((struct in_addr *)host->h_addr))),
-                              (unsigned int)get_memcached_pool_size(arcus->pool),
-                              ARCUS_VERSION_STRING,
-                              ti->tm_year+1900, ti->tm_mon+1, ti->tm_mday, ti->tm_hour, ti->tm_min, ti->tm_sec,
-                              (long long) zoo_client_id(arcus->zk.handle)->client_id);
+
+  int path_len = 0;
+  path_len += snprintf(path + path_len, sizeof(path) - path_len,
+                       "%s/%s/%.*s_%s_%u_c_%s_%d%02d%02d%02d%02d%02d_%llx",
+                       client_info_znode,
+                       arcus->zk.svc_code,
+                       50, hostname,
+                       (host == NULL ? "NULL" : inet_ntoa(*((struct in_addr *)host->h_addr))),
+                       (unsigned int)get_memcached_pool_size(arcus->pool),
+                       ARCUS_VERSION_STRING,
+                       ti->tm_year+1900, ti->tm_mon+1, ti->tm_mday, ti->tm_hour, ti->tm_min, ti->tm_sec,
+                       (long long) zoo_client_id(arcus->zk.handle)->client_id);
+
+  char *sasl_username = memcached_get_sasl_username(mc);
+  if (sasl_username) {
+    path_len += snprintf(path + path_len, sizeof(path) - path_len,
+                         "_sasluser=%s", sasl_username);
+  }
 
   result = zoo_exists(arcus->zk.handle, path, 0, NULL);
   if (result == ZNONODE) {
@@ -683,7 +693,7 @@ static inline arcus_return_t do_arcus_zk_connect(memcached_st *mc)
     }
     pthread_mutex_unlock(&lock_arcus);
 
-    if (do_add_client_info(arcus) < 0) {
+    if (do_add_client_info(arcus, mc) < 0) {
       rc= ARCUS_ERROR; break;
     }
   } while(0);

--- a/libmemcached/sasl.cc
+++ b/libmemcached/sasl.cc
@@ -538,6 +538,22 @@ memcached_return_t memcached_clone_sasl(memcached_st *clone, const  memcached_st
   return MEMCACHED_SUCCESS;
 }
 
+char *memcached_get_sasl_username(memcached_st *ptr)
+{
+  if (ptr->sasl.callbacks == NULL) {
+    return NULL;
+  }
+
+  sasl_callback_t *cb = ptr->sasl.callbacks;
+  while (cb->id != SASL_CB_LIST_END) {
+    if (cb->id == SASL_CB_USER) {
+      return (char*)cb->context;
+    }
+    cb++;
+  }
+
+  return NULL;
+}
 #else
 
 void memcached_set_sasl_callbacks(memcached_st *, const sasl_callback_t *)

--- a/libmemcached/sasl.h
+++ b/libmemcached/sasl.h
@@ -64,6 +64,9 @@ memcached_return_t memcached_destroy_sasl_auth_data(memcached_st *ptr);
 LIBMEMCACHED_API
 sasl_callback_t *memcached_get_sasl_callbacks(memcached_st *ptr);
 
+LIBMEMCACHED_API
+char *memcached_get_sasl_username(memcached_st *ptr);
+
 LIBMEMCACHED_LOCAL
 memcached_return_t memcached_clone_sasl(memcached_st *clone, const  memcached_st *source);
 


### PR DESCRIPTION
### 🔗 Related Issue

- jam2in/arcus-works#809

### ⌨️ What I did

- client_list에 sasluser를 추가합니다.
```
/arcus/client_list/long_running_community/devbox_10.178.0.39_9_c_1.15.0-11_20251117102315_104e96e3a903e31_sasluser=namsic
/arcus/client_list/long_running_community/devbox_10.178.0.39_9_c_1.15.0-11_20251117102341_104e96e3a903e32_sasluser=NULL
```

- 아래 값을 가져오도록 구현하였습니다.
https://github.com/naver/arcus-c-client/blob/2e831dc80c8413bedc7dfdb88565927593a9372b/libmemcached/sasl.cc#L386-L388