### PR TITLE
DOC: Redirect test FAQ to wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ use --enable-zk-integration when running configure.
     ===================
     Tests completed
 
-If any problem exists in test cases, please refer to [test FAQ](/docs/test_faq.md).
+If any problem exists in test cases, please refer to [test FAQ](https://github.com/naver/arcus-c-client/wiki/Unit-test).
 
 ## Issues
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- #406 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- README에서 test_faq.md 파일을 링킹하던 주소를 wiki로 변경합니다.
