### PR TITLE
DOC: Fix incorrect link to getting started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ arcus_proxy_create(proxy_mc, "localhost:2181", "test");
 
 ## Getting Started
 
-- [Getting Started Guide (in Korean)](docs/arcus-c-client-getting-started.md)
+- [Getting Started Guide (in Korean)](docs/getting-started-guide.md)
 
 ## API Documentation
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
-

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- getting started guide 문서 이름을 변경하면서 링크도 같이 수정하지 않았던 문제를 해결합니다.
