### PR TITLE
TEST: Skip GAT tests until the 1.16.0 server release

### DIFF
--- a/tests/mem_functions.cc
+++ b/tests/mem_functions.cc
@@ -865,6 +865,7 @@ static test_return_t touch_test(memcached_st *memc)
 
 static test_return_t gat_test(memcached_st *memc)
 {
+  test_skip(true, bool(libmemcached_util_version_check(memc, 1, 16, 0)));
   memcached_return_t rc;
   const char *key= "foo";
   const char *value= "when we sanitize";


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
-

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 1.16.0 미만 버전의 서버 환경에 진행하는 gat 테스트를 스킵합니다.
