### PR TITLE
INTERNAL: Move in_sasl_mech to memcached_server_st from memcached_st

### DIFF
--- a/libmemcached/memcached.cc
+++ b/libmemcached/memcached.cc
@@ -160,7 +160,6 @@ static inline bool _memcached_init(memcached_st *self)
   self->callbacks= NULL;
   self->sasl.callbacks= NULL;
   self->sasl.is_allocated= false;
-  self->sasl.in_sasl_mech= false;
 
   self->error_messages= NULL;
 #ifdef REFACTORING_ERROR_PRINT

--- a/libmemcached/response.cc
+++ b/libmemcached/response.cc
@@ -489,7 +489,7 @@ static memcached_return_t textual_read_one_response(memcached_server_write_insta
        * let the client fail with the next operation if the error was
        * caused by another problem....
        */
-      if (ptr->root->sasl.in_sasl_mech)
+      if (ptr->in_sasl_mech)
       {
         return MEMCACHED_NOT_SUPPORTED;
       }
@@ -888,7 +888,7 @@ static memcached_return_t binary_read_one_response(memcached_server_write_instan
        * let the client fail with the next operation if the error was
        * caused by another problem....
        */
-      rc= ptr->root->sasl.in_sasl_mech ? MEMCACHED_NOT_SUPPORTED : MEMCACHED_PROTOCOL_ERROR;
+      rc= ptr->in_sasl_mech ? MEMCACHED_NOT_SUPPORTED : MEMCACHED_PROTOCOL_ERROR;
       break;
 
     case PROTOCOL_BINARY_RESPONSE_EINVAL:

--- a/libmemcached/sasl.cc
+++ b/libmemcached/sasl.cc
@@ -228,11 +228,11 @@ memcached_return_t memcached_sasl_authenticate_connection(memcached_server_st *s
    * as authenticated
  */
   char mech[MEMCACHED_MAX_BUFFER];
-  server->root->sasl.in_sasl_mech= true;
+  server->in_sasl_mech= true;
   memcached_return_t rc= server->root->flags.binary_protocol
     ? memcached_sasl_mech_binary(server, mech, sizeof(mech))
     : memcached_sasl_mech_ascii(server, mech, sizeof(mech));
-  server->root->sasl.in_sasl_mech= false;
+  server->in_sasl_mech= false;
   if (memcached_failed(rc))
   {
     if (rc == MEMCACHED_NOT_SUPPORTED)

--- a/libmemcached/sasl.h
+++ b/libmemcached/sasl.h
@@ -88,7 +88,6 @@ struct memcached_sasl_st {
    ** supply that.
  */
   bool is_allocated;
-  bool in_sasl_mech;
 };
 
 #endif /* __LIBMEMCACHED_SASL_H__ */

--- a/libmemcached/server.cc
+++ b/libmemcached/server.cc
@@ -62,6 +62,7 @@ static inline void _server_init(memcached_server_st *self, memcached_st *root,
   self->micro_version= UINT8_MAX;
   self->is_enterprise= false;
   self->send_failed= false;
+  self->in_sasl_mech= false;
   self->type= type;
   self->error_messages= NULL;
   self->read_ptr= self->read_buffer;

--- a/libmemcached/server.h
+++ b/libmemcached/server.h
@@ -90,6 +90,7 @@ struct memcached_server_st {
   uint8_t micro_version; // ditto
   bool is_enterprise;
   bool send_failed;
+  bool in_sasl_mech;
   memcached_connection_t type;
   char *read_ptr;
   size_t read_buffer_length;


### PR DESCRIPTION
### 🔗 Related Issue

- #395

### ⌨️ What I did

- `in_sasl_mech` 플래그를 `memcached_st`에서 관리하는 경우 여러 연결에서 공유하게 되는 문제가 있으므로,
각 `memcached_server_st`마다 in_sasl_mech 플래그를 자체적으로 관리하도록 합니다.
