### PR TITLE
INTERNAL: Define memcached_get_sasl_username when SASL is unavailable

### DIFF
--- a/libmemcached/sasl.cc
+++ b/libmemcached/sasl.cc
@@ -578,6 +578,11 @@ memcached_return_t memcached_set_sasl_auth_data(memcached_st *, const char *, co
   return MEMCACHED_NOT_SUPPORTED;
 }
 
+char *memcached_get_sasl_username(memcached_st *)
+{
+  return NULL;
+}
+
 memcached_return_t memcached_clone_sasl(memcached_st *, const  memcached_st *)
 {
   return MEMCACHED_NOT_SUPPORTED;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- sasl이 설치되어 있지 않은 환경에서 발생하는 에러를 수정합니다.
```
/usr/bin/ld: libmemcached/.libs/libmemcached.so: undefined reference to `memcached_get_sasl_username'
collect2: error: ld returned 1 exit status
```
