### PR TITLE
INTERNAL: Add log when SASL is not supported

### DIFF
--- a/libmemcached/sasl.cc
+++ b/libmemcached/sasl.cc
@@ -239,6 +239,8 @@ memcached_return_t memcached_sasl_authenticate_connection(memcached_server_st *s
     {
       /* If the server doesn't support SASL it will return MEMCACHED_NOT_SUPPORTED.
        */
+      memcached_set_error(*server, rc, MEMCACHED_AT,
+                          memcached_literal_param("Authentication not supported by server, skipping auth flow"));
       rc= MEMCACHED_SUCCESS;
     }
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- jam2in/arcus-works#822

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- NOT_SUPPORTED 응답을 받은 경우 로그를 남깁니다.
- 해당 PR에서 인증 성공 시에는 로그를 추가하지 않았습니다. 
  - 자바 클라이언트는 로그 메시지 형태로 처리하고 있으며, C 클라이언트는 오류가 발생했을 때만 원인 파악을 위한 에러 메시지를 기록합니다.
