### PR TITLE
INTERNAL: Disable memcached_set_sasl_callbacks()

### DIFF
--- a/libmemcached/sasl.cc
+++ b/libmemcached/sasl.cc
@@ -46,6 +46,7 @@
 
 #define CAST_SASL_CB(cb) reinterpret_cast<int(*)()>(reinterpret_cast<intptr_t>(cb))
 
+/* TODO: Re-enable after verifying memcached_clone_sasl() implementation.
 void memcached_set_sasl_callbacks(memcached_st *ptr,
                                   const sasl_callback_t *callbacks)
 {
@@ -57,6 +58,7 @@ sasl_callback_t *memcached_get_sasl_callbacks(memcached_st *ptr)
 {
   return ptr->sasl.callbacks;
 }
+*/
 
 /**
  * Resolve the names for both ends of a connection
@@ -467,6 +469,10 @@ memcached_return_t memcached_clone_sasl(memcached_st *clone, const  memcached_st
    * into the list, but if we don't know the ID we don't know how to handle
    * the context...
  */
+
+  // TODO: Re-enable after verifying memcached_clone_sasl() implementation.
+  return MEMCACHED_NOT_SUPPORTED;
+
   size_t total= 0;
 
   while (source->sasl.callbacks[total].id != SASL_CB_LIST_END)
@@ -556,6 +562,7 @@ char *memcached_get_sasl_username(memcached_st *ptr)
 }
 #else
 
+/* TODO: Re-enable after verifying memcached_clone_sasl() implementation.
 void memcached_set_sasl_callbacks(memcached_st *, const sasl_callback_t *)
 {
 }
@@ -564,6 +571,7 @@ sasl_callback_t *memcached_get_sasl_callbacks(memcached_st *)
 {
   return NULL;
 }
+*/
 
 memcached_return_t memcached_set_sasl_auth_data(memcached_st *, const char *, const char *)
 {

--- a/libmemcached/sasl.h
+++ b/libmemcached/sasl.h
@@ -48,9 +48,11 @@
 extern "C" {
 #endif
 
+/* TODO: Re-enable after verifying memcached_clone_sasl() implementation.
 LIBMEMCACHED_API
 void memcached_set_sasl_callbacks(memcached_st *ptr,
                                   const sasl_callback_t *callbacks);
+*/
 
 LIBMEMCACHED_API
 memcached_return_t  memcached_set_sasl_auth_data(memcached_st *ptr,
@@ -61,8 +63,10 @@ LIBMEMCACHED_API
 memcached_return_t memcached_destroy_sasl_auth_data(memcached_st *ptr);
 
 
+/* TODO: Re-enable after verifying memcached_clone_sasl() implementation.
 LIBMEMCACHED_API
 sasl_callback_t *memcached_get_sasl_callbacks(memcached_st *ptr);
+*/
 
 LIBMEMCACHED_API
 char *memcached_get_sasl_username(memcached_st *ptr);

--- a/tests/mem_functions.cc
+++ b/tests/mem_functions.cc
@@ -1391,7 +1391,8 @@ static test_return_t stats_servername_test(memcached_st *memc)
   memcached_server_instance_st instance=
     memcached_server_instance_by_position(memc, 0);
 
-  if (LIBMEMCACHED_WITH_SASL_SUPPORT and memcached_get_sasl_callbacks(memc))
+  // TODO: Re-enable after verifying memcached_clone_sasl() implementation.
+  if (LIBMEMCACHED_WITH_SASL_SUPPORT /* and memcached_get_sasl_callbacks(memc) */)
   {
     return TEST_SKIPPED;
   }


### PR DESCRIPTION
### 🔗 Related Issue

- jam2in/arcus-works#812

### ⌨️ What I did

- 현재 `memcached_set_sasl_auth_data()`가 아닌 다른 방법으로 sasl callback 등록 시 문제가 있는 상태이므로, 아래와 같이 임시 조치합니다.
  - `memcached_set_sasl_callbacks` 사용 불가능하도록 변경
  - custom callback 사용 시 `memcached_clone_sasl`에서 에러 반환